### PR TITLE
Fixed Increments Rotation

### DIFF
--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -17,6 +17,7 @@
 * along with Akira.  If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+* Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
 */
 public class Akira.Layouts.MainCanvas : Gtk.Grid {
     public Gtk.ScrolledWindow main_scroll;

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -25,7 +25,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     private const int MIN_SIZE = 1;
     private const int MIN_POS = 10;
-    private const int ROTATION_FIXED_STEP = 15;
+    private const double ROTATION_FIXED_STEP = 15.0;
 
     /**
      * Signal triggered when item was clicked by the user
@@ -487,15 +487,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
                 radians = start_radians - radians;
 
-                double current_x, current_y, current_scale, current_rotation_double;
-                selected_item.get_simple_transform (out current_x, out current_y, out current_scale, out current_rotation_double);
+                double current_x, current_y, current_scale, current_rotation;
+                selected_item.get_simple_transform (out current_x, out current_y, out current_scale, out current_rotation);
 
-                var current_rotation = ((int) current_rotation_double);
                 var rotation = radians * (180 / Math.PI);
-
-                debug ("rotation: %f", rotation);
-                debug ("item rotation: %d", current_rotation);
-
 
                 if (ctrl_is_pressed) {
                     do_rotation = false;
@@ -514,9 +509,23 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                         // to the current rotation, which might lead to a situation in which you
                         // cannot "reset" item rotation to rounded values (0, 90, 180, ...) without
                         // manually resetting the rotation input field in the properties panel
-                        var rotation_amount = ROTATION_FIXED_STEP - (current_rotation % ROTATION_FIXED_STEP);
+                        var current_rotation_int = ((int) GLib.Math.round (current_rotation));
+
+                        var rotation_amount = ROTATION_FIXED_STEP;
+
+                        // Strange glitch: when current_rotation == 30.0, the fmod
+                        // function does not work properly.
+                        // 30.00000 % 15.00000 != 0 => rotation_amount becomes 0.
+                        // That's why here is used the int representation of current_rotation
+                        if (current_rotation_int % ROTATION_FIXED_STEP != 0) {
+                            rotation_amount -= GLib.Math.fmod (current_rotation, ROTATION_FIXED_STEP);
+                        }
 
                         rotation = rotation > 0 ? rotation_amount : -rotation_amount;
+
+                        //debug ("Current rotation: %f", current_rotation);
+                        //debug ("Current rotation int: %f", current_rotation_int);
+                        //debug ("Actual rotation: %f", rotation);
 
                         update_x = true;
                         update_y = true;
@@ -549,6 +558,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             temp_event_x = event_x;
             //  debug ("temp event x: %f", temp_event_x);
         }
+
         if (update_y) {
             temp_event_y = event_y;
             //  debug ("temp event y: %f", temp_event_y);

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -551,7 +551,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                     var new_rotation = selected_item.get_data<double?> ("rotation") + rotation;
 
                     // Cap new_rotation to the [0, 360[ range
-                    new_rotation = Math.fmod(new_rotation, 360);
+                    new_rotation = Math.fmod (new_rotation, 360);
 
                     selected_item.set_data<double?> ("rotation", new_rotation);
                     convert_to_item_space (selected_item, ref event_x, ref event_y);

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -25,6 +25,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     private const int MIN_SIZE = 1;
     private const int MIN_POS = 10;
+    private const int ROTATION_FIXED_STEP = 15;
 
     /**
      * Signal triggered when item was clicked by the user
@@ -97,6 +98,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     private Goo.CanvasRect? hover_effect;
 
+    private bool ctrl_is_pressed = false;
     private bool holding;
     private bool temp_event_converted;
     private double temp_event_x;
@@ -291,6 +293,22 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Gdk.Key.Delete:
                 delete_selected ();
                 return true;
+            case Gdk.Key.Control_L:
+            case Gdk.Key.Control_R:
+                ctrl_is_pressed = true;
+
+                return true;
+        }
+
+        return false;
+    }
+
+    public override bool key_release_event (Gdk.EventKey event) {
+        switch (Gdk.keyval_to_upper (event.keyval)) {
+            case Gdk.Key.Control_L:
+            case Gdk.Key.Control_R:
+                ctrl_is_pressed = false;
+                return true;
         }
 
         return false;
@@ -455,23 +473,64 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Nob.ROTATE:
                 var center_x = x + width / 2;
                 var center_y = y + height / 2;
+                var do_rotation = true;
 
                 //  debug ("center x: %f", center_x);
                 //  debug ("center y: %f", center_y);
 
                 var start_radians = GLib.Math.atan2 (center_y - temp_event_y, temp_event_x - center_x);
-                //  debug ("start_radians %f, atan2(%f - %f, %f - %f)", start_radians, center_y, temp_event_y, temp_event_x, center_x);
-                var radians = GLib.Math.atan2 (center_y - event_y, event_x - center_x);
-                //  debug ("radians %f, atan2(%f - %f, %f - %f)", radians, center_y, event_y, event_x, center_x);
-                radians = start_radians - radians;
-                double rotation = radians * (180 / Math.PI);
-                //  debug ("rotation: %f", rotation);
 
-                convert_from_item_space (selected_item, ref event_x, ref event_y);
-                selected_item.rotate (rotation, center_x, center_y);
-                rotation += selected_item.get_data<double?> ("rotation");
-                selected_item.set_data<double?> ("rotation", rotation);
-                convert_to_item_space (selected_item, ref event_x, ref event_y);
+                var radians = GLib.Math.atan2 (center_y - event_y, event_x - center_x);
+
+                // debug ("start_radians %f, atan2(%f - %f, %f - %f)", start_radians, center_y, temp_event_y, temp_event_x, center_x);
+                // debug ("radians %f, atan2(%f - %f, %f - %f)", radians, center_y , event_y, event_x, center_x);
+
+                radians = start_radians - radians;
+
+                double current_x, current_y, current_scale, current_rotation_double;
+                selected_item.get_simple_transform (out current_x, out current_y, out current_scale, out current_rotation_double);
+
+                var current_rotation = ((int) current_rotation_double);
+                var rotation = radians * (180 / Math.PI);
+
+                debug ("rotation: %f", rotation);
+                debug ("item rotation: %d", current_rotation);
+
+
+                if (ctrl_is_pressed) {
+                    do_rotation = false;
+
+                    // Don't update temp_event_x and temp_event_y
+                    // before reaching the ROTATION_FIXED_STEP threshold
+                    update_x = false;
+                    update_y = false;
+
+                    if (rotation.abs () > ROTATION_FIXED_STEP) {
+                        do_rotation = true;
+
+                        // The rotation amount needs to take into consideration
+                        // the current rotation in order to anchor the item to truly
+                        // "fixed" rotation step instead of simply adding ROTATION_FIXED_STEP
+                        // to the current rotation, which might lead to a situation in which you
+                        // cannot "reset" item rotation to rounded values (0, 90, 180, ...) without
+                        // manually resetting the rotation input field in the properties panel
+                        var rotation_amount = ROTATION_FIXED_STEP - (current_rotation % ROTATION_FIXED_STEP);
+
+                        rotation = rotation > 0 ? rotation_amount : -rotation_amount;
+
+                        update_x = true;
+                        update_y = true;
+                    }
+                }
+
+                if (do_rotation) {
+                    convert_from_item_space (selected_item, ref event_x, ref event_y);
+                    selected_item.rotate (rotation, center_x, center_y);
+                    var selected_item_rotation = selected_item.get_data<double?> ("rotation");
+                    selected_item.set_data<double?> ("rotation", selected_item_rotation + rotation);
+                    convert_to_item_space (selected_item, ref event_x, ref event_y);
+                }
+
                 break;
         }
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -18,6 +18,7 @@
 *
 * Authored by: Felipe Escoto <felescoto95@hotmail.com>
 * Authored by: Alberto Fanjul <albertofanjul@gmail.com>
+* Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
 */
 
 public class Akira.Lib.Canvas : Goo.Canvas {

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -550,6 +550,9 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
                     var new_rotation = selected_item.get_data<double?> ("rotation") + rotation;
 
+                    // Cap new_rotation to the [0, 360[ range
+                    new_rotation = Math.fmod(new_rotation, 360);
+
                     selected_item.set_data<double?> ("rotation", new_rotation);
                     convert_to_item_space (selected_item, ref event_x, ref event_y);
                 }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -543,6 +543,9 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 if (do_rotation) {
                     convert_from_item_space (selected_item, ref event_x, ref event_y);
 
+                    // Round rotation in order to avoid sub degree issue
+                    rotation = Math.round (rotation);
+
                     selected_item.rotate (rotation, center_x, center_y);
 
                     var new_rotation = selected_item.get_data<double?> ("rotation") + rotation;

--- a/src/Utils/Math.vala
+++ b/src/Utils/Math.vala
@@ -1,0 +1,32 @@
+/*
+* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+*
+* This file is part of Akira.
+*
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+*
+* Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+*/
+
+public class Akira.Utils.Math {
+    public static double roundDouble(double val, int precision = 2) {
+        int precisionPower = 1;
+
+        for (int i=0; i<precision; i++) {
+            precisionPower *= 10;
+        }
+
+        return GLib.Math.round (val * precisionPower) / precisionPower;
+    }
+}

--- a/src/Utils/Math.vala
+++ b/src/Utils/Math.vala
@@ -20,13 +20,13 @@
 */
 
 public class Akira.Utils.Math {
-    public static double roundDouble(double val, int precision = 2) {
-        int precisionPower = 1;
+    public static double round_double (double val, int precision = 2) {
+        int precision_power = 1;
 
-        for (int i=0; i<precision; i++) {
-            precisionPower *= 10;
+        for (int i = 0; i < precision; i++) {
+            precision_power *= 10;
         }
 
-        return GLib.Math.round (val * precisionPower) / precisionPower;
+        return GLib.Math.round (val * precision_power) / precision_power;
     }
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -33,6 +33,7 @@ executable(
 
     'Utils/Dialogs.vala',
     'Utils/BlendingMode.vala',
+    'Utils/Math.vala',
 
     'Layouts/HeaderBar.vala',
     'Layouts/LeftSideBar.vala',


### PR DESCRIPTION
Before this PR, rotation wasn't bound to any increments and could have been any real number. With this PR, you can easily set often used angles (15, 30, 45, 90, 180) by pressing CTRL and rotation the shape using the nob.

The default increment is 15deg.

## Known Issues / Things To Do
* The fixed increment is _fixed_, so it is not possible to change it. Do we need to create a setting entry for that or is it ok to stick to a fixed one?

## This PR implements the following **features**:

* Fixed rotation while holding CTRL and rotation the shape with the mouse
* Fixed rotation following pointer 
* Capped rotation range to [0, 360[
* Rounded rotation amount to decimal values to prevent subdegree issues