### PR TITLE
Use Popovers and Submenus for Header Bar Buttons

### DIFF
--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -156,8 +156,9 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 
         recent_files_grid.add (back_button);
         recent_files_grid.add (sub_separator);
-        recent_files_popover.add (recent_files_grid);
+        recent_files_grid.show_all ();
 
+        recent_files_popover.add (recent_files_grid);
         fetch_recent_files ();
 
         var open_recent_button = new Gtk.ModelButton ();
@@ -199,6 +200,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         var popover = new Gtk.PopoverMenu ();
         popover.name = "main-menu";
         popover.add (grid);
+        //  popover.child_set_property (recent_files_popover, "submenu", "files-menu");
 
         return popover;
     }
@@ -216,7 +218,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 
         // Create the shapes submenu
         var shapes_popover = new Gtk.PopoverMenu ();
-        shapes_popover.name = "files-menu";
+        shapes_popover.name = "shapes-menu";
 
         var shapes_grid = new Gtk.Grid ();
         shapes_grid.margin_bottom = 3;
@@ -243,7 +245,10 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         shapes_grid.add (sub_separator);
         shapes_grid.add (rectangle);
         shapes_grid.add (ellipse);
+        shapes_grid.show_all ();
+
         shapes_popover.add (shapes_grid);
+        shapes_popover.show_all ();
 
         var shapes_button = new Gtk.ModelButton ();
         shapes_button.text = _("Shapes");
@@ -262,23 +267,6 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 
         var image = new Akira.Partials.PopoverButton (_("Image"), {"I"});
 
-        //  var shapes_item = new Gtk.MenuItem.with_label(_("Shapes"));
-        //  var shapes_submenu = new Gtk.Menu ();
-        //  shapes_item.submenu = shapes_submenu;
-        //  var rect_item = new Gtk.MenuItem.with_label(_("Rect"));
-        //  rect_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_RECT;
-        //  shapes_submenu.add (rect_item);
-        //  var ellipse_item = new Gtk.MenuItem.with_label(_("Ellipse"));
-        //  ellipse_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_ELLIPSE;
-        //  shapes_submenu.add (ellipse_item);
-        //  tools.add (shapes_item);
-        //  tools.add (new Gtk.SeparatorMenuItem ());
-        //  var text_item = new Gtk.MenuItem.with_label(_("Text"));
-        //  text_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_TEXT;
-        //  tools.add (text_item);
-        //  tools.add (new Gtk.MenuItem.with_label(_("Image")));
-        //  tools.show_all ();
-
         grid.add (artboard);
         grid.add (separator);
         grid.add (shapes_button);
@@ -292,6 +280,11 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         var popover = new Gtk.PopoverMenu ();
         popover.name = "items-menu";
         popover.add (grid);
+        popover.add (shapes_popover);
+
+        var submenu_name = Value (typeof (string));
+        submenu_name.set_string ("shapes-menu");
+        popover.child_set_property (shapes_popover, "submenu", submenu_name);
 
         return popover;
     }

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -120,6 +120,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 
     private Gtk.PopoverMenu build_main_menu_popover () {
         var grid = new Gtk.Grid ();
+        grid.margin_top = 6;
         grid.margin_bottom = 3;
         grid.orientation = Gtk.Orientation.VERTICAL;
         grid.width_request = 240;
@@ -139,6 +140,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
             Akira.Services.ActionManager.ACTION_OPEN;
 
         recent_files_grid = new Gtk.Grid ();
+        recent_files_grid.margin_top = 6;
         recent_files_grid.margin_bottom = 3;
         recent_files_grid.orientation = Gtk.Orientation.VERTICAL;
         recent_files_grid.width_request = 220;
@@ -205,6 +207,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 
     private Gtk.PopoverMenu build_items_popover () {
         var grid = new Gtk.Grid ();
+        grid.margin_top = 6;
         grid.margin_bottom = 3;
         grid.orientation = Gtk.Orientation.VERTICAL;
         grid.width_request = 200;
@@ -217,6 +220,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 
         // Create the shapes submenu
         var shapes_grid = new Gtk.Grid ();
+        shapes_grid.margin_top = 6;
         shapes_grid.margin_bottom = 3;
         shapes_grid.orientation = Gtk.Orientation.VERTICAL;
         shapes_grid.width_request = 200;

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -122,11 +122,11 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         var grid = new Gtk.Grid ();
         grid.margin_bottom = 3;
         grid.orientation = Gtk.Orientation.VERTICAL;
-        grid.width_request = 220;
+        grid.width_request = 240;
         grid.name = "main";
 
         var new_window_button = new Akira.Partials.PopoverButton (
-            _("Open New Window"), {"<Ctrl>n"});
+            _("New Window"), "window-new-symbolic", {"<Ctrl>n"});
         new_window_button.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
             Akira.Services.ActionManager.ACTION_NEW_WINDOW;
 
@@ -134,7 +134,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         separator.margin_top = separator.margin_bottom = 3;
 
         var open_button = new Akira.Partials.PopoverButton (
-            _("Open"), {"<Ctrl>o"});
+            _("Open"), "document-open-symbolic", {"<Ctrl>o"});
         open_button.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
             Akira.Services.ActionManager.ACTION_OPEN;
 
