### PR TITLE
Pan action with mouse middle click and Spacebar + click and drag.

### DIFF
--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -20,6 +20,8 @@
 * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
 */
 public class Akira.Layouts.MainCanvas : Gtk.Grid {
+    public const int CANVAS_SIZE = 100000;
+
     public Gtk.ScrolledWindow main_scroll;
     public Akira.Lib.Canvas canvas;
     public Gtk.Allocation main_window_size;
@@ -47,7 +49,7 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         canvas = new Akira.Lib.Canvas (window);
 
         canvas.set_size_request (main_window_size.width, main_window_size.height);
-        canvas.set_bounds (0, 0, 10000, 10000);
+        canvas.set_bounds (0, 0, CANVAS_SIZE, CANVAS_SIZE);
         canvas.set_scale (1.0);
 
         canvas.update_bounds ();
@@ -70,6 +72,10 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         });
 
         main_scroll.add (canvas);
+
+        // Center canvas at startup
+        main_scroll.hadjustment.value = CANVAS_SIZE / 2;
+        main_scroll.vadjustment.value = CANVAS_SIZE / 2;
 
         attach (main_scroll, 0, 0, 1, 1);
     }

--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -24,6 +24,9 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
     public Gtk.Allocation main_window_size;
     public weak Akira.Window window { get; construct; }
 
+    private double scroll_origin_x = 0;
+    private double scroll_origin_y = 0;
+
     public MainCanvas (Akira.Window window) {
         Object (window: window, orientation: Gtk.Orientation.VERTICAL);
     }
@@ -34,9 +37,27 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         main_scroll.expand = true;
 
         canvas = new Akira.Lib.Canvas (window);
+
         canvas.set_size_request (main_window_size.width, main_window_size.height);
         canvas.set_bounds (0, 0, 10000, 10000);
         canvas.set_scale (1.0);
+
+        canvas.canvas_moved.connect((event_x, event_y) => {
+            // Move scroll window according to normalized mouse delta
+            // relative to the scroll window, so with Canvas' pixel
+            // coordinates translated into ScrolledWindow's one.
+            var delta_x = event_x - scroll_origin_x;
+            var delta_y = event_y - scroll_origin_y;
+
+            main_scroll.hadjustment.value -= delta_x;
+            main_scroll.vadjustment.value -= delta_y;
+        });
+
+        canvas.canvas_scroll_set_origin.connect((origin_x, origin_y) => {
+            // Update scroll origin on Canvas' button_press_event
+            scroll_origin_x = origin_x;
+            scroll_origin_y = origin_y;
+        });
 
         main_scroll.add (canvas);
 

--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -42,7 +42,7 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         canvas.set_bounds (0, 0, 10000, 10000);
         canvas.set_scale (1.0);
 
