### PR TITLE
Use affine transforms

### DIFF
--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -51,17 +51,19 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
 									"stroke-color", "#f37329",
 									"fill-color", "#ffa154", null);
 		rect.set ("parent", root);
+		rect.set_transform(Cairo.Matrix.identity ());
 		return  rect;
 	}
 
 	public Goo.CanvasEllipse add_ellipse () {
 		var root = canvas.get_root_item ();
-		var ellipse = new Goo.CanvasEllipse (null, 0, 0, 64, 64,
+		var ellipse = new Goo.CanvasEllipse (null, 150, 150, 64, 64,
 			"line-width", 5.0,
 			"stroke-color", "#9bdb4d",
 			"fill-color", "#68b723");
 
 		ellipse.set ("parent", root);
+		ellipse.set_transform(Cairo.Matrix.identity ());
 		return ellipse;
 	}
 
@@ -69,6 +71,8 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
 		var root = canvas.get_root_item ();
 		var text = new Goo.CanvasText (null, "Add text here", 20, 20, 200, Goo.CanvasAnchorType.NW, "font", "Open Sans 18");
 		text.set ("parent", root);
+		text.set ("height", 25f);
+		text.set_transform(Cairo.Matrix.identity ());
 		return text;
 	}
 }


### PR DESCRIPTION
Relay on affine transforms to translate and rotate,
reapplying it on hover, select effect and nob position

## Summary / How this PR fixes the problem?
Using affine transformations allow us to use the internal state of objects to track its changes and apply to related graphic utilities (like nobs or effects)

## Steps to Test
Reproduce this screencast:

![affine-transform](https://user-images.githubusercontent.com/220968/54243914-9c049600-452a-11e9-806c-75266f96ed21.gif)

## Screenshots 

See screencast

## Known Issues / Things To Do
Stopping translate out of visible canvas is missing for simplicity, it can be reworked now all is solved

## This PR fixes/implements the following **bugs/features**:

Rotate objects, which needs refactoring translate and resize