### PR TITLE
Initial work on Canvas split: Nobs

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -105,7 +105,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     private double delta_y;
     private double hover_x;
     private double hover_y;
-    private double nob_size;
     private double current_scale;
     private int holding_id = Nob.NONE;
     private double bounds_x;
@@ -548,11 +547,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         select_effect.set ("parent", get_root_item ());
 
-        nob_size = 10 / current_scale;
-
         for (int i = 0; i < 9; i++) {
             nobs[i] = new Selection.Nob (get_root_item (), current_scale, i);
-            //  nobs[i].update_position (target, select_effect);
         }
 
         update_nob_position (target);
@@ -696,127 +692,15 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
     }
 
-    // Updates all the nub's position arround the selected item, except for the grabbed nub
-    private void update_nob_position (Goo.CanvasItem target) {
-        if (select_effect == null) {
+    // Updates all the nobs' position arround the selected item, except for the grabbed nob.
+    private void update_nob_position (Goo.CanvasItem? target) {
+        if (target == null || select_effect == null) {
             return;
         }
 
-        var item = (target as Goo.CanvasItemSimple);
-
-        var stroke = (item.line_width / 2);
-        double x, y, width, height;
-        target.get ("x", out x, "y", out y, "width", out width, "height", out height);
-
-        bool print_middle_width_nobs = width > nob_size * 3;
-        bool print_middle_height_nobs = height > nob_size * 3;
-
-        var nob_offset = (nob_size / 2);
-
-        var transform = Cairo.Matrix.identity ();
-        item.get_transform (out transform);
-
-        // TOP LEFT nob
-        nobs[Nob.TOP_LEFT].set_transform (transform);
-        if (print_middle_width_nobs && print_middle_height_nobs) {
-          nobs[Nob.TOP_LEFT].translate (x - (nob_offset + stroke), y - (nob_offset + stroke));
-        } else {
-          nobs[Nob.TOP_LEFT].translate (x - nob_size - stroke, y - nob_size - stroke);
+        foreach (var nob in nobs) {
+            nob.update_position (target, select_effect);
         }
-        nobs[Nob.TOP_LEFT].raise (item);
-
-        if (print_middle_width_nobs) {
-          // TOP CENTER nob
-          nobs[Nob.TOP_CENTER].set_transform (transform);
-          if (print_middle_height_nobs) {
-            nobs[Nob.TOP_CENTER].translate (x + (width / 2) - nob_offset, y - (nob_offset + stroke));
-          } else {
-            nobs[Nob.TOP_CENTER].translate (x + (width / 2) - nob_offset, y - (nob_size + stroke));
-          }
-          nobs[Nob.TOP_CENTER].set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
-        } else {
-          nobs[Nob.TOP_CENTER].set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
-        }
-        nobs[Nob.TOP_CENTER].raise (item);
-
-        // TOP RIGHT nob
-        nobs[Nob.TOP_RIGHT].set_transform (transform);
-        if (print_middle_width_nobs && print_middle_height_nobs) {
-          nobs[Nob.TOP_RIGHT].translate (x + width - (nob_offset - stroke), y - (nob_offset + stroke));
-        } else {
-          nobs[Nob.TOP_RIGHT].translate (x + width + stroke, y - (nob_size + stroke));
-        }
-        nobs[Nob.TOP_RIGHT].raise (item);
-
-        if (print_middle_height_nobs) {
-          // RIGHT CENTER nob
-          nobs[Nob.RIGHT_CENTER].set_transform (transform);
-          if (print_middle_width_nobs) {
-            nobs[Nob.RIGHT_CENTER].translate (x + width - (nob_offset - stroke), y + (height / 2) - nob_offset);
-          } else {
-            nobs[Nob.RIGHT_CENTER].translate (x + width + stroke, y + (height / 2) - nob_offset);
-          }
-          nobs[Nob.RIGHT_CENTER].set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
-        } else {
-          nobs[Nob.RIGHT_CENTER].set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
-        }
-        nobs[Nob.RIGHT_CENTER].raise (item);
-
-        // BOTTOM RIGHT nob
-        nobs[Nob.BOTTOM_RIGHT].set_transform (transform);
-        if (print_middle_width_nobs && print_middle_height_nobs) {
-          nobs[Nob.BOTTOM_RIGHT].translate (x + width - (nob_offset - stroke), y + height - (nob_offset - stroke));
-        } else {
-          nobs[Nob.BOTTOM_RIGHT].translate (x + width + stroke, y + height + stroke);
-        }
-        nobs[Nob.BOTTOM_RIGHT].raise (item);
-
-        if (print_middle_width_nobs) {
-          // BOTTOM CENTER nob
-          nobs[Nob.BOTTOM_CENTER].set_transform (transform);
-          if (print_middle_height_nobs) {
-            nobs[Nob.BOTTOM_CENTER].translate (x + (width / 2) - nob_offset, y + height - (nob_offset - stroke));
-          } else {
-            nobs[Nob.BOTTOM_CENTER].translate (x + (width / 2) - nob_offset, y + height + stroke);
-          }
-          nobs[Nob.BOTTOM_CENTER].set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
-        } else {
-          nobs[Nob.BOTTOM_CENTER].set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
-        }
-        nobs[Nob.BOTTOM_CENTER].raise (item);
-
-        // BOTTOM LEFT nob
-        nobs[Nob.BOTTOM_LEFT].set_transform (transform);
-        if (print_middle_width_nobs && print_middle_height_nobs) {
-          nobs[Nob.BOTTOM_LEFT].translate (x - (nob_offset + stroke), y + height - (nob_offset - stroke));
-        } else {
-          nobs[Nob.BOTTOM_LEFT].translate (x - (nob_size + stroke), y + height + stroke);
-        }
-        nobs[Nob.BOTTOM_LEFT].raise (item);
-
-        if (print_middle_height_nobs) {
-          // LEFT CENTER nob
-          nobs[Nob.LEFT_CENTER].set_transform (transform);
-          if (print_middle_width_nobs) {
-            nobs[Nob.LEFT_CENTER].translate (x - (nob_offset + stroke), y + (height / 2) - nob_offset);
-          } else {
-            nobs[Nob.LEFT_CENTER].translate (x - (nob_size + stroke), y + (height / 2) - nob_offset);
-          }
-          nobs[Nob.LEFT_CENTER].set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
-        } else {
-          nobs[Nob.LEFT_CENTER].set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
-        }
-        nobs[Nob.LEFT_CENTER].raise (item);
-
-        // ROTATE nob
-        double distance = 40;
-        if (current_scale < 1) {
-            distance = 40 * (2 * current_scale - 1);
-        }
-
-        nobs[Nob.ROTATE].set_transform (transform);
-        nobs[Nob.ROTATE].translate (x + (width / 2) - nob_offset, y - nob_offset - distance);
-        nobs[Nob.ROTATE].raise (item);
     }
 
     private void set_cursor (Gdk.CursorType cursor_type) {

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -552,6 +552,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         for (int i = 0; i < 9; i++) {
             nobs[i] = new Selection.Nob (get_root_item (), current_scale, i);
+            //  nobs[i].update_position (target, select_effect);
         }
 
         update_nob_position (target);

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -93,7 +93,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         TEXT
     }
 
-    private Goo.CanvasItemSimple[] nobs = new Goo.CanvasItemSimple[9];
+    private Selection.Nob[] nobs = new Selection.Nob[9];
 
     private Goo.CanvasRect? hover_effect;
 
@@ -615,7 +615,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             return;
         }
 
-        if ((target as Goo.CanvasItemSimple) in nobs) {
+        if ((target as Selection.Nob) in nobs) {
             set_cursor_for_nob (get_grabbed_id (target));
             return;
         }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -612,8 +612,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
 
         if ((target as Selection.Nob) in nobs) {
-            var nob = (target as Selection.Nob);
-            nob.set_cursor_for_nob ();
+            (target as Selection.Nob).set_cursor ();
             return;
         }
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -548,7 +548,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         select_effect.set ("parent", get_root_item ());
 
         for (int i = 0; i < 9; i++) {
-            nobs[i] = new Selection.Nob (get_root_item (), current_scale, i);
+            nobs[i] = new Selection.Nob (this, get_root_item (), current_scale, i);
         }
 
         update_nob_position (target);
@@ -612,7 +612,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
 
         if ((target as Selection.Nob) in nobs) {
-            set_cursor_for_nob (get_grabbed_id (target));
+            var nob = (target as Selection.Nob);
+            nob.set_cursor_for_nob ();
             return;
         }
 
@@ -650,46 +651,11 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     private int get_grabbed_id (Goo.CanvasItem? target) {
-        for (int i = 0; i < 9; i++) {
-            if (target == nobs[i]) return i;
+        if ((target as Selection.Nob) in nobs) {
+            return (target as Selection.Nob).nob_type;
         }
 
         return Nob.NONE;
-    }
-
-    private void set_cursor_for_nob (int grabbed_id) {
-        switch (grabbed_id) {
-            case Nob.NONE:
-                set_cursor_by_edit_mode ();
-                break;
-            case Nob.TOP_LEFT:
-                set_cursor (Gdk.CursorType.TOP_LEFT_CORNER);
-                break;
-            case Nob.TOP_CENTER:
-                set_cursor (Gdk.CursorType.TOP_SIDE);
-                break;
-            case Nob.TOP_RIGHT:
-                set_cursor (Gdk.CursorType.TOP_RIGHT_CORNER);
-                break;
-            case Nob.RIGHT_CENTER:
-                set_cursor (Gdk.CursorType.RIGHT_SIDE);
-                break;
-            case Nob.BOTTOM_RIGHT:
-                set_cursor (Gdk.CursorType.BOTTOM_RIGHT_CORNER);
-                break;
-            case Nob.BOTTOM_CENTER:
-                set_cursor (Gdk.CursorType.BOTTOM_SIDE);
-                break;
-            case Nob.BOTTOM_LEFT:
-                set_cursor (Gdk.CursorType.BOTTOM_LEFT_CORNER);
-                break;
-            case Nob.LEFT_CENTER:
-                set_cursor (Gdk.CursorType.LEFT_SIDE);
-                break;
-            case Nob.ROTATE:
-                set_cursor (Gdk.CursorType.ICON);
-                break;
-        }
     }
 
     // Updates all the nobs' position arround the selected item, except for the grabbed nob.
@@ -703,7 +669,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
     }
 
-    private void set_cursor (Gdk.CursorType cursor_type) {
+    public void set_cursor (Gdk.CursorType cursor_type) {
         var cursor = new Gdk.Cursor.for_display (Gdk.Display.get_default (), cursor_type);
         get_window ().set_cursor (cursor);
     }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -552,13 +552,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         for (int i = 0; i < 9; i++) {
             nobs[i] = new Selection.Nob (get_root_item (), current_scale, i);
-            //  nobs[i] = new Goo.CanvasRect (null, 0, 0, nob_size, nob_size,
-            //                                "line-width", line_width,
-            //                                "radius-x", radius,
-            //                                "radius-y", radius,
-            //                                "stroke-color", "#41c9fd",
-            //                                "fill-color", "#fff", null);
-            //  nobs[i].set ("parent", get_root_item ());
         }
 
         update_nob_position (target);

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -552,13 +552,14 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         for (int i = 0; i < 9; i++) {
             var radius = i == 8 ? nob_size : 0;
-            nobs[i] = new Goo.CanvasRect (null, 0, 0, nob_size, nob_size,
-                                          "line-width", line_width,
-                                          "radius-x", radius,
-                                          "radius-y", radius,
-                                          "stroke-color", "#41c9fd",
-                                          "fill-color", "#fff", null);
-            nobs[i].set ("parent", get_root_item ());
+            nobs[i] = new Selection.Nob (get_root_item (), radius, current_scale, i);
+            //  nobs[i] = new Goo.CanvasRect (null, 0, 0, nob_size, nob_size,
+            //                                "line-width", line_width,
+            //                                "radius-x", radius,
+            //                                "radius-y", radius,
+            //                                "stroke-color", "#41c9fd",
+            //                                "fill-color", "#fff", null);
+            //  nobs[i].set ("parent", get_root_item ());
         }
 
         update_nob_position (target);

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -551,8 +551,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         nob_size = 10 / current_scale;
 
         for (int i = 0; i < 9; i++) {
-            var radius = i == 8 ? nob_size : 0;
-            nobs[i] = new Selection.Nob (get_root_item (), radius, current_scale, i);
+            nobs[i] = new Selection.Nob (get_root_item (), current_scale, i);
             //  nobs[i] = new Goo.CanvasRect (null, 0, 0, nob_size, nob_size,
             //                                "line-width", line_width,
             //                                "radius-x", radius,

--- a/src/Lib/Selection/Nob.vala
+++ b/src/Lib/Selection/Nob.vala
@@ -20,6 +20,7 @@
 */
 public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
     enum Type {
+        NONE=-1,
         TOP_LEFT,
         TOP_CENTER,
         TOP_RIGHT,
@@ -31,13 +32,16 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
         ROTATE
     }
 
-    public string color_fill { get; set; default = "#fff"; }
-    public string color_stroke { get; set; default = "#41c9fd"; }
-    public double current_scale { get; set; default = 1.0; }
-    public int nob_type { get; set; }
-    public double nob_size { get; set; }
+    private new Akira.Lib.Canvas canvas;
 
-    public Nob (Goo.CanvasItem? root, double scale, int i) {
+    private string color_fill { get; set; default = "#fff"; }
+    private string color_stroke { get; set; default = "#41c9fd"; }
+    private double current_scale { get; set; default = 1.0; }
+    public int nob_type;
+    private double nob_size;
+
+    public Nob (Akira.Lib.Canvas _canvas, Goo.CanvasItem? root, double scale, int i) {
+        canvas = _canvas;
         nob_type = i;
         current_scale = scale;
         can_focus = false;
@@ -193,5 +197,40 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
 
     private void updated_visibility (Goo.CanvasItemVisibility visibility) {
         set ("visibility", visibility);
+    }
+
+    public void set_cursor_for_nob () {
+        switch (nob_type) {
+            case Type.NONE:
+                canvas.set_cursor_by_edit_mode ();
+                break;
+            case Type.TOP_LEFT:
+                canvas.set_cursor (Gdk.CursorType.TOP_LEFT_CORNER);
+                break;
+            case Type.TOP_CENTER:
+                canvas.set_cursor (Gdk.CursorType.TOP_SIDE);
+                break;
+            case Type.TOP_RIGHT:
+                canvas.set_cursor (Gdk.CursorType.TOP_RIGHT_CORNER);
+                break;
+            case Type.RIGHT_CENTER:
+                canvas.set_cursor (Gdk.CursorType.RIGHT_SIDE);
+                break;
+            case Type.BOTTOM_RIGHT:
+                canvas.set_cursor (Gdk.CursorType.BOTTOM_RIGHT_CORNER);
+                break;
+            case Type.BOTTOM_CENTER:
+                canvas.set_cursor (Gdk.CursorType.BOTTOM_SIDE);
+                break;
+            case Type.BOTTOM_LEFT:
+                canvas.set_cursor (Gdk.CursorType.BOTTOM_LEFT_CORNER);
+                break;
+            case Type.LEFT_CENTER:
+                canvas.set_cursor (Gdk.CursorType.LEFT_SIDE);
+                break;
+            case Type.ROTATE:
+                canvas.set_cursor (Gdk.CursorType.ICON);
+                break;
+        }
     }
 }

--- a/src/Lib/Selection/Nob.vala
+++ b/src/Lib/Selection/Nob.vala
@@ -94,9 +94,9 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
                 } else {
                     translate (x + (width / 2) - nob_offset, y - (nob_size + stroke));
                 }
-                updated_visibility (Goo.CanvasItemVisibility.VISIBLE);
+                set_visibility (Goo.CanvasItemVisibility.VISIBLE);
             } else {
-                updated_visibility (Goo.CanvasItemVisibility.HIDDEN);
+                set_visibility (Goo.CanvasItemVisibility.HIDDEN);
             }
             raise (item);
         }
@@ -121,9 +121,9 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
                 } else {
                     translate (x + width + stroke, y + (height / 2) - nob_offset);
                 }
-                updated_visibility (Goo.CanvasItemVisibility.VISIBLE);
+                set_visibility (Goo.CanvasItemVisibility.VISIBLE);
             } else {
-                updated_visibility (Goo.CanvasItemVisibility.HIDDEN);
+                set_visibility (Goo.CanvasItemVisibility.HIDDEN);
             }
             raise (item);
         }
