### PR TITLE
Shapes default settings

### DIFF
--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -54,10 +54,27 @@
             <description>Allow user to choose between normal and symbolic icons in HeaderBar.</description>
         </key>
 
+        <key name="fill-color" type="s">
+            <default>'#CCCCCC'</default>
+            <summary>Default Shape Color.</summary>
+            <description>The default color of a newly created shape.</description>
+        </key>
+
         <key name="set-border" type="b">
             <default>true</default>
             <summary>Add Border on Shape Creation</summary>
             <description>Enable the addition of the border style when creating a new shape.</description>
+        </key>
+
+        <key name="border-size" type="i">
+            <default>1</default>
+            <summary>Default Border Width.</summary>
+            <description>The default width of the border for a newly created shape.</description>
+        </key>
+        <key name="border-color" type="s">
+            <default>'#AAAAAA'</default>
+            <summary>Default Border Color.</summary>
+            <description>The default color of the border for a newly created shape.</description>
         </key>
 
         <key name="open-quick" type="b">

--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -54,6 +54,12 @@
             <description>Allow user to choose between normal and symbolic icons in HeaderBar.</description>
         </key>
 
+        <key name="set-border" type="b">
+            <default>true</default>
+            <summary>Add Border on Shape Creation</summary>
+            <description>Enable the addition of the border style when creating a new shape.</description>
+        </key>
+
         <key name="open-quick" type="b">
             <default>false</default>
             <summary>Auto Reopen latest file</summary>

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -114,6 +114,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     private double bounds_w;
     private double bounds_h;
 
