### PR TITLE
Add shapes from menu

### DIFF
--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -98,9 +98,20 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 		tools.add (new Gtk.SeparatorMenuItem ());
 		tools.add (new Gtk.MenuItem.with_label(_("Vector")));
 		tools.add (new Gtk.MenuItem.with_label(_("Pencil")));
-		tools.add (new Gtk.MenuItem.with_label(_("Shapes")));
+		var shapes_item = new Gtk.MenuItem.with_label(_("Shapes"));
+		var shapes_submenu = new Gtk.Menu ();
+		shapes_item.submenu = shapes_submenu;
+		var rect_item = new Gtk.MenuItem.with_label(_("Rect"));
+		rect_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_RECT;
+		shapes_submenu.add (rect_item);
+		var ellipse_item = new Gtk.MenuItem.with_label(_("Ellipse"));
+		ellipse_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_ELLIPSE;
+		shapes_submenu.add (ellipse_item);
+		tools.add (shapes_item);
 		tools.add (new Gtk.SeparatorMenuItem ());
-		tools.add (new Gtk.MenuItem.with_label(_("Text")));
+		var text_item = new Gtk.MenuItem.with_label(_("Text"));
+		text_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_TEXT;
+		tools.add (text_item);
 		tools.add (new Gtk.MenuItem.with_label(_("Image")));
 		tools.show_all ();
 

--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -37,6 +37,12 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
 		canvas.set_bounds (0, 0, 10000, 10000);
 		canvas.set_scale (1.0);
 
+		main_scroll.add (canvas);
+
+		attach (main_scroll, 0, 0, 1, 1);
+	}
+
+	public Goo.CanvasRect add_rect () {
 		var root = canvas.get_root_item ();
 		var rect = new Goo.CanvasRect (null, 100.0, 100.0, 400.0, 400.0,
 									"line-width", 5.0,
@@ -45,28 +51,24 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
 									"stroke-color", "#f37329",
 									"fill-color", "#ffa154", null);
 		rect.set ("parent", root);
+		return  rect;
+	}
 
-		var rect2 = new Goo.CanvasRect (null, 50, 100, 200, 100,
-			"line-width", 5.0,
-			"stroke-color", "#64baff",
-			"fill-color", "#3689e6");
-
-		rect2.set ("parent", root);
-
-		var rect3 = new Goo.CanvasRect (null, 0, 0, 64, 64,
-			"radius-x", 32.0,
-			"radius-y", 32.0,
+	public Goo.CanvasEllipse add_ellipse () {
+		var root = canvas.get_root_item ();
+		var ellipse = new Goo.CanvasEllipse (null, 0, 0, 64, 64,
 			"line-width", 5.0,
 			"stroke-color", "#9bdb4d",
 			"fill-color", "#68b723");
 
-		rect3.set ("parent", root);
+		ellipse.set ("parent", root);
+		return ellipse;
+	}
 
+	public Goo.CanvasText add_text () {
+		var root = canvas.get_root_item ();
 		var text = new Goo.CanvasText (null, "Add text here", 20, 20, 200, Goo.CanvasAnchorType.NW, "font", "Open Sans 18");
 		text.set ("parent", root);
-
-		main_scroll.add (canvas);
-
-		attach (main_scroll, 0, 0, 1, 1);
+		return text;
 	}
 }

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -25,6 +25,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 	public Akira.Layouts.Partials.Layer? layer_group { construct set; get; }
 	public string layer_name { get; construct; }
 	public string icon_name { get; construct; }
+	public Goo.CanvasItemSimple item { get; construct; }
 
 	private bool scroll_up = false;
 	private bool scrolling = false;
@@ -82,14 +83,15 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
 	// public Akira.Shape shape { get; construct; }
 