@@ -148,9 +148,9 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
                 } else {
                     translate (x + (width / 2) - nob_offset, y + height + stroke);
                 }
-                updated_visibility (Goo.CanvasItemVisibility.VISIBLE);
+                set_visibility (Goo.CanvasItemVisibility.VISIBLE);
             } else {
-                updated_visibility (Goo.CanvasItemVisibility.HIDDEN);
+                set_visibility (Goo.CanvasItemVisibility.HIDDEN);
             }
             raise (item);
         }
@@ -175,9 +175,9 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
                 } else {
                     translate (x - (nob_size + stroke), y + (height / 2) - nob_offset);
                 }
-                updated_visibility (Goo.CanvasItemVisibility.VISIBLE);
+                set_visibility (Goo.CanvasItemVisibility.VISIBLE);
             } else {
-                updated_visibility (Goo.CanvasItemVisibility.HIDDEN);
+                set_visibility (Goo.CanvasItemVisibility.HIDDEN);
             }
             raise (item);
         }
@@ -195,11 +195,11 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
         }
     }
 
-    private void updated_visibility (Goo.CanvasItemVisibility visibility) {
+    private void set_visibility (Goo.CanvasItemVisibility visibility) {
         set ("visibility", visibility);
     }
 
-    public void set_cursor_for_nob () {
+    public void set_cursor () {
         switch (nob_type) {
             case Type.NONE:
                 canvas.set_cursor_by_edit_mode ();

--- a/src/Lib/Selection/Nob.vala
+++ b/src/Lib/Selection/Nob.vala
@@ -37,7 +37,7 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
     public double current_scale { get; set; default = 1.0; }
     public int nob_type { get; set; }
 
-    public Nob (Goo.CanvasItem? root, double radius, double scale, int i) {
+    public Nob (Goo.CanvasItem? root, double scale, int i) {
         nob_type = i;
         current_scale = scale;
 
@@ -47,8 +47,8 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
         line_width = 1.0 / current_scale;
         fill_color = color_fill;
         stroke_color = color_stroke;
-        radius_x = radius;
-        radius_y = radius;
+        radius_x = i == 8 ? width : 0;
+        radius_y = i == 8 ? width : 0;
 
         set ("parent", root);
     }

--- a/src/Lib/Selection/Nob.vala
+++ b/src/Lib/Selection/Nob.vala
@@ -40,6 +40,7 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
     public Nob (Goo.CanvasItem? root, double scale, int i) {
         nob_type = i;
         current_scale = scale;
+        can_focus = false;
 
         parent = null;
         height = 10 / current_scale;
@@ -92,9 +93,9 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
                 } else {
                     translate (x + (width / 2) - nob_offset, y - (width + stroke));
                 }
-                set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+                updated_visibility (Goo.CanvasItemVisibility.VISIBLE);
             } else {
-                set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+                updated_visibility (Goo.CanvasItemVisibility.HIDDEN);
             }
             raise (item);
         }
@@ -119,9 +120,9 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
                 } else {
                     translate (x + width + stroke, y + (height / 2) - nob_offset);
                 }
-                set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+                updated_visibility (Goo.CanvasItemVisibility.VISIBLE);
             } else {
-                set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+                updated_visibility (Goo.CanvasItemVisibility.HIDDEN);
             }
             raise (item);
         }
