### PR TITLE
Connect z-order buttons in HeaderBar

### DIFF
--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -77,9 +77,21 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         ungroup = new Akira.Partials.HeaderBarButton ("object-ungroup", _("Ungroup"), {"<Ctrl><Shift>g"});
 
         move_up = new Akira.Partials.HeaderBarButton ("selection-raise", _("Up"), {"<Ctrl>Up"});
+        move_up.button.clicked.connect (() => {
+            window.main_window.main_canvas.canvas.change_z_selected(true, false);
+        });
         move_down = new Akira.Partials.HeaderBarButton ("selection-lower", _("Down"), {"<Ctrl>Down"});
+        move_down.button.clicked.connect (() => {
+            window.main_window.main_canvas.canvas.change_z_selected(false, false);
+        });
         move_top = new Akira.Partials.HeaderBarButton ("selection-top", _("Top"), {"<Ctrl><Shift>Up"});
+        move_top.button.clicked.connect (() => {
+            window.main_window.main_canvas.canvas.change_z_selected(true, true);
+        });
         move_bottom = new Akira.Partials.HeaderBarButton ("selection-bottom", _("Bottom"), {"<Ctrl><Shift>Down"});
+        move_bottom.button.clicked.connect (() => {
+            window.main_window.main_canvas.canvas.change_z_selected(false, true);
+        });
 
         preferences = new Akira.Partials.HeaderBarButton ("open-menu", _("Settings"), {"<Ctrl>comma"});
         preferences.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX + Akira.Services.ActionManager.ACTION_PREFERENCES;

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -189,6 +189,31 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         grab_focus (get_root_item ());
     }
 
+    public void change_z_selected (bool raise, bool total) {
+        if (selected_item == null)
+            return;
+
+        var root_item = get_root_item ();
+        var pos_selected = root_item.find_child (selected_item);
+        if (pos_selected != -1) {
+            int target_item_pos;
+            if (total) {
+                target_item_pos = raise ? (root_item.get_n_children () - 1): 0;
+            } else {
+                target_item_pos = pos_selected + (raise ? 1 : -1);
+            }
+            var target_item = root_item.get_child (target_item_pos);
+            if (target_item != null) {
+                if (raise) {
+                    selected_item.raise (target_item);
+                } else {
+                    selected_item.lower (target_item);
+                }
+                update_decorations (selected_item);
+            }
+        }
+    }
+
     public Goo.CanvasItem? insert_object (Gdk.EventButton event) {
         udpate_default_values ();
 
@@ -694,19 +719,21 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         } else {
           nobs[Nob.TOP_LEFT].translate (x - nob_size - stroke, y - nob_size - stroke);
         }
+        nobs[Nob.TOP_LEFT].raise (item);
 
         if (print_middle_width_nobs) {
           // TOP CENTER nob
           nobs[Nob.TOP_CENTER].set_transform (transform);
-        if (print_middle_height_nobs) {
-          nobs[Nob.TOP_CENTER].translate (x + (width / 2) - nob_offset, y - (nob_offset + stroke));
-        } else {
-          nobs[Nob.TOP_CENTER].translate (x + (width / 2) - nob_offset, y - (nob_size + stroke));
-        }
+          if (print_middle_height_nobs) {
+            nobs[Nob.TOP_CENTER].translate (x + (width / 2) - nob_offset, y - (nob_offset + stroke));
+          } else {
+            nobs[Nob.TOP_CENTER].translate (x + (width / 2) - nob_offset, y - (nob_size + stroke));
+          }
           nobs[Nob.TOP_CENTER].set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
         } else {
           nobs[Nob.TOP_CENTER].set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
         }
+        nobs[Nob.TOP_CENTER].raise (item);
 
         // TOP RIGHT nob
         nobs[Nob.TOP_RIGHT].set_transform (transform);
@@ -715,6 +742,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         } else {
           nobs[Nob.TOP_RIGHT].translate (x + width + stroke, y - (nob_size + stroke));
         }
+        nobs[Nob.TOP_RIGHT].raise (item);
 
         if (print_middle_height_nobs) {
           // RIGHT CENTER nob
@@ -728,6 +756,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         } else {
           nobs[Nob.RIGHT_CENTER].set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
         }
+        nobs[Nob.RIGHT_CENTER].raise (item);
 
         // BOTTOM RIGHT nob
         nobs[Nob.BOTTOM_RIGHT].set_transform (transform);
@@ -736,6 +765,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         } else {
           nobs[Nob.BOTTOM_RIGHT].translate (x + width + stroke, y + height + stroke);
         }
+        nobs[Nob.BOTTOM_RIGHT].raise (item);
 
 
         if (print_middle_width_nobs) {
@@ -750,6 +780,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         } else {
           nobs[Nob.BOTTOM_CENTER].set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
         }