-	public Layer (Akira.Window main_window, Akira.Layouts.Partials.Artboard artboard, string name, string icon, bool group, Akira.Layouts.Partials.Layer? parent = null) {
+	public Layer (Akira.Window main_window, Akira.Layouts.Partials.Artboard artboard, Goo.CanvasItemSimple item_simple, string name, string icon, bool group, Akira.Layouts.Partials.Layer? parent = null) {
 		Object (
 			window: main_window,
 			layer_name: name,
 			icon_name: icon,
 			artboard: artboard,
 			grouped: group,
-			layer_group: parent
+			layer_group: parent,
+			item: item_simple
 		);
 	}
 
@@ -576,6 +578,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 			} else {
 				button_hidden.get_style_context ().remove_class ("show");
 			}
+
+			item.visibility = active ? Goo.CanvasItemVisibility.INVISIBLE: Goo.CanvasItemVisibility.VISIBLE;
 
 			icon_visible.visible = active;
 			icon_visible.no_show_all = ! active;

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -31,6 +31,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
 	private const int SCROLL_STEP_SIZE = 5;
 	private const int SCROLL_DISTANCE = 30;
 	private const int SCROLL_DELAY = 50;
+	public Akira.Layouts.Partials.Artboard artboard;
 
 	private const Gtk.TargetEntry targetEntries[] = {
 		{ "ARTBOARD", Gtk.TargetFlags.SAME_APP, 0 }
@@ -48,47 +49,13 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
 		get_style_context ().add_class ("layers-panel");
 		expand = true;
 
-		var artboard = new Akira.Layouts.Partials.Artboard (window, "Artboard 1");
+		artboard = new Akira.Layouts.Partials.Artboard (window, "Artboard 1");
 		var placeholder = new Gtk.ListBoxRow ();
 		artboard.container.insert (placeholder, 0);
 		placeholder.visible = false;
 		placeholder.no_show_all = true;
 
-		artboard.container.insert (new Akira.Layouts.Partials.Layer (window, artboard, "Rectangle", "shape-rectangle-symbolic", false), 1);
-		artboard.container.insert (new Akira.Layouts.Partials.Layer (window, artboard, "Circle", "shape-circle-symbolic", false), 2);
-		artboard.container.insert (new Akira.Layouts.Partials.Layer (window, artboard, "Triangle", "shape-triangle-symbolic", false), 3);
-
-		var layer_group = new Akira.Layouts.Partials.Layer (window, artboard, "Group", "folder-symbolic", true);
-		var layer_placeholder = new Gtk.ListBoxRow ();
-		layer_group.container.insert (layer_placeholder, 0);
-		layer_placeholder.visible = false;
-		layer_placeholder.no_show_all = true;
-
-		layer_group.container.insert (new Akira.Layouts.Partials.Layer (window, artboard, "Rectangle", "shape-rectangle-symbolic", false, layer_group), 1);
-		layer_group.container.insert (new Akira.Layouts.Partials.Layer (window, artboard, "Circle", "shape-circle-symbolic", false, layer_group), 2);
-		layer_group.container.insert (new Akira.Layouts.Partials.Layer (window, artboard, "Triangle", "shape-triangle-symbolic", false, layer_group), 3);
-
-		artboard.container.insert (layer_group, 4);
-
-		artboard.container.insert (new Akira.Layouts.Partials.Layer (window, artboard, "Text", "shape-text-symbolic", false), 5);
-		artboard.container.insert (new Akira.Layouts.Partials.Layer (window, artboard, "Bezier", "shape-bezier-symbolic", false), 6);
-		artboard.container.insert (new Akira.Layouts.Partials.Layer (window, artboard, "Path", "shape-pencil-symbolic", false), 7);
-
-		var artboard2 = new Akira.Layouts.Partials.Artboard (window, "Artboard 2");
-		var artboard3 = new Akira.Layouts.Partials.Artboard (window, "Artboard 3");
-		var artboard4 = new Akira.Layouts.Partials.Artboard (window, "Artboard 4");
-		var artboard5 = new Akira.Layouts.Partials.Artboard (window, "Artboard 5");
-
-		var artboard_placeholder = new Gtk.ListBoxRow ();
-		artboard_placeholder.visible = false;
-		artboard_placeholder.no_show_all = true;
-
-		insert (artboard_placeholder, 0);
-		insert (artboard, 1);
-		insert (artboard2, 2);
-		insert (artboard3, 3);
-		insert (artboard4, 4);
-		insert (artboard5, 5);
+		insert (artboard, 0);
 
 		build_drag_and_drop ();
 

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -40,6 +40,9 @@ public class Akira.Services.ActionManager : Object {
 	public const string ACTION_ZOOM_IN = "action_zoom_in";
 	public const string ACTION_ZOOM_OUT = "action_zoom_out";
 	public const string ACTION_ZOOM_RESET = "action_zoom_reset";
+	public const string ACTION_ADD_RECT = "action_add_rect";
+	public const string ACTION_ADD_ELLIPSE = "action_add_ellipse";
+	public const string ACTION_ADD_TEXT = "action_add_text";
 
 	public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 
@@ -58,6 +61,9 @@ public class Akira.Services.ActionManager : Object {
 		{ ACTION_ZOOM_IN, action_zoom_in },
 		{ ACTION_ZOOM_OUT, action_zoom_out },
 		{ ACTION_ZOOM_RESET, action_zoom_reset },
+		{ ACTION_ADD_RECT, action_add_rect },
+		{ ACTION_ADD_ELLIPSE, action_add_ellipse },
+		{ ACTION_ADD_TEXT, action_add_text },
 	};
 
 	public ActionManager (Akira.Application akira_app, Akira.Window main_window) {
@@ -221,6 +227,27 @@ public class Akira.Services.ActionManager : Object {
 
 	private void action_zoom_reset () {
 		window.headerbar.zoom.zoom_reset ();
+	}
+
+	private void action_add_rect () {
+		var rect = window.main_window.main_canvas.add_rect ();
+		var artboard = window.main_window.right_sidebar.layers_panel.artboard;
+		artboard.container.add (new Akira.Layouts.Partials.Layer (window, artboard, rect, "Rectangle", "shape-rectangle-symbolic", false));
+		artboard.show_all ();
+	}
+
+	private void action_add_ellipse () {
+		var ellipse = window.main_window.main_canvas.add_ellipse ();
+		var artboard = window.main_window.right_sidebar.layers_panel.artboard;
+		artboard.container.add (new Akira.Layouts.Partials.Layer (window, artboard, ellipse, "Circle", "shape-circle-symbolic", false));
+		artboard.show_all ();
+	}
+
+	private void action_add_text () {
+		var text = window.main_window.main_canvas.add_text ();
+		var artboard = window.main_window.right_sidebar.layers_panel.artboard;
+		artboard.container.add (new Akira.Layouts.Partials.Layer (window, artboard, text, "Text", "shape-text-symbolic", false));
+		artboard.show_all ();
 	}
 
 	public static void action_from_group (string action_name, ActionGroup? action_group) {


### PR DESCRIPTION
Allow adding basic shapes by menu and toggle visibility with right side bar

## Summary / How this PR fixes the problem?
Add shapes to canvas from header bar insert menu
Toggle visibility for added shapes through right side bar

## Steps to Test
You can run through flatpak and just add shapes from menu and toggle visibility from right side bar

## Screenshots 

![captura de pantalla de 2019-03-06 23-08-42](https://user-images.githubusercontent.com/220968/53917484-e71f3480-4064-11e9-92ac-f096af27ce6d.png)


## Known Issues / Things To Do
Model is needed to make things more maintanable
Z-Order can be implemented from D&D feature from right side bar
Colors and strokes are not retrieved from last used (a properties pane is needed for that)

## This PR fixes/implements the following **bugs/features**:
There's no specific issue, just basic functionality for milestone 1.0
