### PR TITLE
Left Panel: New alignment box

### DIFF
--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -21,13 +21,11 @@
 .alignment-box {
   background-color: @base_color;
   border-bottom: 1pt solid shade (@bg_color, 0.8);
-  padding: 0 5pt;
+  padding: 3pt 5pt;
 }
 
-.align-box-button {
-  border-radius: 50%;
-  padding: 5pt;
-  margin: 2pt;
+.alignment-box button {
+  border-radius: 100%;
 }
 
 .alignment-box separator {

--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -17,3 +17,21 @@
 .border-bottom {
     border-bottom: 1px solid shade (@bg_color, 0.8);
 }
+
+.alignment-box {
+  background-color: @base_color;
+  border-bottom: 1pt solid shade (@bg_color, 0.8);
+  padding: 0 5pt;
+}
+
+.align-box-button {
+  border-radius: 50%;
+  padding: 5pt;
+  margin: 2pt;
+}
+
+.alignment-box separator {
+  margin: 4pt 6pt;
+  border-color: @bg_color;
+  border-width: 1px;
+}

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -21,7 +21,6 @@
 
 namespace Akira {
 	public Akira.Services.Settings settings;
-	public Akira.Services.EventBus event_bus;
 }
 
 public class Akira.Application : Granite.Application {
@@ -36,7 +35,6 @@ public class Akira.Application : Granite.Application {
 		build_version_info = Constants.VERSION_INFO;
 
 		settings = new Akira.Services.Settings ();
-		event_bus = new Akira.Services.EventBus ();
 		windows = new GLib.List <Window> ();
 
 		program_name = "Akira";

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -21,6 +21,7 @@
 
 namespace Akira {
 	public Akira.Services.Settings settings;
+	public Akira.Services.EventBus event_bus;
 }
 
 public class Akira.Application : Granite.Application {
@@ -35,6 +36,7 @@ public class Akira.Application : Granite.Application {
 		build_version_info = Constants.VERSION_INFO;
 
 		settings = new Akira.Services.Settings ();
+		event_bus = new Akira.Services.EventBus ();
 		windows = new GLib.List <Window> ();
 
 		program_name = "Akira";
@@ -58,8 +60,8 @@ public class Akira.Application : Granite.Application {
 	}
 
 	protected override void activate () {
-		Gtk.Settings.get_default().set_property("gtk-icon-theme-name", "elementary");
-		Gtk.Settings.get_default().set_property("gtk-theme-name", "elementary");
+		Gtk.Settings.get_default ().set_property ("gtk-icon-theme-name", "elementary");
+		Gtk.Settings.get_default ().set_property ("gtk-theme-name", "elementary");
 
 		weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
 		default_theme.add_resource_path ("/com/github/akiraux/akira");

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -123,7 +123,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 		group = new Akira.Partials.HeaderBarButton ("object-group", _("Group"), {"<Ctrl>g"});
 		ungroup = new Akira.Partials.HeaderBarButton ("object-ungroup", _("Ungroup"), {"<Ctrl><Shift>g"});
 
-		move_up = new Akira.Partials.HeaderBarButton ("selection-raise", _("Up"), {"<Ctrl>Up"});
+		move_up = new Akira.Partials.HeaderBarButton ("distribute-horizontal-center", _("Up"), {"<Ctrl>Up"});
 		move_down = new Akira.Partials.HeaderBarButton ("selection-lower", _("Down"), {"<Ctrl>Down"});
 		move_top = new Akira.Partials.HeaderBarButton ("selection-top", _("Top"), {"<Ctrl><Shift>Up"});
 		move_bottom = new Akira.Partials.HeaderBarButton ("selection-bottom", _("Bottom"), {"<Ctrl><Shift>Down"});

--- a/src/Layouts/LeftSideBar.vala
+++ b/src/Layouts/LeftSideBar.vala
@@ -20,6 +20,8 @@
 */
 
 public class Akira.Layouts.LeftSideBar : Gtk.Grid {
+    public weak Akira.Window window { get; construct; }
+
 	public bool toggled {
 		get {
 			return visible;
@@ -29,8 +31,9 @@ public class Akira.Layouts.LeftSideBar : Gtk.Grid {
 		}
 	}
 
-	public LeftSideBar () {
+	public LeftSideBar (Akira.Window window) {
 		Object (
+            window: window,
 			orientation: Gtk.Orientation.HORIZONTAL,
 			toggled: true
 		);
@@ -40,7 +43,7 @@ public class Akira.Layouts.LeftSideBar : Gtk.Grid {
 		get_style_context ().add_class ("sidebar-l");
 		width_request = 220;
 
-        var align_items_panel = new Akira.Layouts.Partials.AlignItemsPanel ();
+        var align_items_panel = new Akira.Layouts.Partials.AlignItemsPanel (window);
 
 		var label = new Gtk.Label ("Sidebar L");
 		label.halign = Gtk.Align.CENTER;

--- a/src/Layouts/LeftSideBar.vala
+++ b/src/Layouts/LeftSideBar.vala
@@ -31,7 +31,7 @@ public class Akira.Layouts.LeftSideBar : Gtk.Grid {
 
 	public LeftSideBar () {
 		Object (
-			orientation: Gtk.Orientation.HORIZONTAL, 
+			orientation: Gtk.Orientation.HORIZONTAL,
 			toggled: true
 		);
 	}
@@ -39,14 +39,17 @@ public class Akira.Layouts.LeftSideBar : Gtk.Grid {
 	construct {
 		get_style_context ().add_class ("sidebar-l");
 		width_request = 220;
-		
+
+        var align_items_panel = new Akira.Layouts.Partials.AlignItemsPanel ();
+
 		var label = new Gtk.Label ("Sidebar L");
 		label.halign = Gtk.Align.CENTER;
 		label.expand = true;
 		label.margin = 10;
 		label.expand = true;
 
-		attach (label, 0, 0, 1, 1);
+		attach (align_items_panel, 0, 0, 1, 1);
+		attach (label, 0, 1, 1, 1);
 	}
 
 	public void toggle () {

--- a/src/Layouts/MainWindow.vala
+++ b/src/Layouts/MainWindow.vala
@@ -36,7 +36,7 @@ public class Akira.Layouts.MainWindow : Gtk.Grid {
 	}
 
 	construct {
-		left_sidebar = new Akira.Layouts.LeftSideBar ();
+		left_sidebar = new Akira.Layouts.LeftSideBar (window);
 		right_sidebar = new Akira.Layouts.RightSideBar (window);
 		statusbar = new Akira.Layouts.StatusBar ();
 		main_canvas = new Akira.Layouts.MainCanvas ();

--- a/src/Layouts/Partials/AlignItemsPanel.vala
+++ b/src/Layouts/Partials/AlignItemsPanel.vala
@@ -19,6 +19,8 @@
  * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
  */
 public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
+	public weak Akira.Window window { get; construct; }
+
     private Gtk.Grid alignment_box;
 
     private struct AlignBoxItem {
@@ -28,7 +30,7 @@ public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
         public string tooltip_text;
     }
 
-    private const AlignBoxItem[] align_items_panel_buttons = {
+    private const AlignBoxItem[] ALIGN_ITEMS_PANEL_BUTTONS = {
         { "btn", "even-h", "distribute-horizontal-center", "Distribute centers evenly horizontally" },
         { "btn", "even-v", "distribute-vertical-center", "Distribute center evenly vertically" },
         { "sep" },
@@ -41,10 +43,11 @@ public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
         { "btn", "alig-v-b", "align-vertical-bottom", "Align bottom sides" }
     };
 
-    public AlignItemsPanel () {
+    public AlignItemsPanel (Akira.Window window) {
         Object (
+            window: window,
             orientation: Gtk.Orientation.VERTICAL
-            );
+        );
     }
 
     construct {
@@ -56,7 +59,7 @@ public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
 
         int current_button_column = 0;
 
-        foreach (var item in align_items_panel_buttons) {
+        foreach (var item in ALIGN_ITEMS_PANEL_BUTTONS) {
             switch (item.type) {
                 case "sep":
                     alignment_box.attach (new Gtk.Separator
@@ -66,7 +69,8 @@ public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
 
                 case "btn":
                     var tmp_align_box_button =
-                        new Akira.Partials.AlignBoxButton (item.action,
+                        new Akira.Partials.AlignBoxButton (window,
+                                                           item.action,
                                                            item.icon_name,
                                                            item.tooltip_text);
 

--- a/src/Layouts/Partials/AlignItemsPanel.vala
+++ b/src/Layouts/Partials/AlignItemsPanel.vala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+ */
+public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
+    private Gtk.Grid alignment_box;
+
+    struct AlignBoxItem {
+        public string type;
+        public string action;
+        public string icon_name;
+        public string title;
+    }
+
+    public AlignItemsPanel () {
+        Object (
+            orientation: Gtk.Orientation.VERTICAL
+            );
+    }
+
+    private const AlignBoxItem[] align_items_panel_buttons = {
+        { "btn", "even-h", "distribute-horizontal-center", "Distribute centers evenly horizontally" },
+        { "btn", "even-v", "distribute-vertical-center", "Distribute center evenly vertically" },
+        { "sep" },
+        { "btn", "alig-h-l", "align-horizontal-left", "Align left sides" },
+        { "btn", "alig-h-c", "align-horizontal-center", "Center on horizontal axis" },
+        { "btn", "alig-h-r", "align-horizontal-right", "Align right sides" },
+        { "sep" },
+        { "btn", "alig-v-t", "align-vertical-top", "Align top sides" },
+        { "btn", "alig-v-c", "align-vertical-center", "Center on vertical axis" },
+        { "btn", "alig-v-b", "align-vertical-bottom", "Align bottom sides" }
+    };
+
+    construct {
+        vexpand = false;
+        hexpand = true;
+
+        alignment_box = new Gtk.Grid ();
+        alignment_box.halign = Gtk.Align.CENTER;
+
+        int current_button_column = 0;
+
+        foreach (var item in align_items_panel_buttons) {
+            switch (item.type) {
+                case "sep":
+                    alignment_box.attach (new Gtk.Separator
+                                          (Gtk.Orientation.VERTICAL),
+                                          current_button_column++, 0, 1, 1 );
+                    break;
+
+                case "btn":
+                    var tmp_align_box_button =
+                        new Akira.Partials.AlignBoxButton (item.action,
+                                                           item.icon_name,
+                                                           item.title);
+
+                    alignment_box.attach (tmp_align_box_button,
+                                          current_button_column++,
+                                          0, 1, 1);
+                    break;
+            }
+        }
+
+        get_style_context ().add_class ("alignment-box");
+
+        attach (alignment_box, 1, 0, 1, 1);
+    }
+}

--- a/src/Layouts/Partials/AlignItemsPanel.vala
+++ b/src/Layouts/Partials/AlignItemsPanel.vala
@@ -21,17 +21,11 @@
 public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
     private Gtk.Grid alignment_box;
 
-    struct AlignBoxItem {
+    private struct AlignBoxItem {
         public string type;
         public string action;
         public string icon_name;
         public string title;
-    }
-
-    public AlignItemsPanel () {
-        Object (
-            orientation: Gtk.Orientation.VERTICAL
-            );
     }
 
     private const AlignBoxItem[] align_items_panel_buttons = {
@@ -46,6 +40,12 @@ public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
         { "btn", "alig-v-c", "align-vertical-center", "Center on vertical axis" },
         { "btn", "alig-v-b", "align-vertical-bottom", "Align bottom sides" }
     };
+
+    public AlignItemsPanel () {
+        Object (
+            orientation: Gtk.Orientation.VERTICAL
+            );
+    }
 
     construct {
         vexpand = false;

--- a/src/Layouts/Partials/AlignItemsPanel.vala
+++ b/src/Layouts/Partials/AlignItemsPanel.vala
@@ -19,7 +19,7 @@
  * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
  */
 public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
-	public weak Akira.Window window { get; construct; }
+    public weak Akira.Window window { get; construct; }
 
     private Gtk.Grid alignment_box;
 
@@ -47,24 +47,24 @@ public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
         Object (
             window: window,
             orientation: Gtk.Orientation.VERTICAL
-        );
+            );
     }
 
     construct {
-        vexpand = false;
-        hexpand = true;
+        int current_button_column = 0;
+
+        halign = Gtk.Align.FILL;
 
         alignment_box = new Gtk.Grid ();
         alignment_box.halign = Gtk.Align.CENTER;
-
-        int current_button_column = 0;
+        alignment_box.hexpand = true;
 
         foreach (var item in ALIGN_ITEMS_PANEL_BUTTONS) {
             switch (item.type) {
                 case "sep":
                     alignment_box.attach (new Gtk.Separator
-                                          (Gtk.Orientation.VERTICAL),
-                                          current_button_column++, 0, 1, 1 );
+                            (Gtk.Orientation.VERTICAL),
+                            current_button_column++, 0, 1, 1 );
                     break;
 
                 case "btn":
@@ -75,8 +75,8 @@ public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
                                                            item.tooltip_text);
 
                     alignment_box.attach (tmp_align_box_button,
-                                          current_button_column++,
-                                          0, 1, 1);
+                            current_button_column++,
+                            0, 1, 1);
                     break;
             }
         }

--- a/src/Layouts/Partials/AlignItemsPanel.vala
+++ b/src/Layouts/Partials/AlignItemsPanel.vala
@@ -25,7 +25,7 @@ public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
         public string type;
         public string action;
         public string icon_name;
-        public string title;
+        public string tooltip_text;
     }
 
     private const AlignBoxItem[] align_items_panel_buttons = {
@@ -68,7 +68,7 @@ public class Akira.Layouts.Partials.AlignItemsPanel : Gtk.Grid {
                     var tmp_align_box_button =
                         new Akira.Partials.AlignBoxButton (item.action,
                                                            item.icon_name,
-                                                           item.title);
+                                                           item.tooltip_text);
 
                     alignment_box.attach (tmp_align_box_button,
                                           current_button_column++,

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -86,7 +86,7 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
         });
 
         button.clicked.connect (() => {
-            event_bus.emit ("align_items", action);
+            event_bus.emit ("align-items", action);
         });
     }
 }

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -21,6 +21,8 @@
 public class Akira.Partials.AlignBoxButton : Gtk.Grid {
     public signal void triggered (Akira.Partials.AlignBoxButton emitter);
 
+	public weak Akira.Window window { get; construct; }
+
     public string icon_name { get; construct; }
     public string action { get; construct; }
     public string tooltip_text { get; construct; }
@@ -28,8 +30,9 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
     private Gtk.Button button;
     private Gtk.Image image;
 
-    public AlignBoxButton (string action, string icon_name, string tooltip_text) {
-        Object(
+    public AlignBoxButton (Akira.Window window, string action, string icon_name, string tooltip_text) {
+        Object (
+            window: window,
             icon_name: icon_name,
             action: action,
             tooltip_text: tooltip_text
@@ -73,12 +76,12 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
     }
 
     private void connect_signals () {
-        event_bus.update_icons_style.connect (() => {
+        window.event_bus.update_icons_style.connect (() => {
             update_icon_style ();
         });
 
         button.clicked.connect (() => {
-            event_bus.emit ("align-items", action);
+            window.event_bus.emit ("align-items", action);
         });
     }
 }

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -18,16 +18,15 @@
  *
  * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
  */
-public class Akira.Partials.AlignBoxButton : Gtk.Grid {
+public class Akira.Partials.AlignBoxButton : Gtk.Button {
     public signal void triggered (Akira.Partials.AlignBoxButton emitter);
 
-	public weak Akira.Window window { get; construct; }
+    public weak Akira.Window window { get; construct; }
 
     public string icon_name { get; construct; }
     public string action { get; construct; }
     public string tooltip_text { get; construct; }
 
-    private Gtk.Button button;
     private Gtk.Image image;
 
     public AlignBoxButton (Akira.Window window, string action, string icon_name, string tooltip_text) {
@@ -36,22 +35,15 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
             icon_name: icon_name,
             action: action,
             tooltip_text: tooltip_text
-        );
+            );
     }
 
     construct {
+        get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
         can_focus = false;
-        hexpand = true;
-
-        button = new Gtk.Button ();
-        button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
-        button.can_focus = false;
-        button.halign = Gtk.Align.CENTER;
 
         update_icon_style ();
-
-        attach (button, 0, 0, 1, 1);
 
         connect_signals ();
     }
@@ -66,12 +58,11 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
             : icon_name;
 
         if (image != null) {
-            button.remove (image);
+            remove (image);
         }
 
         image = new Gtk.Image.from_icon_name (new_icon_name, new_icon_size);
-        button.add (image);
-
+        add (image);
         image.show_all ();
     }
 
@@ -80,7 +71,7 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
             update_icon_style ();
         });
 
-        button.clicked.connect (() => {
+        clicked.connect (() => {
             window.event_bus.emit ("align-items", action);
         });
     }

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -59,15 +59,15 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
             : Gtk.IconSize.LARGE_TOOLBAR;
 
         var new_icon_name = settings.use_symbolic == true
-            ? this.icon_name + "-symbolic"
-            : this.icon_name;
+            ? icon_name + "-symbolic"
+            : icon_name;
 
         if (image != null) {
-            this.button.remove (this.image);
+            button.remove (image);
         }
 
-        this.image = new Gtk.Image.from_icon_name (new_icon_name, new_icon_size);
-        this.button.add (image);
+        image = new Gtk.Image.from_icon_name (new_icon_name, new_icon_size);
+        button.add (image);
 
         image.show_all ();
     }

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -19,16 +19,14 @@
  * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
  */
 public class Akira.Partials.AlignBoxButton : Gtk.Grid {
+    public signal void triggered (Akira.Partials.AlignBoxButton emitter);
+
     public string icon_name { get; construct; }
     public string action { get; construct; }
     public string tooltip_text { get; construct; }
 
-    public Gtk.IconSize icon_size;
-
     private Gtk.Button button;
     private Gtk.Image image;
-
-    public signal void triggered (Akira.Partials.AlignBoxButton emitter);
 
     public AlignBoxButton (string action, string icon_name, string tooltip_text) {
         Object(

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -19,8 +19,9 @@
  * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
  */
 public class Akira.Partials.AlignBoxButton : Gtk.Grid {
-    public string icon_name;
-    public string action;
+    public string icon_name { get; construct; }
+    public string action { get; construct; }
+    public string tooltip_text { get; construct; }
 
     public Gtk.IconSize icon_size;
 
@@ -29,27 +30,17 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
 
     public signal void triggered (Akira.Partials.AlignBoxButton emitter);
 
-    public AlignBoxButton (
-        string action,
-        string icon_name,
-        string title) {
-        this.action = action;
+    public AlignBoxButton (string action, string icon_name, string tooltip_text) {
+        Object(
+            icon_name: icon_name,
+            action: action,
+            tooltip_text: tooltip_text
+        );
+    }
 
-        this.tooltip_text = title;
-
+    construct {
         can_focus = false;
         hexpand = true;
-
-        this.icon_name = icon_name;
-        this.icon_size = Gtk.IconSize.LARGE_TOOLBAR;
-
-        if (settings.use_symbolic) {
-          this.icon_name = icon_name + "-symbolic";
-          this.icon_size = Gtk.IconSize.SMALL_TOOLBAR;
-        }
-
-        image = new Gtk.Image.from_icon_name (this.icon_name, this.icon_size);
-        image.margin = 0;
 
         button = new Gtk.Button ();
         button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
@@ -57,7 +48,7 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
         button.can_focus = false;
         button.halign = Gtk.Align.CENTER;
 
-        button.add (image);
+        update_icon_style ();
 
         attach (button, 0, 0, 1, 1);
 
@@ -73,7 +64,10 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
             ? this.icon_name + "-symbolic"
             : this.icon_name;
 
-        this.button.remove (this.image);
+        if (image != null) {
+            this.button.remove (this.image);
+        }
+
         this.image = new Gtk.Image.from_icon_name (new_icon_name, new_icon_size);
         this.button.add (image);
 

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -32,27 +32,27 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
     public AlignBoxButton (
         string action,
         string icon_name,
-        string title,
-        Gtk.IconSize icon_size = Gtk.IconSize.SMALL_TOOLBAR) {
-
+        string title) {
         this.action = action;
-        this.icon_name = icon_name;
-        this.icon_size = icon_size;
 
         this.tooltip_text = title;
 
         can_focus = false;
         hexpand = true;
 
-        image = new Gtk.Image ();
+        this.icon_name = icon_name;
+        this.icon_size = Gtk.IconSize.LARGE_TOOLBAR;
+
+        if (settings.use_symbolic) {
+          this.icon_name = icon_name + "-symbolic";
+          this.icon_size = Gtk.IconSize.SMALL_TOOLBAR;
+        }
+
+        image = new Gtk.Image.from_icon_name (this.icon_name, this.icon_size);
         image.margin = 0;
 
-        update_icon_style ();
-
         button = new Gtk.Button ();
-
         button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        button.get_style_context ().add_class ("align-box-button");
 
         button.can_focus = false;
         button.halign = Gtk.Align.CENTER;
@@ -73,9 +73,11 @@ public class Akira.Partials.AlignBoxButton : Gtk.Grid {
             ? this.icon_name + "-symbolic"
             : this.icon_name;
 
-        this.image.icon_name = new_icon_name;
-        this.image.icon_size = new_icon_size;
-        this.image.show_all ();
+        this.button.remove (this.image);
+        this.image = new Gtk.Image.from_icon_name (new_icon_name, new_icon_size);
+        this.button.add (image);
+
+        image.show_all ();
     }
 
     private void connect_signals () {

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+ */
+public class Akira.Partials.AlignBoxButton : Gtk.Grid {
+    public string icon_name;
+    public string action;
+
+    public Gtk.IconSize icon_size;
+
+    private Gtk.Button button;
+    private Gtk.Image image;
+
+    public signal void triggered (Akira.Partials.AlignBoxButton emitter);
+
+    public AlignBoxButton (
+        string action,
+        string icon_name,
+        string title,
+        Gtk.IconSize icon_size = Gtk.IconSize.SMALL_TOOLBAR) {
+
+        this.action = action;
+        this.icon_name = icon_name;
+        this.icon_size = icon_size;
+
+        this.tooltip_text = title;
+
+        can_focus = false;
+        hexpand = true;
+
+        image = new Gtk.Image ();
+        image.margin = 0;
+
+        update_icon_style ();
+
+        button = new Gtk.Button ();
+
+        button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        button.get_style_context ().add_class ("align-box-button");
+
+        button.can_focus = false;
+        button.halign = Gtk.Align.CENTER;
+
+        button.add (image);
+
+        attach (button, 0, 0, 1, 1);
+
+        connect_signals ();
+    }
+
+    private void update_icon_style () {
+        var new_icon_size = settings.use_symbolic == true
+            ? Gtk.IconSize.SMALL_TOOLBAR
+            : Gtk.IconSize.LARGE_TOOLBAR;
+
+        var new_icon_name = settings.use_symbolic == true
+            ? this.icon_name + "-symbolic"
+            : this.icon_name;
+
+        this.image.icon_name = new_icon_name;
+        this.image.icon_size = new_icon_size;
+        this.image.show_all ();
+    }
+
+    private void connect_signals () {
+        event_bus.update_icons_style.connect (() => {
+            update_icon_style ();
+        });
+
+        button.clicked.connect (() => {
+            event_bus.emit ("align_items", action);
+        });
+    }
+}

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -163,6 +163,8 @@ public class Akira.Services.ActionManager : Object {
 		window.headerbar.toggle ();
 		window.headerbar.update_icons_style ();
 		window.headerbar.toggle ();
+
+        event_bus.emit ("update_icons_style");
 	}
 
 	private void action_quit () {
@@ -199,20 +201,20 @@ public class Akira.Services.ActionManager : Object {
 	private void action_show_ui_grid () {
 		warning ("show UI grid");
 	}
-	
+
 	private void action_preferences () {
 		if (window.settings_dialog == null) {
 			window.settings_dialog = new Akira.Widgets.SettingsDialog (window);
 			window.settings_dialog.show_all ();
-			
+
 			window.settings_dialog.destroy.connect (() => {
 				window.settings_dialog = null;
 			});
 		}
-		
+
 		window.settings_dialog.present ();
 	}
-	
+
 	private void action_export () {
 		warning ("export");
 	}

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -164,7 +164,7 @@ public class Akira.Services.ActionManager : Object {
 		window.headerbar.update_icons_style ();
 		window.headerbar.toggle ();
 
-        event_bus.emit ("update-icons-style");
+        window.event_bus.emit ("update-icons-style");
 	}
 
 	private void action_quit () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -164,7 +164,7 @@ public class Akira.Services.ActionManager : Object {
 		window.headerbar.update_icons_style ();
 		window.headerbar.toggle ();
 
-        event_bus.emit ("update_icons_style");
+        event_bus.emit ("update-icons-style");
 	}
 
 	private void action_quit () {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -28,10 +28,10 @@ public class Akira.Services.EventBus : Object {
 
     public void emit (string signal_id, string param = "") {
         switch (signal_id) {
-            case "update_icons_style":
+            case "update-icons-style":
                 update_icons_style ();
                 break;
-            case "align_items":
+            case "align-items":
                 align_items (param);
                 break;
         }

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018 Alecaddd (http://alecaddd.com)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+ */
+public class Akira.Services.EventBus : Object {
+    public signal void update_icons_style ();
+    public signal void align_items (string align_action);
+
+    public EventBus () {
+        Object ();
+    }
+
+    public void emit (string signal_id, string param = "") {
+        switch (signal_id) {
+            case "update_icons_style":
+                update_icons_style ();
+                break;
+            case "align_items":
+                align_items (param);
+                break;
+        }
+    }
+}

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -23,6 +23,7 @@ public class Akira.Window : Gtk.ApplicationWindow {
 	public weak Akira.Application app { get; construct; }
 
 	public Akira.Services.ActionManager action_manager;
+    public Akira.Services.EventBus event_bus;
 	public Akira.Layouts.HeaderBar headerbar;
 	public Akira.Layouts.MainWindow main_window;
 	public Akira.Widgets.SettingsDialog? settings_dialog = null;
@@ -43,6 +44,8 @@ public class Akira.Window : Gtk.ApplicationWindow {
 	}
 
 	construct {
+        event_bus = new Akira.Services.EventBus ();
+
 		accel_group = new Gtk.AccelGroup ();
 		add_accel_group (accel_group);
 
@@ -75,7 +78,7 @@ public class Akira.Window : Gtk.ApplicationWindow {
 
 		var css_provider = new Gtk.CssProvider ();
 		css_provider.load_from_resource ("/com/github/akiraux/akira/stylesheet.css");
-		
+
 		Gtk.StyleContext.add_provider_for_screen (
 			Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
 		);

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,6 +24,7 @@ executable(
 
     'Services/Settings.vala',
     'Services/ActionManager.vala',
+    'Services/EventBus.vala',
 
     'Utils/Dialogs.vala',
 
@@ -37,10 +38,12 @@ executable(
     'Layouts/Partials/PagesPanel.vala',
     'Layouts/Partials/Artboard.vala',
     'Layouts/Partials/Layer.vala',
+    'Layouts/Partials/AlignItemsPanel.vala',
 
     'Partials/HeaderBarButton.vala',
     'Partials/MenuButton.vala',
     'Partials/ZoomButton.vala',
+    'Partials/AlignBoxButton.vala',
 
     'Widgets/SettingsDialog.vala',
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
<!--- Please write a description here -->
Initial structure for the Alignment Panel has been created. 
There is a `Gtk.Grid` centered in the LeftPanel with all the buttons needed for the alignment of elements on the canvas. 

In addition, I've created a bus (not D-Bus) to ease the communication between components without the need to honor the callback chain from the `window` object to the event triggerer, to help to decouple code and to ease multiple event subscription through the signal-slot mechanism. 

The object is called `EventBus` and is created as a singleton and made available in the same way as the `settings` object. 

Alignment Panel's Buttons already communicate this way and also their images are updated using this technique, instead of manually triggering the `update_icon` method from the Settings dialog page. 
 
## Steps to Test
<!--- In case your change requires testing, this should show that your code is solid! --> 
There's no testing needed, maybe it can be proved that the prototype actually respects the mockup sizing. 

## Screenshots 
<!--- Share a screenshot with us if it was a visual change, -->
<!--- preferably with before/after shots -->
![image](https://user-images.githubusercontent.com/11556031/54566398-0442f400-49d1-11e9-9b10-be669de69684.png)


## Known Issues / Things To Do
<!--- If your PR is in progress or you know something is wrong with the code -->
<!--- write it here so we can help/discuss it -->
<!--- This is also a good place for a checklist with things left to fix in the PR -->
I'm not totally convinced about the size of the icons, I think that `Gtk.IconSize.LARGE_TOOLBAR` is not going to work, I'd rather use the `SMALL_TOOLBAR` in either case (symbolic and not symbolic), I think that the design is more balanced this way. 

## This PR fixes/implements the following **bugs/features**:
<!--- If there was an issue that this PR targets, adding it here will auto close it --> 
- Implements #88