### PR TITLE
Add Github sponsorship button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: akiraux
+liberapay: AkiraUX


### PR DESCRIPTION
Hi, I was setting this up for my own repo today. Thought it would be useful here too.

---

Enable in settings once merged.
![Screenshot from 2019-06-14 21-43-21](https://user-images.githubusercontent.com/2096087/59534259-0ba16d00-8eee-11e9-9fab-4614f0ba8e0f.png)

This is how it will look like, once merged and enabled in settings
![Screenshot from 2019-06-14 21-46-23](https://user-images.githubusercontent.com/2096087/59534271-178d2f00-8eee-11e9-82bb-113f034d3d8d.png)

> Note it says `nisrulz/Akira` because I created the branch in my repo, but the user name is picked from the repo the file exists in. 