### PR TITLE
Receive scroll events on canvas

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -133,6 +133,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         events |= Gdk.EventMask.BUTTON_PRESS_MASK;
         events |= Gdk.EventMask.BUTTON_RELEASE_MASK;
         events |= Gdk.EventMask.POINTER_MOTION_MASK;
+        events |= Gdk.EventMask.SCROLL_MASK;
+        events |= Gdk.EventMask.SMOOTH_SCROLL_MASK;
+        events |= Gdk.EventMask.TOUCHPAD_GESTURE_MASK;
+        events |= Gdk.EventMask.TOUCH_MASK;
         get_bounds (out bounds_x, out bounds_y, out bounds_w, out bounds_h);
     }
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Is expected that two fingers gesture on a touchpad scroll the canvas. This PR just enable to receive events. `Gdk.EventMask.SMOOTH_SCROLL_MASK` seems to do the trick, but only horizontal scroll is being executed.

Maybe is a first thing that needs upstream patches. 

## Steps to Test
Build and try to scroll using two finger gestures. Only horizontal works.

## Screenshots 

## Known Issues / Things To Do
- [ ] React to vertical scroll

## This PR fixes/implements the following **bugs/features**:
