### PR TITLE
Settings: reduce code duplication

### DIFF
--- a/build-aux/flatpak/com.github.akiraux.akira.json
+++ b/build-aux/flatpak/com.github.akiraux.akira.json
@@ -19,7 +19,10 @@
       "--share=ipc",
       "--socket=x11",
       "--socket=wayland",
-      "--talk-name=org.gtk.vfs.*"
+      "--talk-name=org.gtk.vfs.*",
+      /* dconf */
+      "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+      "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
    ],
    "modules": [
       {

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -172,23 +172,6 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         // dinamically toggle button sensitivity based on document status or actor selected.
     }
 
-    public void update_icons_style () {
-        menu.update_image ();
-        toolset.update_image ();
-        export.update_image ();
-        preferences.update_image ();
-        group.update_image ();
-        ungroup.update_image ();
-        move_up.update_image ();
-        move_down.update_image ();
-        move_top.update_image ();
-        move_bottom.update_image ();
-        path_difference.update_image ();
-        path_exclusion.update_image ();
-        path_intersect.update_image ();
-        path_union.update_image ();
-    }
-
     public void toggle () {
         toggled = !toggled;
     }

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -43,6 +43,7 @@ public class Akira.Partials.AlignBoxButton : Gtk.Button {
         sensitive = false;
 
         btn_image = new ButtonImage (icon);
+        add (btn_image);
         connect_signals ();
     }
 

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -25,7 +25,7 @@ public class Akira.Partials.AlignBoxButton : Gtk.Button {
 
     public string icon { get; construct; }
     public string action { get; construct; }
-    public Gtk.Image btn_image;
+    public Akira.Partials.ButtonImage btn_image;
 
     public AlignBoxButton (Akira.Window main_window, string action_name, string icon_name, string tooltip, string[] accels) {
         Object (
@@ -42,30 +42,12 @@ public class Akira.Partials.AlignBoxButton : Gtk.Button {
         get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         sensitive = false;
 
-        update_icon_style ();
+        btn_image = new ButtonImage (icon);
         connect_signals ();
     }
 
-    private void update_icon_style () {
-        var size = settings.use_symbolic == true ? Gtk.IconSize.SMALL_TOOLBAR : Gtk.IconSize.LARGE_TOOLBAR;
-
-        var new_icon = settings.use_symbolic == true ? ("%s-symbolic".printf (icon)) : icon.replace ("-symbolic", "");
-
-        if (btn_image != null) {
-            remove (btn_image);
-        }
-
-        btn_image = new Gtk.Image.from_icon_name (new_icon, size);
-        add (btn_image);
-
-        show_all ();
-    }
 
     private void connect_signals () {
-        window.event_bus.update_icons_style.connect (() => {
-            update_icon_style ();
-        });
-
         clicked.connect (() => {
             window.event_bus.emit ("align-items", action);
         });

--- a/src/Partials/ButtonImage.vala
+++ b/src/Partials/ButtonImage.vala
@@ -20,22 +20,27 @@
 */
 
 
-public class Akira.Partials.IconButton: Gtk.Grid {
+public class Akira.Partials.ButtonImage: Gtk.Image {
 
-    private Gtk.Label label_btn;
-    public Gtk.Image image;
+    private string icon;
 
-    public IconButton (string icon_name, string name, string[]? accels = null) {
+    public ButtonImage (string icon_name) {
+        icon = icon_name;
+        margin = 0;
 
+        settings.changed["use-symbolic"].connect(() => {
+            update_image();
+        });
+
+        update_image ();
     }
 
-    public
 
-    private Gtk.Image create_button_image (string icon_name) {
+    private void update_image () {
         var size = settings.use_symbolic ? Gtk.IconSize.SMALL_TOOLBAR : Gtk.IconSize.LARGE_TOOLBAR;
-        var icon = settings.use_symbolic ? ("%s-symbolic".printf (icon_name)) : icon_name.replace ("-symbolic", "");
-        image = new Gtk.Image.from_icon_name (icon_name, size);
-        image.margin = 0;
-        return image;
+        var icon = settings.use_symbolic ? ("%s-symbolic".printf (icon)) : icon.replace ("-symbolic", "");
+        set_from_icon_name(icon, size);
     }
+
+
 }

--- a/src/Partials/HeaderBarButton.vala
+++ b/src/Partials/HeaderBarButton.vala
@@ -19,12 +19,34 @@
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
-public class Akira.Partials.HeaderBarButton : Akira.Partials.IconButton {
+public class Akira.Partials.HeaderBarButton : Gtk.Grid {
 
     public Gtk.Button button;
+    private Gtk.Label label_btn;
+    public Akira.Partials.ButtonImage image;
 
     public HeaderBarButton (string icon_name, string name, string[]? accels = null) {
+        label_btn = new Gtk.Label (name);
+        label_btn.get_style_context ().add_class ("headerbar-label");
+
+        settings.changed["show-label"].connect( () => {
+            label_btn.visible = settings.show_label;
+            label_btn.no_show_all = !settings.show_label;
+        });
+
         button = new Gtk.Button ();
-        base (icon_name, name, accels);
+
+        button.can_focus = false;
+        button.halign = Gtk.Align.CENTER;
+        button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        button.tooltip_markup = Granite.markup_accel_tooltip (accels, name);
+
+        image = new ButtonImage (icon_name);
+        button.add (image);
+
+        attach (button, 0, 0, 1, 1);
+        attach (label_btn, 0, 1, 1, 1);
+
+        valign = Gtk.Align.CENTER;
     }
 }

--- a/src/Partials/IconButton.vala
+++ b/src/Partials/IconButton.vala
@@ -16,15 +16,26 @@
 * You should have received a copy of the GNU General Public License
 * along with Akira.  If not, see <https://www.gnu.org/licenses/>.
 *
-* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+* Authored by: Bilal Elmoussaoui <bilal.elmoussaoui@gnome.org>
 */
 
-public class Akira.Partials.HeaderBarButton : Akira.Partials.IconButton {
 
-    public Gtk.Button button;
+public class Akira.Partials.IconButton: Gtk.Grid {
 
-    public HeaderBarButton (string icon_name, string name, string[]? accels = null) {
-        button = new Gtk.Button ();
-        base (icon_name, name, accels);
+    private Gtk.Label label_btn;
+    public Gtk.Image image;
+
+    public IconButton (string icon_name, string name, string[]? accels = null) {
+
+    }
+
+    public
+
+    private Gtk.Image create_button_image (string icon_name) {
+        var size = settings.use_symbolic ? Gtk.IconSize.SMALL_TOOLBAR : Gtk.IconSize.LARGE_TOOLBAR;
+        var icon = settings.use_symbolic ? ("%s-symbolic".printf (icon_name)) : icon_name.replace ("-symbolic", "");
+        image = new Gtk.Image.from_icon_name (icon_name, size);
+        image.margin = 0;
+        return image;
     }
 }

--- a/src/Partials/MenuButton.vala
+++ b/src/Partials/MenuButton.vala
@@ -19,61 +19,12 @@
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
-public class Akira.Partials.MenuButton : Gtk.Grid {
-    public bool labeled {
-        get {
-            return label_btn.visible;
-        } set {
-            label_btn.visible = value;
-            label_btn.no_show_all = !value;
-        }
-    }
+public class Akira.Partials.MenuButton : Akira.Partials.IconButton {
 
-    private Gtk.Label label_btn;
     public Gtk.MenuButton button;
-    public Gtk.Image image;
 
     public MenuButton (string icon_name, string name, string[]? accels = null) {
-        label_btn = new Gtk.Label (name);
-        label_btn.get_style_context ().add_class ("headerbar-label");
-
-        var size = settings.use_symbolic == true ? Gtk.IconSize.SMALL_TOOLBAR : Gtk.IconSize.LARGE_TOOLBAR;
-        var icon = settings.use_symbolic == true ? ("%s-symbolic".printf (icon_name)) : icon_name;
-
-        image = new Gtk.Image.from_icon_name (icon, size);
-        image.margin = 0;
-
         button = new Gtk.MenuButton ();
-        button.can_focus = false;
-        button.halign = Gtk.Align.CENTER;
-        button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        button.add (image);
-        button.tooltip_markup = Granite.markup_accel_tooltip (accels, name);
-
-        attach (button, 0, 0, 1, 1);
-        attach (label_btn, 0, 1, 1, 1);
-
-        valign = Gtk.Align.CENTER;
-    }
-
-    public void toggle () {
-        labeled = !labeled;
-    }
-
-    public void show_labels () {
-        labeled = true;
-    }
-
-    public void hide_labels () {
-        labeled = false;
-    }
-
-    public void update_image () {
-        var size = settings.use_symbolic == true ? Gtk.IconSize.SMALL_TOOLBAR : Gtk.IconSize.LARGE_TOOLBAR;
-        var new_icon = settings.use_symbolic == true ? ("%s-symbolic".printf (image.icon_name)) : image.icon_name.replace ("-symbolic", "");
-        button.remove (image);
-        image = new Gtk.Image.from_icon_name (new_icon, size);
-        button.add (image);
-        image.show_all ();
+        base (icon_name, name, accels);
     }
 }

--- a/src/Partials/MenuButton.vala
+++ b/src/Partials/MenuButton.vala
@@ -19,12 +19,34 @@
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
-public class Akira.Partials.MenuButton : Akira.Partials.IconButton {
+public class Akira.Partials.MenuButton : Gtk.Grid {
 
     public Gtk.MenuButton button;
+    private Gtk.Label label_btn;
+    public Akira.Partials.ButtonImage image;
 
     public MenuButton (string icon_name, string name, string[]? accels = null) {
-        button = new Gtk.MenuButton ();
-        base (icon_name, name, accels);
+        label_btn = new Gtk.Label (name);
+        label_btn.get_style_context ().add_class ("headerbar-label");
+
+        settings.changed["show-label"].connect( () => {
+            label_btn.visible = settings.show_label;
+            label_btn.no_show_all = !settings.show_label;
+        });
+
+
+        button = new Gtk.MenuButton();
+        button.can_focus = false;
+        button.halign = Gtk.Align.CENTER;
+        button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        button.tooltip_markup = Granite.markup_accel_tooltip (accels, name);
+
+        image = new ButtonImage (icon_name);
+        button.add (image);
+
+        attach (button, 0, 0, 1, 1);
+        attach (label_btn, 0, 1, 1, 1);
+
+        valign = Gtk.Align.CENTER;
     }
 }

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -22,15 +22,6 @@
 public class Akira.Partials.ZoomButton : Gtk.Grid {
     public weak Akira.Window window { get; construct; }
 
-    public bool labeled {
-        get {
-            return label_btn.visible;
-        } set {
-            label_btn.visible = value;
-            label_btn.no_show_all = !value;
-        }
-    }
-
     private Gtk.Label label_btn;
     public Gtk.Button zoom_out_button;
     public Gtk.Button zoom_default_button;
@@ -78,19 +69,12 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         label_btn.get_style_context ().add_class ("headerbar-label");
         label_btn.margin_top = 4;
 
+        settings.changed["show-label"].connect( () => {
+            label_btn.visible = settings.show_label;
+            label_btn.no_show_all = !settings.show_label;
+        });
+
         attach (label_btn, 0, 1, 3, 1);
-    }
-
-    public void toggle () {
-        labeled = !labeled;
-    }
-
-    public void show_labels () {
-        labeled = true;
-    }
-
-    public void hide_labels () {
-        labeled = false;
     }
 
     public void zoom_out () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -135,7 +135,6 @@ public class Akira.Services.ActionManager : Object {
 
     private void action_preferences () {
         var settings_dialog = new Akira.Widgets.SettingsDialog();
-        settings_dialog.parent = window;
         settings_dialog.transient_for = window;
         settings_dialog.show_all ();
         settings_dialog.present ();

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -203,16 +203,11 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_preferences () {
-        if (window.settings_dialog == null) {
-            window.settings_dialog = new Akira.Widgets.SettingsDialog (window);
-            window.settings_dialog.show_all ();
-
-            window.settings_dialog.destroy.connect (() => {
-                window.settings_dialog = null;
-            });
-        }
-
-        window.settings_dialog.present ();
+        settings_dialog = new Akira.Widgets.SettingsDialog();
+        settings_dialog.parent = window;
+        settings_dialog.transient_for = window;
+        settings_dialog.show_all ();
+        settings_dialog.present ();
     }
 
     private void action_export () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -35,7 +35,6 @@ public class Akira.Services.ActionManager : Object {
     public const string ACTION_PRESENTATION = "action_presentation";
     public const string ACTION_PREFERENCES = "action_preferences";
     public const string ACTION_EXPORT = "action_export";
-    public const string ACTION_LABELS = "action_labels";
     public const string ACTION_QUIT = "action_quit";
     public const string ACTION_ZOOM_IN = "action_zoom_in";
     public const string ACTION_ZOOM_OUT = "action_zoom_out";
@@ -56,7 +55,6 @@ public class Akira.Services.ActionManager : Object {
         { ACTION_PRESENTATION, action_presentation },
         { ACTION_PREFERENCES, action_preferences },
         { ACTION_EXPORT, action_export },
-        { ACTION_LABELS, action_labels },
         { ACTION_QUIT, action_quit },
         { ACTION_ZOOM_IN, action_zoom_in },
         { ACTION_ZOOM_OUT, action_zoom_out },
@@ -99,73 +97,6 @@ public class Akira.Services.ActionManager : Object {
         }
     }
 
-    private void action_labels () {
-        window.headerbar.toggle ();
-        window.headerbar.menu.toggle ();
-        window.headerbar.toolset.toggle ();
-        window.headerbar.zoom.toggle ();
-        window.headerbar.preferences.toggle ();
-        window.headerbar.export.toggle ();
-        window.headerbar.group.toggle ();
-        window.headerbar.ungroup.toggle ();
-        window.headerbar.move_up.toggle ();
-        window.headerbar.move_down.toggle ();
-        window.headerbar.move_top.toggle ();
-        window.headerbar.move_bottom.toggle ();
-        window.headerbar.path_difference.toggle ();
-        window.headerbar.path_exclusion.toggle ();
-        window.headerbar.path_intersect.toggle ();
-        window.headerbar.path_union.toggle ();
-        window.headerbar.toggle ();
-    }
-
-    public void show_labels () {
-        window.headerbar.toggle ();
-        window.headerbar.menu.show_labels ();
-        window.headerbar.toolset.show_labels ();
-        window.headerbar.zoom.show_labels ();
-        window.headerbar.preferences.show_labels ();
-        window.headerbar.export.show_labels ();
-        window.headerbar.group.show_labels ();
-        window.headerbar.ungroup.show_labels ();
-        window.headerbar.move_up.show_labels ();
-        window.headerbar.move_down.show_labels ();
-        window.headerbar.move_top.show_labels ();
-        window.headerbar.move_bottom.show_labels ();
-        window.headerbar.path_difference.show_labels ();
-        window.headerbar.path_exclusion.show_labels ();
-        window.headerbar.path_intersect.show_labels ();
-        window.headerbar.path_union.show_labels ();
-        window.headerbar.toggle ();
-    }
-
-    public void hide_labels () {
-        window.headerbar.toggle ();
-        window.headerbar.menu.hide_labels ();
-        window.headerbar.toolset.hide_labels ();
-        window.headerbar.zoom.hide_labels ();
-        window.headerbar.preferences.hide_labels ();
-        window.headerbar.export.hide_labels ();
-        window.headerbar.group.hide_labels ();
-        window.headerbar.ungroup.hide_labels ();
-        window.headerbar.move_up.hide_labels ();
-        window.headerbar.move_down.hide_labels ();
-        window.headerbar.move_top.hide_labels ();
-        window.headerbar.move_bottom.hide_labels ();
-        window.headerbar.path_difference.hide_labels ();
-        window.headerbar.path_exclusion.hide_labels ();
-        window.headerbar.path_intersect.hide_labels ();
-        window.headerbar.path_union.hide_labels ();
-        window.headerbar.toggle ();
-    }
-
-    public void update_icons_style () {
-        window.headerbar.toggle ();
-        window.headerbar.update_icons_style ();
-        window.headerbar.toggle ();
-
-        window.event_bus.emit ("update-icons-style");
-    }
 
     private void action_quit () {
         window.before_destroy ();
@@ -203,7 +134,7 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_preferences () {
-        settings_dialog = new Akira.Widgets.SettingsDialog();
+        var settings_dialog = new Akira.Widgets.SettingsDialog();
         settings_dialog.parent = window;
         settings_dialog.transient_for = window;
         settings_dialog.show_all ();

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -91,6 +91,7 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
 
         content_grid.attach (new SettingsLabel (_("Use Dark Theme:")), 0, 1, 1, 1);
         dark_theme_switch = new SettingsSwitch ("dark-theme");
+
         content_grid.attach (dark_theme_switch, 1, 1, 1, 1);
 
         dark_theme_switch.notify["active"].connect (() => {
@@ -103,22 +104,11 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
         label_switch = new SettingsSwitch ("show-label");
         content_grid.attach (label_switch, 1, 3, 1, 1);
 
-        label_switch.notify["active"].connect (() => {
-            if (!settings.show_label) {
-                window.action_manager.hide_labels ();
-            } else if (settings.show_label) {
-                window.action_manager.show_labels ();
-            }
-        });
-
         content_grid.attach (new SettingsLabel (_("Use Symbolic Icons:")), 0, 4, 1, 1);
         symbolic_switch = new SettingsSwitch ("use-symbolic");
         content_grid.attach (symbolic_switch, 1, 4, 1, 1);
 
-        symbolic_switch.notify["active"].connect (() => {
-            window.action_manager.update_icons_style ();
-        });
-
+        
         return content_grid;
     }
 

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -20,7 +20,6 @@
 */
 
 public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
-    public weak Akira.Window window { get; construct; }
 
     private Gtk.Stack main_stack;
     private Gtk.Switch dark_theme_switch;
@@ -31,14 +30,13 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
         ICONTYPE
     }
 
-    public SettingsDialog (Akira.Window parent) {
+    public SettingsDialog () {
         Object (
             border_width: 5,
             deletable: false,
             resizable: false,
-            title: _("Preferences"),
-            transient_for: parent,
-            window: parent
+            modal: true,
+            title: _("Preferences")
         );
     }
 

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -86,10 +86,6 @@ public class Akira.Window : Gtk.ApplicationWindow {
         Gtk.StyleContext.add_provider_for_screen (
             Gdk.Screen.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         );
-
-        if (!settings.show_label) {
-            Akira.Services.ActionManager.action_from_group (Akira.Services.ActionManager.ACTION_LABELS, get_action_group ("win"));
-        }
     }
 
     public bool before_destroy () {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -28,7 +28,6 @@ public class Akira.Window : Gtk.ApplicationWindow {
     public Akira.Services.EventBus event_bus;
     public Akira.Layouts.HeaderBar headerbar;
     public Akira.Layouts.MainWindow main_window;
-    public Akira.Widgets.SettingsDialog? settings_dialog = null;
     public Akira.Utils.Dialogs dialogs;
 
     public SimpleActionGroup actions { get; construct; }

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,6 +53,7 @@ executable(
     'Partials/HeaderBarButton.vala',
     'Partials/MenuButton.vala',
     'Partials/ZoomButton.vala',
+    'Partials/IconButton.vala',
     'Partials/AlignBoxButton.vala',
     'Partials/LinkedInput.vala',
     'Partials/PanelSeparator.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,7 +53,7 @@ executable(
     'Partials/HeaderBarButton.vala',
     'Partials/MenuButton.vala',
     'Partials/ZoomButton.vala',
-    'Partials/IconButton.vala',
+    'Partials/ButtonImage.vala',
     'Partials/AlignBoxButton.vala',
     'Partials/LinkedInput.vala',
     'Partials/PanelSeparator.vala',


### PR DESCRIPTION
- We used to pass the main window reference to the settings dialog which is not needed anymore (see 2nd point)
- We have been showing and hiding the labels for the buttons manually for each button which cost us a few lines of code every time we add a new MenuButton or a HeaderButton. This is now fixed as we listen to the settings changes signals and update all the buttons state.

Not ready to be reviewed yet.