@@ -166,12 +166,12 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         separator2.margin_top = separator2.margin_bottom = 3;
 
         var save_button = new Akira.Partials.PopoverButton (
-            _("Save"), {"<Ctrl>s"});
+            _("Save"), "document-save-symbolic", {"<Ctrl>s"});
         save_button.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
             Akira.Services.ActionManager.ACTION_SAVE;
 
         var save_as_button = new Akira.Partials.PopoverButton (
-            _("Save As"), {"<Ctrl><Shift>s"});
+            _("Save As"), "document-save-as-symbolic", {"<Ctrl><Shift>s"});
         save_as_button.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
             Akira.Services.ActionManager.ACTION_SAVE_AS;
 
@@ -179,7 +179,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         separator3.margin_top = separator3.margin_bottom = 3;
 
         var quit_button = new Akira.Partials.PopoverButton (
-            _("Quit"), {"<Ctrl>q"});
+            _("Quit"), "system-shutdown-symbolic", {"<Ctrl>q"});
         quit_button.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
             Akira.Services.ActionManager.ACTION_QUIT;
 
@@ -210,7 +210,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         grid.width_request = 200;
         grid.name = "main";
 
-        var artboard = new Akira.Partials.PopoverButton (_("Artboard"), {"A"});
+        var artboard = new Akira.Partials.PopoverButton (_("Artboard"), "window-new-symbolic", {"A"});
 
         var separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
         separator.margin_top = separator.margin_bottom = 3;
@@ -230,11 +230,11 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         var sub_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
         sub_separator.margin_top = sub_separator.margin_bottom = 3;
 
-        var rectangle = new Akira.Partials.PopoverButton (_("Rectangle"), {"R"});
+        var rectangle = new Akira.Partials.PopoverButton (_("Rectangle"), "shape-rectangle-symbolic", {"R"});
         rectangle.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
             Akira.Services.ActionManager.ACTION_ADD_RECT;
 
-        var ellipse = new Akira.Partials.PopoverButton (_("Ellipse"), {"E"});
+        var ellipse = new Akira.Partials.PopoverButton (_("Ellipse"), "shape-circle-symbolic", {"E"});
         ellipse.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
             Akira.Services.ActionManager.ACTION_ADD_ELLIPSE;
 
@@ -251,15 +251,15 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         var separator2 = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
         separator2.margin_top = separator2.margin_bottom = 3;
 
-        var vector = new Akira.Partials.PopoverButton (_("Vector"), {"V"});
+        var vector = new Akira.Partials.PopoverButton (_("Vector"), "segment-curve", {"V"});
 
-        var pencil = new Akira.Partials.PopoverButton (_("Pencil"), {"P"});
+        var pencil = new Akira.Partials.PopoverButton (_("Pencil"), "edit-symbolic", {"P"});
 
-        var text = new Akira.Partials.PopoverButton (_("Text"), {"T"});
+        var text = new Akira.Partials.PopoverButton (_("Text"), "shape-text-symbolic", {"T"});
         text.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
             Akira.Services.ActionManager.ACTION_ADD_TEXT;
 
-        var image = new Akira.Partials.PopoverButton (_("Image"), {"I"});
+        var image = new Akira.Partials.PopoverButton (_("Image"), "image-x-generic-symbolic", {"I"});
 
         grid.add (artboard);
         grid.add (separator);

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -28,7 +28,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
     public Gtk.Grid recent_files_grid;
 
     public Akira.Partials.MenuButton menu;
-    public Akira.Partials.MenuButton toolset;
+    public Akira.Partials.MenuButton items;
     public Akira.Partials.ZoomButton zoom;
     public Akira.Partials.HeaderBarButton group;
     public Akira.Partials.HeaderBarButton ungroup;
@@ -63,10 +63,66 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
     construct {
         set_show_close_button (true);
 
-        var menu_popover_grid = new Gtk.Grid ();
-        menu_popover_grid.margin_bottom = 3;
-        menu_popover_grid.orientation = Gtk.Orientation.VERTICAL;
-        menu_popover_grid.width_request = 220;
+        menu = new Akira.Partials.MenuButton ("document-open", _("Menu"), null);
+        var menu_popover = build_main_menu_popover ();
+        menu.button.popover = menu_popover;
+
+        items = new Akira.Partials.MenuButton ("insert-object", _("Insert"), null);
+        var items_popover = build_items_popover ();
+        items.button.popover = items_popover;
+
+        zoom = new Akira.Partials.ZoomButton (window);
+
+        group = new Akira.Partials.HeaderBarButton ("object-group", _("Group"), {"<Ctrl>g"});
+        ungroup = new Akira.Partials.HeaderBarButton ("object-ungroup", _("Ungroup"), {"<Ctrl><Shift>g"});
+
+        move_up = new Akira.Partials.HeaderBarButton ("selection-raise", _("Up"), {"<Ctrl>Up"});
+        move_down = new Akira.Partials.HeaderBarButton ("selection-lower", _("Down"), {"<Ctrl>Down"});
+        move_top = new Akira.Partials.HeaderBarButton ("selection-top", _("Top"), {"<Ctrl><Shift>Up"});
+        move_bottom = new Akira.Partials.HeaderBarButton ("selection-bottom", _("Bottom"), {"<Ctrl><Shift>Down"});
+
+        preferences = new Akira.Partials.HeaderBarButton ("open-menu", _("Settings"), {"<Ctrl>comma"});
+        preferences.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_PREFERENCES;
+
+        export = new Akira.Partials.HeaderBarButton ("document-export", _("Export"), {"<Ctrl><Shift>E"});
+        export.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_EXPORT;
+
+        path_difference = new Akira.Partials.HeaderBarButton ("path-difference", _("Difference"), null);
+        path_exclusion = new Akira.Partials.HeaderBarButton ("path-exclusion", _("Exclusion"), null);
+        path_intersect = new Akira.Partials.HeaderBarButton ("path-intersection", _("Intersect"), null);
+        path_union = new Akira.Partials.HeaderBarButton ("path-union", _("Union"), null);
+
+        pack_start (menu);
+        pack_start (items);
+        pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        pack_start (zoom);
+        pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        pack_start (group);
+        pack_start (ungroup);
+        pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        pack_start (move_up);
+        pack_start (move_down);
+        pack_start (move_top);
+        pack_start (move_bottom);
+        pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+
+        pack_end (preferences);
+        pack_end (export);
+        pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        pack_end (path_difference);
+        pack_end (path_exclusion);
+        pack_end (path_intersect);
+        pack_end (path_union);
+        pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+
+        build_signals ();
+    }
+
+    private Gtk.PopoverMenu build_main_menu_popover () {
+        var grid = new Gtk.Grid ();
+        grid.margin_bottom = 3;
+        grid.orientation = Gtk.Orientation.VERTICAL;
+        grid.width_request = 220;
 
         var new_window_button = new Akira.Partials.PopoverButton (
             _("Open New Window"), {"<Ctrl>n"});
@@ -90,14 +146,15 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         recent_files_grid.orientation = Gtk.Orientation.VERTICAL;
         recent_files_grid.width_request = 220;
 
-        var main_menu_button = new Gtk.ModelButton ();
-        main_menu_button.text = _("Main Menu");
-        main_menu_button.inverted = true;
+        var back_button = new Gtk.ModelButton ();
+        back_button.text = _("Main Menu");
+        back_button.inverted = true;
+        back_button.menu_name = "main-menu";
 
         var sub_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
         sub_separator.margin_top = sub_separator.margin_bottom = 3;
 
-        recent_files_grid.add (main_menu_button);
+        recent_files_grid.add (back_button);
         recent_files_grid.add (sub_separator);
         recent_files_popover.add (recent_files_grid);
 
@@ -128,108 +185,130 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         quit_button.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
             Akira.Services.ActionManager.ACTION_QUIT;
 
-        menu = new Akira.Partials.MenuButton ("document-open", _("Menu"), null);
-        var menu_popover = new Gtk.PopoverMenu ();
-        menu_popover.name = "main-menu";
-        menu.button.popover = menu_popover;
-        main_menu_button.menu_name = "main-menu";
+        grid.add (new_window_button);
+        grid.add (separator);
+        grid.add (open_button);
+        grid.add (open_recent_button);
+        grid.add (separator2);
+        grid.add (save_button);
+        grid.add (save_as_button);
+        grid.add (separator3);
+        grid.add (quit_button);
+        grid.show_all ();
 
-        menu_popover_grid.add (new_window_button);
-        menu_popover_grid.add (separator);
-        menu_popover_grid.add (open_button);
-        menu_popover_grid.add (open_recent_button);
-        menu_popover_grid.add (separator2);
-        menu_popover_grid.add (save_button);
-        menu_popover_grid.add (save_as_button);
-        menu_popover_grid.add (separator3);
-        menu_popover_grid.add (quit_button);
-        menu_popover_grid.show_all ();
+        var popover = new Gtk.PopoverMenu ();
+        popover.name = "main-menu";
+        popover.add (grid);
 
-        menu_popover.add (menu_popover_grid);
+        return popover;
+    }
 