@@ -146,9 +147,9 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
                 } else {
                     translate (x + (width / 2) - nob_offset, y + height + stroke);
                 }
-                set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+                updated_visibility (Goo.CanvasItemVisibility.VISIBLE);
             } else {
-                set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+                updated_visibility (Goo.CanvasItemVisibility.HIDDEN);
             }
             raise (item);
         }
@@ -173,9 +174,9 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
                 } else {
                     translate (x - (width + stroke), y + (height / 2) - nob_offset);
                 }
-                set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+                updated_visibility (Goo.CanvasItemVisibility.VISIBLE);
             } else {
-                set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+                updated_visibility (Goo.CanvasItemVisibility.HIDDEN);
             }
             raise (item);
         }
@@ -191,5 +192,9 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
             translate (x + (width / 2) - nob_offset, y - nob_offset - distance);
             raise (item);
         }
+    }
+
+    private void updated_visibility (Goo.CanvasItemVisibility visibility) {
+        set ("visibility", visibility);
     }
 }

--- a/src/Lib/Selection/Nob.vala
+++ b/src/Lib/Selection/Nob.vala
@@ -20,7 +20,6 @@
 */
 public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
     enum Type {
-        NONE=-1,
         TOP_LEFT,
         TOP_CENTER,
         TOP_RIGHT,
@@ -36,6 +35,7 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
     public string color_stroke { get; set; default = "#41c9fd"; }
     public double current_scale { get; set; default = 1.0; }
     public int nob_type { get; set; }
+    public double nob_size { get; set; }
 
     public Nob (Goo.CanvasItem? root, double scale, int i) {
         nob_type = i;
@@ -45,6 +45,7 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
         parent = null;
         height = 10 / current_scale;
         width = 10 / current_scale;
+        nob_size = width;
         line_width = 1.0 / current_scale;
         fill_color = color_fill;
         stroke_color = color_stroke;
@@ -55,20 +56,16 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
     }
 
     public void update_position (Goo.CanvasItem? target, Goo.CanvasItem? select_effect) {
-        if (select_effect == null) {
-            return;
-        }
-
         var item = (target as Goo.CanvasItemSimple);
 
         var stroke = (item.line_width / 2);
         double x, y, width, height;
         target.get ("x", out x, "y", out y, "width", out width, "height", out height);
 
-        bool print_middle_width_nobs = width > width * 3;
-        bool print_middle_height_nobs = height > width * 3;
+        bool print_middle_width_nobs = width > nob_size * 3;
+        bool print_middle_height_nobs = height > nob_size * 3;
 
-        var nob_offset = (width / 2);
+        var nob_offset = (nob_size / 2);
 
         var transform = Cairo.Matrix.identity ();
         item.get_transform (out transform);
@@ -79,7 +76,7 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
             if (print_middle_width_nobs && print_middle_height_nobs) {
                 translate (x - (nob_offset + stroke), y - (nob_offset + stroke));
             } else {
-                translate (x - width - stroke, y - width - stroke);
+                translate (x - nob_size - stroke, y - nob_size - stroke);
             }
             raise (item);
         }
@@ -91,7 +88,7 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
                 if (print_middle_height_nobs) {
                     translate (x + (width / 2) - nob_offset, y - (nob_offset + stroke));
                 } else {
-                    translate (x + (width / 2) - nob_offset, y - (width + stroke));
+                    translate (x + (width / 2) - nob_offset, y - (nob_size + stroke));
                 }
                 updated_visibility (Goo.CanvasItemVisibility.VISIBLE);
             } else {
@@ -106,7 +103,7 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
             if (print_middle_width_nobs && print_middle_height_nobs) {
                 translate (x + width - (nob_offset - stroke), y - (nob_offset + stroke));
             } else {
-                translate (x + width + stroke, y - (width + stroke));
+                translate (x + width + stroke, y - (nob_size + stroke));
             }
             raise (item);
         }