+    private double border_size;
+    private string border_color;
+    private string fill_color;
+
     construct {
         edit_mode = EditMode.MODE_SELECTION;
         events |= Gdk.EventMask.KEY_PRESS_MASK;
@@ -177,6 +181,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     public Goo.CanvasItem? insert_object (Gdk.EventButton event) {
+        udpate_default_values ();
+
         if (insert_type == InsertType.RECT) {
           return add_rect (event);
         } else if (insert_type == InsertType.ELLIPSE) {
@@ -806,16 +812,18 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     public Goo.CanvasRect add_rect (Gdk.EventButton event) {
         var root = get_root_item ();
-        var rect = new Goo.CanvasRect (null, event.x, event.y, 10, 10,
-                                    "line-width", 5.0,
-                                    "radius-x", 100.0,
-                                    "radius-y", 100.0,
-                                    "stroke-color", "#f37329",
-                                    "fill-color", "#ffa154", null);
+        var rect = new Goo.CanvasRect (null, event.x, event.y, 1, 1,
+                                       "line-width", border_size,
+                                       "radius-x", 0.0,
+                                       "radius-y", 0.0,
+                                       "stroke-color", border_color,
+                                       "fill-color", fill_color, null);
+
         rect.set ("parent", root);
-        rect.set_transform(Cairo.Matrix.identity ());
+        rect.set_transform (Cairo.Matrix.identity ());
         var artboard = window.main_window.right_sidebar.layers_panel.artboard;
-        var layer = new Akira.Layouts.Partials.Layer (window, artboard, rect, "Rectangle", "shape-rectangle-symbolic", false);
+        var layer = new Akira.Layouts.Partials.Layer (window, artboard, rect,
+            "Rectangle", "shape-rectangle-symbolic", false);
         rect.set_data<Akira.Layouts.Partials.Layer?> ("layer", layer);
         artboard.container.add (layer);
         artboard.show_all ();
@@ -824,15 +832,16 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     public Goo.CanvasEllipse add_ellipse (Gdk.EventButton event) {
         var root = get_root_item ();
-        var ellipse = new Goo.CanvasEllipse (null, event.x, event.y, 10, 10,
-            "line-width", 5.0,
-            "stroke-color", "#9bdb4d",
-            "fill-color", "#68b723");
+        var ellipse = new Goo.CanvasEllipse (null, event.x, event.y, 1, 1,
+                                             "line-width", border_size,
+                                             "stroke-color", border_color,
+                                             "fill-color", fill_color);
 
         ellipse.set ("parent", root);
-        ellipse.set_transform(Cairo.Matrix.identity ());
+        ellipse.set_transform (Cairo.Matrix.identity ());
         var artboard = window.main_window.right_sidebar.layers_panel.artboard;
-        var layer = new Akira.Layouts.Partials.Layer (window, artboard, ellipse, "Circle", "shape-circle-symbolic", false);
+        var layer = new Akira.Layouts.Partials.Layer (window, artboard, ellipse,
+            "Circle", "shape-circle-symbolic", false);
         ellipse.set_data<Akira.Layouts.Partials.Layer?> ("layer", layer);
         artboard.container.add (layer);
         artboard.show_all ();
@@ -841,7 +850,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     public Goo.CanvasText add_text (Gdk.EventButton event) {
         var root = get_root_item ();
-        var text = new Goo.CanvasText (null, "Add text here", event.x, event.y, 200, Goo.CanvasAnchorType.NW, "font", "Open Sans 18");
+        var text = new Goo.CanvasText (null, "Add text here", event.x, event.y, 200,
+                                       Goo.CanvasAnchorType.NW, "font", "Open Sans 18");
         text.set ("parent", root);
         text.set ("height", 25f);
         text.set_transform(Cairo.Matrix.identity ());
@@ -853,4 +863,9 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         return text;
     }
 
+    public void udpate_default_values () {
+        border_size = settings.set_border ? settings.border_size : 0.0;
+        border_color = settings.set_border ? settings.border_color: "";
+        fill_color = settings.fill_color;
+    }
 }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -152,7 +152,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
 
         if (clicked_item != null) {
-
             var clicked_id = get_grabbed_id (clicked_item);
             holding = true;
 
@@ -167,7 +166,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             } else { // nob was clicked
                 holding_id = clicked_id;
             }
-
         } else {
             remove_select_effect ();
             focus ();
@@ -216,7 +214,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     public override bool key_press_event (Gdk.EventKey event) {
         switch (Gdk.keyval_to_upper (event.keyval)) {
-            case Gdk.Key.C:
+            case Gdk.Key.E:
                 edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
                 insert_type = Akira.Lib.Canvas.InsertType.ELLIPSE;
                 return true;
@@ -481,9 +479,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         var real_y = y - stroke;
 
         select_effect = new Goo.CanvasRect (null, real_x, real_y, 0, 0,
-                                   "line-width", line_width,
-                                   "stroke-color", "#666", null
-                                   );
+                                            "line-width", line_width,
+                                            "stroke-color", "#666", null);
 
         update_select_effect (target);
 
@@ -494,12 +491,11 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         for (int i = 0; i < 9; i++) {
             var radius = i == 8 ? nob_size : 0;
             nobs[i] = new Goo.CanvasRect (null, 0, 0, nob_size, nob_size,
-                "line-width", line_width,
-                "radius-x", radius,
-                "radius-y", radius,
-                "stroke-color", "#41c9fd",
-                "fill-color", "#fff", null
-            );
+                                          "line-width", line_width,
+                                          "radius-x", radius,
+                                          "radius-y", radius,
+                                          "stroke-color", "#41c9fd",
+                                          "fill-color", "#fff", null);
             nobs[i].set ("parent", get_root_item ());
         }
 
@@ -557,7 +553,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     private void add_hover_effect (Goo.CanvasItem? target) {
-        if (target == null || hover_effect != null || target == selected_item || target == select_effect) {
+        if (target == null || hover_effect != null || target == selected_item
+            || target == select_effect || edit_mode == EditMode.MODE_INSERT) {
             return;
         }
 
@@ -579,9 +576,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         var real_height = height + stroke * 2;
 
         hover_effect = new Goo.CanvasRect (null, real_x, real_y, real_width, real_height,
-                                   "line-width", line_width,
-                                   "stroke-color", "#41c9fd", null
-                                   );
+                                           "line-width", line_width,
+                                           "stroke-color", "#41c9fd", null);
         var transform = Cairo.Matrix.identity ();
         item.get_transform (out transform);
         hover_effect.set_transform (transform);

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -29,6 +29,7 @@ public class Akira.Services.Settings : Granite.Services.Settings {
     public bool dark_theme { get; set; }
     public bool show_label { get; set; }
     public bool use_symbolic { get; set; }
+    public bool set_border { get; set; }
     public bool open_quick { get; set; }
 
     public Settings () {

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -29,7 +29,10 @@ public class Akira.Services.Settings : Granite.Services.Settings {
     public bool dark_theme { get; set; }
     public bool show_label { get; set; }
     public bool use_symbolic { get; set; }
+    public string fill_color { get; set; }
     public bool set_border { get; set; }
+    public int border_size { get; set; }
+    public string border_color { get; set; }
     public bool open_quick { get; set; }
 
     public Settings () {

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -28,7 +28,7 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
     private Gtk.Switch border_switch;
     private Gtk.ColorButton fill_color;
     private Gtk.ColorButton border_color;
-    private int border;
+    private Gtk.SpinButton border_size;
 
     enum Column {
         ICONTYPE
@@ -121,7 +121,11 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
         grid.row_spacing = 6;
         grid.column_spacing = 12;
         grid.column_homogeneous = true;
-        border = 1;
+
+        var fillRGBA = Gdk.RGBA ();
+        fillRGBA.parse (settings.fill_color);
+        var borderRGBA = Gdk.RGBA ();
+        borderRGBA.parse (settings.border_color);
 
         grid.attach (new SettingsHeader (_("Default Colors")), 0, 0, 2, 1);
 
@@ -131,23 +135,38 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
         grid.attach (description, 0, 1, 2, 1);
 
         grid.attach (new SettingsLabel (_("Fill Color:")), 0, 2, 1, 1);
-        fill_color = new Gtk.ColorButton ();
+        fill_color = new Gtk.ColorButton.with_rgba (fillRGBA);
         fill_color.halign = Gtk.Align.START;
         grid.attach (fill_color, 1, 2, 1, 1);
+
+        fill_color.color_set.connect (() => {
+            settings.fill_color = fill_color.get_rgba ().to_string ();
+        });
 
         grid.attach (new SettingsLabel (_("Enable Border Style:")), 0, 3, 1, 1);
         border_switch = new SettingsSwitch ("set-border");
         grid.attach (border_switch, 1, 3, 1, 1);
 
+        border_switch.notify["active"].connect (() => {
+			border_color.sensitive = border_switch.get_active ();
+			border_size.sensitive = border_switch.get_active ();
+		});
+
         grid.attach (new SettingsLabel (_("Border Color:")), 0, 4, 1, 1);
-        border_color = new Gtk.ColorButton ();
+        border_color = new Gtk.ColorButton.with_rgba (borderRGBA);
         border_color.halign = Gtk.Align.START;
         grid.attach (border_color, 1, 4, 1, 1);
 
+        border_color.color_set.connect (() => {
+            settings.border_color = border_color.get_rgba ().to_string ();
+        });
+
         grid.attach (new SettingsLabel (_("Border Width:")), 0, 5, 1, 1);
-        var border_width = new Gtk.SpinButton.with_range (1, 9999, 1);
-        border_width.halign = Gtk.Align.START;
-        grid.attach (border_width, 1, 5, 1, 1);
+        border_size = new Gtk.SpinButton.with_range (1, 9999, 1);
+        border_size.halign = Gtk.Align.START;
+        grid.attach (border_size, 1, 5, 1, 1);
+
+        settings.schema.bind ("border-size", border_size, "value", SettingsBindFlags.DEFAULT);
 
         return grid;
     }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implements a new section in the Settings Dialog to allow users to control  the default color settings for all the shapes.
It's a global settings for all the shapes, which is really important since it allows users to set up the application with the preferred default values, mostly used for wire-framing purposes.

## Steps to Test
* Create shapes with <kbd>R</kbd> and <kbd>E</kbd>
* Open settings with <kbd>CTRL</kbd> + <kbd>,</kbd>
* In the `Shapes` section, edit the available settings.
* Add new shapes and see them respecting the new default values.

## Screenshots 
![Screenshot from 2019-10-06 23-02-31](https://user-images.githubusercontent.com/2527103/66288287-73a90400-e88d-11e9-93f7-5607f2c5708a.png)

![Screen record from 2019-10-06 23 09 49](https://user-images.githubusercontent.com/2527103/66288620-b8816a80-e88e-11e9-8a57-439cc7f0460e.gif)

## Fixes
I also update the shortcut for the Ellipse shape to be an E, since it reflects the name of the object and the accelerator specified in the popover menu.