-        var tools = new Gtk.Menu ();
-        tools.add (new Gtk.MenuItem.with_label(_("Artboard")));
-        tools.add (new Gtk.SeparatorMenuItem ());
-        tools.add (new Gtk.MenuItem.with_label(_("Vector")));
-        tools.add (new Gtk.MenuItem.with_label(_("Pencil")));
-        var shapes_item = new Gtk.MenuItem.with_label(_("Shapes"));
-        var shapes_submenu = new Gtk.Menu ();
-        shapes_item.submenu = shapes_submenu;
-        var rect_item = new Gtk.MenuItem.with_label(_("Rect"));
-        rect_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_RECT;
-        shapes_submenu.add (rect_item);
-        var ellipse_item = new Gtk.MenuItem.with_label(_("Ellipse"));
-        ellipse_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_ELLIPSE;
-        shapes_submenu.add (ellipse_item);
-        tools.add (shapes_item);
-        tools.add (new Gtk.SeparatorMenuItem ());
-        var text_item = new Gtk.MenuItem.with_label(_("Text"));
-        text_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_TEXT;
-        tools.add (text_item);
-        tools.add (new Gtk.MenuItem.with_label(_("Image")));
-        tools.show_all ();
+    private Gtk.PopoverMenu build_items_popover () {
+        var grid = new Gtk.Grid ();
+        grid.margin_bottom = 3;
+        grid.orientation = Gtk.Orientation.VERTICAL;
+        grid.width_request = 200;
 
-        toolset = new Akira.Partials.MenuButton ("insert-object", _("Insert"), null);
-        toolset.button.popup = tools;
+        var artboard = new Akira.Partials.PopoverButton (_("Artboard"), {"A"});
 
-        zoom = new Akira.Partials.ZoomButton (window);
+        var separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
+        separator.margin_top = separator.margin_bottom = 3;
 
-        group = new Akira.Partials.HeaderBarButton ("object-group", _("Group"), {"<Ctrl>g"});
-        ungroup = new Akira.Partials.HeaderBarButton ("object-ungroup", _("Ungroup"), {"<Ctrl><Shift>g"});
+        // Create the shapes submenu
+        var shapes_popover = new Gtk.PopoverMenu ();
+        shapes_popover.name = "files-menu";
 
-        move_up = new Akira.Partials.HeaderBarButton ("selection-raise", _("Up"), {"<Ctrl>Up"});
-        move_down = new Akira.Partials.HeaderBarButton ("selection-lower", _("Down"), {"<Ctrl>Down"});
-        move_top = new Akira.Partials.HeaderBarButton ("selection-top", _("Top"), {"<Ctrl><Shift>Up"});
-        move_bottom = new Akira.Partials.HeaderBarButton ("selection-bottom", _("Bottom"), {"<Ctrl><Shift>Down"});
+        var shapes_grid = new Gtk.Grid ();
+        shapes_grid.margin_bottom = 3;
+        shapes_grid.orientation = Gtk.Orientation.VERTICAL;
+        shapes_grid.width_request = 200;
 
-        preferences = new Akira.Partials.HeaderBarButton ("open-menu", _("Settings"), {"<Ctrl>comma"});
-        preferences.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_PREFERENCES;
+        var back_button = new Gtk.ModelButton ();
+        back_button.text = _("Add Items");
+        back_button.inverted = true;
+        back_button.menu_name = "items-menu";
 
-        export = new Akira.Partials.HeaderBarButton ("document-export", _("Export"), {"<Ctrl><Shift>E"});
-        export.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_EXPORT;
+        var sub_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
+        sub_separator.margin_top = sub_separator.margin_bottom = 3;
 
-        path_difference = new Akira.Partials.HeaderBarButton ("path-difference", _("Difference"), null);
-        path_exclusion = new Akira.Partials.HeaderBarButton ("path-exclusion", _("Exclusion"), null);
-        path_intersect = new Akira.Partials.HeaderBarButton ("path-intersection", _("Intersect"), null);
-        path_union = new Akira.Partials.HeaderBarButton ("path-union", _("Union"), null);
+        var rectangle = new Akira.Partials.PopoverButton (_("Rectangle"), {"R"});
+        rectangle.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
+            Akira.Services.ActionManager.ACTION_ADD_RECT;
 
-        pack_start (menu);
-        pack_start (toolset);
-        pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-        pack_start (zoom);
-        pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-        pack_start (group);
-        pack_start (ungroup);
-        pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-        pack_start (move_up);
-        pack_start (move_down);
-        pack_start (move_top);
-        pack_start (move_bottom);
-        pack_start (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        var ellipse = new Akira.Partials.PopoverButton (_("Ellipse"), {"E"});
+        ellipse.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
+            Akira.Services.ActionManager.ACTION_ADD_ELLIPSE;
 
-        pack_end (preferences);
-        pack_end (export);
-        pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
-        pack_end (path_difference);
-        pack_end (path_exclusion);
-        pack_end (path_intersect);
-        pack_end (path_union);
-        pack_end (new Gtk.Separator (Gtk.Orientation.VERTICAL));
+        shapes_grid.add (back_button);
+        shapes_grid.add (sub_separator);
+        shapes_grid.add (rectangle);
+        shapes_grid.add (ellipse);
+        shapes_popover.add (shapes_grid);
 
-        build_signals ();
+        var shapes_button = new Gtk.ModelButton ();
+        shapes_button.text = _("Shapes");
+        shapes_button.menu_name = "shapes-menu";
+
+        var separator2 = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
+        separator2.margin_top = separator2.margin_bottom = 3;
+
+        var vector = new Akira.Partials.PopoverButton (_("Vector"), {"V"});
+
+        var pencil = new Akira.Partials.PopoverButton (_("Pencil"), {"P"});
+
+        var text = new Akira.Partials.PopoverButton (_("Text"), {"T"});
+        text.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
+            Akira.Services.ActionManager.ACTION_ADD_TEXT;
+
+        var image = new Akira.Partials.PopoverButton (_("Image"), {"I"});
+
+        //  var shapes_item = new Gtk.MenuItem.with_label(_("Shapes"));
+        //  var shapes_submenu = new Gtk.Menu ();
+        //  shapes_item.submenu = shapes_submenu;
+        //  var rect_item = new Gtk.MenuItem.with_label(_("Rect"));
+        //  rect_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_RECT;
+        //  shapes_submenu.add (rect_item);
+        //  var ellipse_item = new Gtk.MenuItem.with_label(_("Ellipse"));
+        //  ellipse_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_ELLIPSE;
+        //  shapes_submenu.add (ellipse_item);
+        //  tools.add (shapes_item);
+        //  tools.add (new Gtk.SeparatorMenuItem ());
+        //  var text_item = new Gtk.MenuItem.with_label(_("Text"));
+        //  text_item.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_ADD_TEXT;
+        //  tools.add (text_item);
+        //  tools.add (new Gtk.MenuItem.with_label(_("Image")));
+        //  tools.show_all ();
+
+        grid.add (artboard);
+        grid.add (separator);
+        grid.add (shapes_button);
+        grid.add (separator2);
+        grid.add (vector);
+        grid.add (pencil);
+        grid.add (text);
+        grid.add (image);
+        grid.show_all ();
+
+        var popover = new Gtk.PopoverMenu ();
+        popover.name = "items-menu";
+        popover.add (grid);
+
+        return popover;
     }
 
     private void build_signals () {
-        // deal with signals not part of accelerators
+        // TODO: deal with signals not part of accelerators
     }
 
     public void button_sensitivity () {
-        // dinamically toggle button sensitivity based on document status or actor selected.
+        /* TODO: dinamically toggle button sensitivity
+         * based on document status or actor selected.
+         */
     }
 
     public void update_icons_style () {
         menu.update_image ();
-        toolset.update_image ();
+        items.update_image ();
         export.update_image ();
         preferences.update_image ();
         group.update_image ();

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -123,6 +123,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         grid.margin_bottom = 3;
         grid.orientation = Gtk.Orientation.VERTICAL;
         grid.width_request = 220;
+        grid.name = "main";
 
         var new_window_button = new Akira.Partials.PopoverButton (
             _("Open New Window"), {"<Ctrl>n"});
@@ -137,19 +138,17 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         open_button.action_name = Akira.Services.ActionManager.ACTION_PREFIX +
             Akira.Services.ActionManager.ACTION_OPEN;
 
-        // Create the recent files submenu
-        var recent_files_popover = new Gtk.PopoverMenu ();
-        recent_files_popover.name = "files-menu";
-
         recent_files_grid = new Gtk.Grid ();
         recent_files_grid.margin_bottom = 3;
         recent_files_grid.orientation = Gtk.Orientation.VERTICAL;
         recent_files_grid.width_request = 220;
+        recent_files_grid.name = "files-menu";
 
         var back_button = new Gtk.ModelButton ();
         back_button.text = _("Main Menu");
         back_button.inverted = true;
-        back_button.menu_name = "main-menu";
+        back_button.menu_name = "main";
+        back_button.expand = true;
 
         var sub_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
         sub_separator.margin_top = sub_separator.margin_bottom = 3;
@@ -157,8 +156,6 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         recent_files_grid.add (back_button);
         recent_files_grid.add (sub_separator);
         recent_files_grid.show_all ();
-
-        recent_files_popover.add (recent_files_grid);
         fetch_recent_files ();
 
         var open_recent_button = new Gtk.ModelButton ();
@@ -198,9 +195,10 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         grid.show_all ();
 
         var popover = new Gtk.PopoverMenu ();
-        popover.name = "main-menu";
         popover.add (grid);
-        //  popover.child_set_property (recent_files_popover, "submenu", "files-menu");
+        popover.add (recent_files_grid);
+        popover.child_set_property (grid, "submenu", "main");
+        popover.child_set_property (recent_files_grid, "submenu", "files-menu");
 
         return popover;
     }
@@ -210,6 +208,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         grid.margin_bottom = 3;
         grid.orientation = Gtk.Orientation.VERTICAL;
         grid.width_request = 200;
+        grid.name = "main";
 
         var artboard = new Akira.Partials.PopoverButton (_("Artboard"), {"A"});
 
@@ -217,18 +216,16 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         separator.margin_top = separator.margin_bottom = 3;
 
         // Create the shapes submenu
-        var shapes_popover = new Gtk.PopoverMenu ();
-        shapes_popover.name = "shapes-menu";
-
         var shapes_grid = new Gtk.Grid ();
         shapes_grid.margin_bottom = 3;
         shapes_grid.orientation = Gtk.Orientation.VERTICAL;
         shapes_grid.width_request = 200;
+        shapes_grid.name = "shapes-menu";
 
         var back_button = new Gtk.ModelButton ();
         back_button.text = _("Add Items");
         back_button.inverted = true;
-        back_button.menu_name = "items-menu";
+        back_button.menu_name = "main";
 
         var sub_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
         sub_separator.margin_top = sub_separator.margin_bottom = 3;
@@ -246,9 +243,6 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         shapes_grid.add (rectangle);
         shapes_grid.add (ellipse);
         shapes_grid.show_all ();
-
-        shapes_popover.add (shapes_grid);
-        shapes_popover.show_all ();
 
         var shapes_button = new Gtk.ModelButton ();
         shapes_button.text = _("Shapes");
@@ -278,13 +272,10 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         grid.show_all ();
 
         var popover = new Gtk.PopoverMenu ();
-        popover.name = "items-menu";
         popover.add (grid);
-        popover.add (shapes_popover);
-
-        var submenu_name = Value (typeof (string));
-        submenu_name.set_string ("shapes-menu");
-        popover.child_set_property (shapes_popover, "submenu", submenu_name);
+        popover.add (shapes_grid);
+        popover.child_set_property (grid, "submenu", "main");
+        popover.child_set_property (shapes_grid, "submenu", "shapes-menu");
 
         return popover;
     }