@@ -160,7 +157,7 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
             if (print_middle_width_nobs && print_middle_height_nobs) {
                 translate (x - (nob_offset + stroke), y + height - (nob_offset - stroke));
             } else {
-                translate (x - (width + stroke), y + height + stroke);
+                translate (x - (nob_size + stroke), y + height + stroke);
             }
             raise (item);
         }
@@ -172,7 +169,7 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
                 if (print_middle_width_nobs) {
                     translate (x - (nob_offset + stroke), y + (height / 2) - nob_offset);
                 } else {
-                    translate (x - (width + stroke), y + (height / 2) - nob_offset);
+                    translate (x - (nob_size + stroke), y + (height / 2) - nob_offset);
                 }
                 updated_visibility (Goo.CanvasItemVisibility.VISIBLE);
             } else {

--- a/src/Lib/Selection/Nob.vala
+++ b/src/Lib/Selection/Nob.vala
@@ -18,42 +18,178 @@
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
-public class Akira.Lib.Selection.Nob : Goo.CanvasItemSimple, Goo.CanvasItem {
-    public double height { get; set; default = 10; }
-    public double radius_x { get; set; }
-    public double radius_y { get; set; }
-    public double width { get; set; default = 10; }
-    public double x { get; set; }
-    public double y { get; set; }
-
-    public string f_color { get; set; default = "#fff"; }
-    public string s_color { get; set; default = "#41c9fd"; }
-    public double s { get; set; default = 1.0; }
-
-    public double scale { get; set; default = 1.0; }
-
-    public Nob (Goo.CanvasItem? root) {
-        set_rectangle (root, 0, 0);
+public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
+    enum Type {
+        NONE=-1,
+        TOP_LEFT,
+        TOP_CENTER,
+        TOP_RIGHT,
+        RIGHT_CENTER,
+        BOTTOM_RIGHT,
+        BOTTOM_CENTER,
+        BOTTOM_LEFT,
+        LEFT_CENTER,
+        ROTATE
     }
 
-    public Nob.with_values (Goo.CanvasItem? root, double x, double y, double canvas_scale) {
-        Object (parent: root);
-        scale = canvas_scale;
-        set_rectangle (root, x, y);
+    public string color_fill { get; set; default = "#fff"; }
+    public string color_stroke { get; set; default = "#41c9fd"; }
+    public double current_scale { get; set; default = 1.0; }
+    public int nob_type { get; set; }
+
+    public Nob (Goo.CanvasItem? root, double radius, double scale, int i) {
+        nob_type = i;
+        current_scale = scale;
+
+        parent = null;
+        height = 10 / current_scale;
+        width = 10 / current_scale;
+        line_width = 1.0 / current_scale;
+        fill_color = color_fill;
+        stroke_color = color_stroke;
+        radius_x = radius;
+        radius_y = radius;
+
+        set ("parent", root);
     }
 
-    construct {
-        can_focus = false;
-    }
+    public void update_position (Goo.CanvasItem? target, Goo.CanvasItem? select_effect) {
+        if (select_effect == null) {
+            return;
+        }
 
-    public void set_rectangle (Goo.CanvasItem? root, double _x, double _y) {
-        parent = root;
-        height = height / scale;
-        width = width / scale;
-        x = _x - (width / 2);
-        y = _y - (height / 2);
-        line_width = s / scale;
-        fill_color = "#fff";
-        stroke_color = "#41c9fd";
+        var item = (target as Goo.CanvasItemSimple);
+
+        var stroke = (item.line_width / 2);
+        double x, y, width, height;
+        target.get ("x", out x, "y", out y, "width", out width, "height", out height);
+
+        bool print_middle_width_nobs = width > width * 3;
+        bool print_middle_height_nobs = height > width * 3;
+
+        var nob_offset = (width / 2);
+
+        var transform = Cairo.Matrix.identity ();
+        item.get_transform (out transform);
+
+        // TOP LEFT nob
+        if (nob_type == Type.TOP_LEFT) {
+            set_transform (transform);
+            if (print_middle_width_nobs && print_middle_height_nobs) {
+                translate (x - (nob_offset + stroke), y - (nob_offset + stroke));
+            } else {
+                translate (x - width - stroke, y - width - stroke);
+            }
+            raise (item);
+        }
+
+        // TOP CENTER nob
+        if (nob_type == Type.TOP_CENTER) {
+            if (print_middle_width_nobs) {
+                set_transform (transform);
+                if (print_middle_height_nobs) {
+                    translate (x + (width / 2) - nob_offset, y - (nob_offset + stroke));
+                } else {
+                    translate (x + (width / 2) - nob_offset, y - (width + stroke));
+                }
+                set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+            } else {
+                set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+            }
+            raise (item);
+        }
+
+        // TOP RIGHT nob
+        if (nob_type == Type.TOP_RIGHT) {
+            set_transform (transform);
+            if (print_middle_width_nobs && print_middle_height_nobs) {
+                translate (x + width - (nob_offset - stroke), y - (nob_offset + stroke));
+            } else {
+                translate (x + width + stroke, y - (width + stroke));
+            }
+            raise (item);
+        }
+
+        // RIGHT CENTER nob
+        if (nob_type == Type.RIGHT_CENTER) {
+            if (print_middle_height_nobs) {
+                set_transform (transform);
+                if (print_middle_width_nobs) {
+                    translate (x + width - (nob_offset - stroke), y + (height / 2) - nob_offset);
+                } else {
+                    translate (x + width + stroke, y + (height / 2) - nob_offset);
+                }
+                set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+            } else {
+                set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+            }
+            raise (item);
+        }
+
+        // BOTTOM RIGHT nob
+        if (nob_type == Type.BOTTOM_RIGHT) {
+            set_transform (transform);
+            if (print_middle_width_nobs && print_middle_height_nobs) {
+                translate (x + width - (nob_offset - stroke), y + height - (nob_offset - stroke));
+            } else {
+                translate (x + width + stroke, y + height + stroke);
+            }
+            raise (item);
+        }
+
+        // BOTTOM CENTER nob
+        if (nob_type == Type.BOTTOM_CENTER) {
+            if (print_middle_width_nobs) {
+                set_transform (transform);
+                if (print_middle_height_nobs) {
+                    translate (x + (width / 2) - nob_offset, y + height - (nob_offset - stroke));
+                } else {
+                    translate (x + (width / 2) - nob_offset, y + height + stroke);
+                }
+                set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+            } else {
+                set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+            }
+            raise (item);
+        }
+
+        // BOTTOM LEFT nob
+        if (nob_type == Type.BOTTOM_LEFT) {
+            set_transform (transform);
+            if (print_middle_width_nobs && print_middle_height_nobs) {
+                translate (x - (nob_offset + stroke), y + height - (nob_offset - stroke));
+            } else {
+                translate (x - (width + stroke), y + height + stroke);
+            }
+            raise (item);
+        }
+
+        // LEFT CENTER nob
+        if (nob_type == Type.LEFT_CENTER) {
+            if (print_middle_height_nobs) {
+                set_transform (transform);
+                if (print_middle_width_nobs) {
+                    translate (x - (nob_offset + stroke), y + (height / 2) - nob_offset);
+                } else {
+                    translate (x - (width + stroke), y + (height / 2) - nob_offset);
+                }
+                set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+            } else {
+                set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+            }
+            raise (item);
+        }
+
+        // ROTATE nob
+        if (nob_type == Type.ROTATE) {
+            double distance = 40;
+            if (current_scale < 1) {
+                distance = 40 * (2 * current_scale - 1);
+            }
+
+            set_transform (transform);
+            translate (x + (width / 2) - nob_offset, y - nob_offset - distance);
+            raise (item);
+        }
     }
 }


### PR DESCRIPTION
This is a Draft PR to kick-off the discussion on how to split the canvas in dedicated classes to simplify our life.

The idea here is to create a dedicated class to handle the `Nobs` and delegate the update of their position internally, based on the type.

It's possible to extend the `Goo.CanvasRect` pretty easily, and I was able to create the Nob with a simple line:
```
nobs[i] = new Selection.Nob (get_root_item (), current_scale, i);
```

Unfortunately, I'm not able to call the newly created `update_position()` method with this:
```
nobs[i].update_position (target, select_effect);
```
as I'm getting:
```
error: The name `update_position' does not exist in the context of `Goo.CanvasItemSimple'
```

Do you guys know if it's possible to implement a new method here?
@albfan @giacomoalbe 