+        nobs[Nob.BOTTOM_CENTER].raise (item);
 
         // BOTTOM LEFT nob
         nobs[Nob.BOTTOM_LEFT].set_transform (transform);
@@ -758,6 +789,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         } else {
           nobs[Nob.BOTTOM_LEFT].translate (x - (nob_size + stroke), y + height + stroke);
         }
+        nobs[Nob.BOTTOM_LEFT].raise (item);
 
         if (print_middle_height_nobs) {
           // LEFT CENTER nob
@@ -771,6 +803,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         } else {
           nobs[Nob.LEFT_CENTER].set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
         }
+        nobs[Nob.LEFT_CENTER].raise (item);
 
         // ROTATE nob
         double distance = 40;
@@ -780,6 +813,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         nobs[Nob.ROTATE].set_transform (transform);
         nobs[Nob.ROTATE].translate (x + (width / 2) - nob_offset, y - nob_offset - distance);
+        nobs[Nob.ROTATE].raise (item);
     }
 
     private void set_cursor (Gdk.CursorType cursor_type) {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -39,6 +39,10 @@ public class Akira.Services.ActionManager : Object {
     public const string ACTION_ZOOM_IN = "action_zoom_in";
     public const string ACTION_ZOOM_OUT = "action_zoom_out";
     public const string ACTION_ZOOM_RESET = "action_zoom_reset";
+    public const string ACTION_MOVE_UP = "action_move_up";
+    public const string ACTION_MOVE_DOWN = "action_move_down";
+    public const string ACTION_MOVE_TOP = "action_move_top";
+    public const string ACTION_MOVE_BOTTOM = "action_move_bottom";
     public const string ACTION_RECT_TOOL = "action_rect_tool";
     public const string ACTION_ELLIPSE_TOOL = "action_ellipse_tool";
     public const string ACTION_TEXT_TOOL = "action_text_tool";
@@ -60,6 +64,10 @@ public class Akira.Services.ActionManager : Object {
         { ACTION_QUIT, action_quit },
         { ACTION_ZOOM_IN, action_zoom_in },
         { ACTION_ZOOM_OUT, action_zoom_out },
+        { ACTION_MOVE_UP, action_move_up },
+        { ACTION_MOVE_DOWN, action_move_down },
+        { ACTION_MOVE_TOP, action_move_top },
+        { ACTION_MOVE_BOTTOM, action_move_bottom },
         { ACTION_ZOOM_RESET, action_zoom_reset },
         { ACTION_RECT_TOOL, action_rect_tool },
         { ACTION_ELLIPSE_TOOL, action_ellipse_tool },
@@ -89,6 +97,10 @@ public class Akira.Services.ActionManager : Object {
         action_accelerators.set (ACTION_ZOOM_IN, "<Control>plus");
         action_accelerators.set (ACTION_ZOOM_OUT, "<Control>minus");
         action_accelerators.set (ACTION_ZOOM_RESET, "<Control>0");
+        action_accelerators.set (ACTION_MOVE_UP, "<Control>Up");
+        action_accelerators.set (ACTION_MOVE_DOWN, "<Control>Down");
+        action_accelerators.set (ACTION_MOVE_TOP, "<Control><Shift>Up");
+        action_accelerators.set (ACTION_MOVE_BOTTOM, "<Control><Shift>Down");
     }
 
     construct {
@@ -156,6 +168,22 @@ public class Akira.Services.ActionManager : Object {
 
     private void action_zoom_reset () {
         window.headerbar.zoom.zoom_reset ();
+    }
+
+    private void action_move_up () {
+        window.main_window.main_canvas.canvas.change_z_selected(true, false);
+    }
+
+    private void action_move_down () {
+        window.main_window.main_canvas.canvas.change_z_selected(false, false);
+    }
+
+    private void action_move_top () {
+        window.main_window.main_canvas.canvas.change_z_selected(true, true);
+    }
+
+    private void action_move_bottom () {
+        window.main_window.main_canvas.canvas.change_z_selected(false, true);
     }
 
     private void action_rect_tool () {


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Allow a basic reorder of items from headerbar

## Steps to Test
Add some items and try to reorder

## Screenshots 
![z-order-headerbar](https://user-images.githubusercontent.com/220968/66699388-be3fdb80-ece6-11e9-91f6-9b7727e7e985.gif)

## Known Issues / Things To Do
- [x] items has an internal order, if to contiguous items are not touching each other put one upon/below other has no effect. We need to detect which item is upon/below selected one to raise/lower on them not on next item
- [x] Special items (like hover/select effect or nobs) are taken into account to raise/lower. That's an undesired effect. This match with a general need to ignore this items in any operation (like save) Add a property `ignored` should be enough.
- [x] link shortcuts

## This PR fixes/implements the following **bugs/features**:
Relates with #212 allowing to order items