--- a/src/Partials/PopoverButton.vala
+++ b/src/Partials/PopoverButton.vala
@@ -20,7 +20,7 @@
  */
 
 public class Akira.Partials.PopoverButton : Gtk.Button {
-    public PopoverButton (string text, string[]? accels = null) {
+    public PopoverButton (string text, string? icon, string[]? accels = null) {
         get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
 
         var label = new Gtk.Label (text);
@@ -29,6 +29,11 @@ public class Akira.Partials.PopoverButton : Gtk.Button {
         label.margin_start = 6;
 
         var grid = new Gtk.Grid ();
+
+        if (icon != null) {
+            grid.add (new Gtk.Image.from_icon_name (icon, Gtk.IconSize.MENU));
+        }
+
         grid.add (label);
 
         if (accels != null) {

--- a/src/Partials/PopoverButton.vala
+++ b/src/Partials/PopoverButton.vala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+ */
+
+public class Akira.Partials.PopoverButton : Gtk.Button {
+    public PopoverButton (string text, string[]? accels = null) {
+        get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
+
+        var label = new Gtk.Label (text);
+        label.halign = Gtk.Align.START;
+        label.hexpand = true;
+        label.margin_start = 6;
+
+        var grid = new Gtk.Grid ();
+        grid.add (label);
+
+        if (accels != null) {
+            var accel_label = new Gtk.Label (Granite.markup_accel_tooltip (accels));
+            accel_label.halign = Gtk.Align.END;
+            accel_label.margin_end = 6;
+            accel_label.use_markup = true;
+
+            grid.add (accel_label);
+        }
+
+        add (grid);
+    }
+}

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -102,7 +102,7 @@ public class Akira.Services.ActionManager : Object {
     private void action_labels () {
         window.headerbar.toggle ();
         window.headerbar.menu.toggle ();
-        window.headerbar.toolset.toggle ();
+        window.headerbar.items.toggle ();
         window.headerbar.zoom.toggle ();
         window.headerbar.preferences.toggle ();
         window.headerbar.export.toggle ();
@@ -122,7 +122,7 @@ public class Akira.Services.ActionManager : Object {
     public void show_labels () {
         window.headerbar.toggle ();
         window.headerbar.menu.show_labels ();
-        window.headerbar.toolset.show_labels ();
+        window.headerbar.items.show_labels ();
         window.headerbar.zoom.show_labels ();
         window.headerbar.preferences.show_labels ();
         window.headerbar.export.show_labels ();
@@ -142,7 +142,7 @@ public class Akira.Services.ActionManager : Object {
     public void hide_labels () {
         window.headerbar.toggle ();
         window.headerbar.menu.hide_labels ();
-        window.headerbar.toolset.hide_labels ();
+        window.headerbar.items.hide_labels ();
         window.headerbar.zoom.hide_labels ();
         window.headerbar.preferences.hide_labels ();
         window.headerbar.export.hide_labels ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -56,6 +56,7 @@ executable(
     'Partials/AlignBoxButton.vala',
     'Partials/LinkedInput.vala',
     'Partials/PanelSeparator.vala',
+    'Partials/PopoverButton.vala',
 
     'Models/FillsItemModel.vala',
     'Models/FillsListModel.vala',


### PR DESCRIPTION
## Summary
Convert the currently implement `Gtk.Popup`s into `Gtk.Popover`s.
This is helpful and necessary since those dropdowns reveal multiple submenus, and navigating through them with a regular popup is prone to mistakes.
Popovers also allow us to better handle spacing and show accelerators.

## Screenshot
![Screenshot from 2019-04-28 22-44-50](https://user-images.githubusercontent.com/2527103/56878152-65fe7100-6a07-11e9-958d-34dd1579a9cf.png)

## Known Issues / Things To Do
- [x] Convert Main Menu
- [x] Convert Shapes Menu
- [x] Implement Submenu
- [x] Add Icons to menu items Submenu

- Fixes #114