-        canvas.canvas_moved.connect((event_x, event_y) => {
+        canvas.canvas_moved.connect ((event_x, event_y) => {
             // Move scroll window according to normalized mouse delta
             // relative to the scroll window, so with Canvas' pixel
             // coordinates translated into ScrolledWindow's one.
@@ -53,7 +53,7 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
             main_scroll.vadjustment.value -= delta_y;
         });
 
-        canvas.canvas_scroll_set_origin.connect((origin_x, origin_y) => {
+        canvas.canvas_scroll_set_origin.connect ((origin_x, origin_y) => {
             // Update scroll origin on Canvas' button_press_event
             scroll_origin_x = origin_x;
             scroll_origin_y = origin_y;

--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -44,7 +44,7 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         //main_scroll.overlay_scrolling = false;
 
         // Change visibility of canvas scrollbars
-        main_scroll.set_policy (Gtk.PolicyType.NEVER, Gtk.PolicyType.NEVER);
+        //main_scroll.set_policy (Gtk.PolicyType.NEVER, Gtk.PolicyType.NEVER);
 
         canvas = new Akira.Lib.Canvas (window);
 
@@ -71,6 +71,8 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
             scroll_origin_y = origin_y;
         });
 
+        canvas.scroll_event.connect (on_scroll);
+
         main_scroll.add (canvas);
 
         // Center canvas at startup
@@ -78,5 +80,34 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         main_scroll.vadjustment.value = CANVAS_SIZE / 2;
 
         attach (main_scroll, 0, 0, 1, 1);
+    }
+
+    public bool on_scroll (Gdk.EventScroll event) {
+        bool isShift = (event.state & Gdk.ModifierType.SHIFT_MASK) > 0;
+        bool isCtrl = (event.state & Gdk.ModifierType.CONTROL_MASK) > 0;
+
+        switch (event.direction) {
+            case Gdk.ScrollDirection.UP:
+                // Zoom in
+                if (isCtrl) {
+                    window.headerbar.zoom.zoom_in ();
+                } else if (isShift) {
+                    main_scroll.hadjustment.value += 10;
+                } else {
+                    main_scroll.vadjustment.value -= 10;
+                }
+                break;
+            case Gdk.ScrollDirection.DOWN:
+                // Zoom out
+                if (isCtrl) {
+                    window.headerbar.zoom.zoom_out ();
+                } else if (isShift) {
+                    main_scroll.hadjustment.value -= 10;
+                } else {
+                    main_scroll.vadjustment.value += 10;
+                }
+                break;
+        }
+        return true;
     }
 }

--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -38,6 +38,12 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         main_scroll = new Gtk.ScrolledWindow (null, null);
         main_scroll.expand = true;
 
+        // Overlay the scrollbars only if mouse pointer is inside canvas
+        //main_scroll.overlay_scrolling = false;
+
+        // Change visibility of canvas scrollbars
+        main_scroll.set_policy (Gtk.PolicyType.NEVER, Gtk.PolicyType.NEVER);
+
         canvas = new Akira.Lib.Canvas (window);
 
         canvas.set_size_request (main_window_size.width, main_window_size.height);

--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -34,6 +34,7 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
 
     construct {
         get_allocation (out main_window_size);
+
         main_scroll = new Gtk.ScrolledWindow (null, null);
         main_scroll.expand = true;
 
@@ -42,6 +43,8 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         canvas.set_size_request (main_window_size.width, main_window_size.height);
         canvas.set_bounds (0, 0, 10000, 10000);
         canvas.set_scale (1.0);
+
+        canvas.update_bounds ();
 
         canvas.canvas_moved.connect ((event_x, event_y) => {
             // Move scroll window according to normalized mouse delta

--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -17,6 +17,7 @@
 * along with Akira.  If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+* Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
 */
 public class Akira.Layouts.MainCanvas : Gtk.Grid {
     public Gtk.ScrolledWindow main_scroll;

--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -83,15 +83,15 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
     }
 
     public bool on_scroll (Gdk.EventScroll event) {
-        bool isShift = (event.state & Gdk.ModifierType.SHIFT_MASK) > 0;
-        bool isCtrl = (event.state & Gdk.ModifierType.CONTROL_MASK) > 0;
+        bool is_shift = (event.state & Gdk.ModifierType.SHIFT_MASK) > 0;
+        bool is_ctrl = (event.state & Gdk.ModifierType.CONTROL_MASK) > 0;
 
         switch (event.direction) {
             case Gdk.ScrollDirection.UP:
                 // Zoom in
-                if (isCtrl) {
+                if (is_ctrl) {
                     window.headerbar.zoom.zoom_in ();
-                } else if (isShift) {
+                } else if (is_shift) {
                     main_scroll.hadjustment.value += 10;
                 } else {
                     main_scroll.vadjustment.value -= 10;
@@ -99,9 +99,9 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
                 break;
             case Gdk.ScrollDirection.DOWN:
                 // Zoom out
-                if (isCtrl) {
+                if (is_ctrl) {
                     window.headerbar.zoom.zoom_out ();
-                } else if (isShift) {
+                } else if (is_shift) {
                     main_scroll.hadjustment.value -= 10;
                 } else {
                     main_scroll.vadjustment.value += 10;

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -89,7 +89,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         MODE_SELECTION,
         MODE_INSERT,
         MODE_PAN,
-        MODE_ZOOM,
     }
 
     public enum InsertType {
@@ -173,7 +172,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         //  debug ("canvas temp event x: %f", temp_event_x);
         //  debug ("canvas temp event y: %f", temp_event_y);
 
-        if (edit_mode == EditMode.MODE_PAN || edit_mode == EditMode.MODE_ZOOM) {
+        if (edit_mode == EditMode.MODE_PAN) {
             double tmp_event_x_normalized = temp_event_x;
             double tmp_event_y_normalized = temp_event_y;
 
@@ -540,15 +539,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 delete_selected ();
                 return true;
             case Gdk.Key.space:
-                if (edit_mode != EditMode.MODE_ZOOM) {
-                    edit_mode = EditMode.MODE_PAN;
-                }
+                edit_mode = EditMode.MODE_PAN;
                 return true;
             case Gdk.Key.Control_L:
             case Gdk.Key.Control_R:
-                if (edit_mode != EditMode.MODE_PAN) {
-                    edit_mode = EditMode.MODE_ZOOM;
-                }
                 return true;
         }
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -175,6 +175,12 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         //  debug ("canvas temp event x: %f", temp_event_x);
         //  debug ("canvas temp event y: %f", temp_event_y);
 
+        if (event.button == 2) {
+            // Middle mouse clicked
+            holding = true;
+            edit_mode = EditMode.MODE_PAN;
+        }
+
         if (edit_mode == EditMode.MODE_PAN) {
             double tmp_event_x_normalized = temp_event_x;
             double tmp_event_y_normalized = temp_event_y;
@@ -291,6 +297,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         holding = false;
 
+        if (event.button == 2) {
+            edit_mode = EditMode.MODE_SELECTION;
+        }
+
         if (delta_x == 0 && delta_y == 0) {
             return false;
         }
@@ -302,7 +312,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         delta_y = 0;
 
         edit_mode = EditMode.MODE_SELECTION;
-        set_cursor_by_edit_mode ();
 
         return false;
     }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -311,13 +311,13 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             return false;
         }
 
-        convert_to_item_space(selected_item, ref event_x, ref event_y);
+        convert_to_item_space (selected_item, ref event_x, ref event_y);
 
         //  debug ("event x: %f", event_x);
         //  debug ("event y: %f", event_y);
 
         if (!temp_event_converted) {
-            convert_to_item_space(selected_item, ref temp_event_x, ref temp_event_y);
+            convert_to_item_space (selected_item, ref temp_event_x, ref temp_event_y);
             temp_event_converted = true;
         }
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -18,6 +18,7 @@
 *
 * Authored by: Felipe Escoto <felescoto95@hotmail.com>
 * Authored by: Alberto Fanjul <albertofanjul@gmail.com>
+* Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
 */
 
 public class Akira.Lib.Canvas : Goo.Canvas {

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -181,6 +181,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             canvas_scroll_set_origin (tmp_event_x_normalized, tmp_event_y_normalized);
 
             holding = true;
+
+            return true;
         }
 
         Goo.CanvasItem clicked_item;
@@ -290,8 +292,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             return false;
         }
 
-        debug (@"SelectedItem is null: $(selected_item == null)");
-
         item_moved (selected_item);
         add_hover_effect (selected_item);
 
@@ -310,14 +310,19 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         if (edit_mode == EditMode.MODE_PAN) {
             if (holding) {
+                // Move canvas if holding mouse and spacebar pressed
                 move_canvas (event_x, event_y);
+            } else {
+                // Remove hover effect on selected items if just
+                // moving around with spacebar pressed
+                remove_hover_effect ();
             }
 
             return false;
         }
 
         if (!holding) {
-            motion_hover_event (event);
+            motion_hover_event (event.x, event.y);
             return false;
         }
 
@@ -540,6 +545,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 return true;
             case Gdk.Key.space:
                 edit_mode = EditMode.MODE_PAN;
+                remove_hover_effect ();
                 return true;
             case Gdk.Key.Control_L:
             case Gdk.Key.Control_R:
@@ -553,6 +559,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         switch (Gdk.keyval_to_upper (event.keyval)) {
             case Gdk.Key.space:
                 edit_mode = EditMode.MODE_SELECTION;
+                motion_hover_event (hover_x, hover_y);
                 return true;
 
             case Gdk.Key.Control_L:
@@ -574,8 +581,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         return;
     }
 
-    private void motion_hover_event (Gdk.EventMotion event) {
-        var hovered_item = get_item_at (event.x / get_scale (), event.y / get_scale (), true);
+    private void motion_hover_event (double event_x, double event_y) {
+        var hovered_item = get_item_at (event_x / get_scale (), event_y / get_scale (), true);
 
         if (!(hovered_item is Goo.CanvasItemSimple)) {
             remove_hover_effect ();

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -134,8 +134,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         events |= Gdk.EventMask.SCROLL_MASK;
         events |= Gdk.EventMask.TOUCHPAD_GESTURE_MASK;
         events |= Gdk.EventMask.TOUCH_MASK;
-
-        get_bounds (out bounds_x, out bounds_y, out bounds_w, out bounds_h);
     }
 
     public void set_cursor_by_edit_mode () {
@@ -160,6 +158,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 set_cursor ("default");
                 break;
         }
+    }
+
+    public void update_bounds () {
+        get_bounds (out bounds_x, out bounds_y, out bounds_w, out bounds_h);
     }
 
     public override bool button_press_event (Gdk.EventButton event) {
@@ -365,6 +367,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         var canvas_x = x;
         var canvas_y = y;
+
         convert_from_item_space (selected_item, ref canvas_x, ref canvas_y);
 
         //  debug ("new delta x: %f", new_delta_x);
@@ -383,8 +386,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Nob.NONE: // Moving
                 double move_x = fix_x_position (canvas_x, width, delta_x);
                 double move_y = fix_y_position (canvas_y, height, delta_y);
-                //  debug ("move x %f", move_x);
-                //  debug ("move y %f", move_y);
+
+                // debug ("move x %f", move_x);
+                // debug ("move y %f", move_y);
+
                 selected_item.translate (move_x, move_y);
                 event_x -= move_x;
                 event_y -= move_y;
@@ -908,11 +913,14 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     private double fix_y_position (double y, double height, double delta_y) {
-        var min_delta = Math.round ((MIN_POS - height) * current_scale);
-        //  debug ("min delta y %f", min_delta);
-        var max_delta = Math.round ((bounds_h - MIN_POS) * current_scale);
-        //  debug ("max delta y %f", max_delta);
+        var min_delta = Math.round (MIN_POS / current_scale - height);
+        var max_delta = Math.round (bounds_h - MIN_POS / current_scale);
         var new_y = Math.round (y + delta_y);
+
+        //debug ("min delta y %f", min_delta);
+        //debug ("max delta y %f", max_delta);
+        //debug ("new_y %f", new_y);
+
         if (new_y < min_delta) {
             return 0;
         } else if (new_y > max_delta) {
@@ -923,11 +931,14 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     private double fix_x_position (double x, double width, double delta_x) {
-        var min_delta = Math.round ((MIN_POS - width) * current_scale);
-        //  debug ("min delta x %f", min_delta);
-        var max_delta = Math.round ((bounds_h - MIN_POS) * current_scale);
-        //  debug ("max delta x %f", max_delta);
+        var min_delta = Math.round (MIN_POS / current_scale - width);
+        var max_delta = Math.round (bounds_h - MIN_POS / current_scale);
         var new_x = Math.round (x + delta_x);
+
+        //debug ("min delta x %f", min_delta);
+        //debug ("max delta x %f", max_delta);
+        //debug ("new_x %f", new_x);
+
         if (new_x < min_delta) {
             return 0;
         } else if (new_x > max_delta) {


### PR DESCRIPTION
## Known Issues / Things To Do
- [**DONE**]Right now MainCanvas is 10k x 10k pixels but the Canvas only get noticed about 1k x 1k.
- [**DONE**]Canvas starting position is top-left, maybe centering it would be a better idea in order to enable panning in every direction since the beginning (right now right panning is not possible since the canvas is already at its leftmost edge)
- Canvas scrollbars have been removed, since it would have difficult to grab object near the edges. Now what has become difficult is the ability to understand where we are on the canvas, so we should give a way to the user to understand precisely where he/she is and when the canvas "ends". Maybe a minimap would help?
- We should provide (maybe for the next release, not the 1.0) a way to reset canvas to "center" and to zoom in to certain objects (maybe by selecting them in the right panel). Maybe also "locking" the view to a specific zoom would help, too.

## This PR implements the following **features**:
- [x] Canvas pan action with Spacebar + click
- [x] Canvas pan with middle mouse click and drag
- [x] Center canvas at startup
- [x] Make canvas' items move action aware of canvas entire size
- [x] Zoom with scroll + ctrl
- [x] Vertical scroll with scroll
- [x] Horizontal scroll with shift + scroll