### PR TITLE
Fix debug logging

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,7 @@ gettext_package = application_id
 
 # Set our translation domain
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (gettext_package), language:'c')
+add_global_arguments(['-DG_LOG_DOMAIN="Akira"'], language:'c')
 
 subdir('src')
 subdir('data')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -23,25 +23,17 @@ namespace Akira {
 	public Akira.Services.Settings settings;
 }
 
-public class Akira.Application : Granite.Application {
+public class Akira.Application : Gtk.Application {
 	private Gee.HashMap<string, Akira.Window> opened_files;
 	public GLib.List <Window> windows;
 
 	construct {
 		flags |= ApplicationFlags.HANDLES_OPEN;
-		build_data_dir = Constants.DATADIR;
-		build_pkg_data_dir = Constants.PKGDATADIR;
-		build_release_name = Constants.RELEASE_NAME;
-		build_version = Constants.VERSION;
-		build_version_info = Constants.VERSION_INFO;
 
 		settings = new Akira.Services.Settings ();
 		windows = new GLib.List <Window> ();
 		opened_files = new Gee.HashMap<string, Akira.Window>();
 
-		program_name = "Akira";
-		exec_name = Constants.APP_ID;
-		app_launcher = Constants.APP_ID + ".desktop";
 		application_id = Constants.APP_ID;
 	}
 


### PR DESCRIPTION
Log debug traces on classes like Akira.Lib.Canvas do not work.  They are not logged due to usage of Granite.Application, which is deprecated

https://github.com/elementary/granite/blob/master/lib/Application.vala#L25

## Summary / How this PR fixes the problem?

Use Gtk.Application resolve it.

Added `G_LOG_DOMAIN` to allow see logging only for Akira domain:

## Steps to Test

G_MESSAGES_DEBUG=Akira com.github.akiraux.akira

## Known Issues / Things To Do

Until https://gitlab.gnome.org/GNOME/vala/issues/765 is landed in vala, we can use

    log(DOMAIN,LEVEL, format, arguments)

to track different domains, but just filter debug messages only for Akira is a great benefit
