### PR TITLE
[WIP] Fill Panel Connection with Selected Object

### DIFF
--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -167,23 +167,19 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
             }
         );
 
-        color_container.key_release_event.connect ((event) => {
-            if (!color_container.text.contains ("#")) {
-                var builder = new StringBuilder ();
-                builder.append ("#");
-                builder.append (color_container.text);
-                color_container.text = builder.str;
-                color_container.set_position (-1);
-            }
+        color_container.delete_text.connect ((start_pos, end_pos) => {
+            string new_text = color_container.text.splice (start_pos, end_pos);
 
-            return false;
+            if (!new_text.contains ("#")) {
+                GLib.Signal.stop_emission_by_name (color_container, "delete-text");
+            }
         });
 
         color_container.insert_text.connect ((_new_text, new_text_length) => {
-            string new_text = _new_text;
+            string new_text = _new_text.strip ();
 
             if (new_text.contains ("#")) {
-                new_text = _new_text.substring (1, new_text.length - 1);
+                new_text = new_text.substring (1, new_text.length - 1);
             }
 
             bool is_valid_hex = true;
@@ -191,16 +187,15 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
             bool char_is_numeric = true;
             bool char_is_valid_alpha = true;
 
-            uint keyval;
+            char keyval;
 
             for (var i = 0; i < new_text.length; i++) {
-                keyval = Gdk.keyval_to_upper (new_text [i]);
+                keyval = new_text [i];
 
                 char_is_numeric = keyval >= Gdk.Key.@0 && keyval <= Gdk.Key.@9;
                 char_is_valid_alpha = keyval >= Gdk.Key.A && keyval <= Gdk.Key.F;
 
-                is_valid_hex &= (char_is_numeric || char_is_valid_alpha);
-
+                is_valid_hex &= keyval.isxdigit ();
             }
 
             if (!is_valid_hex) {

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -222,7 +222,7 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         opacity_container = new Akira.Partials.InputField (
             Akira.Partials.InputField.Unit.PERCENTAGE, 7, true, true);
         opacity_container.entry.sensitive = true;
-        opacity_container.entry.text = Math. round((double) alpha / 255 * 100).to_string ();
+        opacity_container.entry.text = Math. round ((double) alpha / 255 * 100).to_string ();
         opacity_container.entry.bind_property (
             "text", model, "alpha",
             BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE,

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -99,6 +99,8 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         hidden = model.hidden;
         //  blending_mode = model.blending_mode;
         color = model.color;
+
+        debug (@"model.color: $(model.color)");
     }
 
     private void create_ui () {

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -133,7 +133,7 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         color_container.width_chars = 8;
         color_container.max_length = 7;
         color_container.hexpand = true;
-        //color_container.text = Utils.Color.rgba_to_hex (color);
+        color_container.text = Utils.Color.rgba_to_hex (color);
 
         color_container.bind_property (
             "text", model, "color",
@@ -157,7 +157,7 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
                 return true;
             },
             // model => this
-            (binding, model_value, ref color_container_value) => {
+            (bpnding, model_value, ref color_container_value) => {
                 var model_rgba = model_value.dup_string ();
 
                 old_color = model_rgba;
@@ -223,7 +223,7 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         opacity_container = new Akira.Partials.InputField (
             Akira.Partials.InputField.Unit.PERCENTAGE, 7, true, true);
         opacity_container.entry.sensitive = true;
-        opacity_container.entry.text = Math. round ((double) alpha / 255 * 100).to_string ();
+        opacity_container.entry.text = Math.round ((double) alpha / 255 * 100).to_string ();
         opacity_container.entry.bind_property (
             "text", model, "alpha",
             BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE,
@@ -252,7 +252,7 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
 
                 src = Math.round (src * 100);
 
-                entry_text_val.set_string (("%f").printf (src * 100));
+                entry_text_val.set_string (("%f").printf (src));
 
                 return true;
             }
@@ -316,9 +316,7 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
     }
 
     private void on_color_changed () {
-        var selected_color = color_chooser_widget.rgba;
-
-        color = selected_color.to_string ();
+        color = color_chooser_widget.rgba.to_string ();
     }
 
     //  private void on_row_activated (Gtk.ListBoxRow? item) {

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -57,10 +57,11 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         }
     }
 
-    private double alpha {
+    private int alpha {
         owned get {
             return model.alpha;
         } set {
+            debug (@"Alpha value set in setter: $(value)");
             model.alpha = value;
 
             set_button_color ();
@@ -222,20 +223,28 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         opacity_container = new Akira.Partials.InputField (
             Akira.Partials.InputField.Unit.PERCENTAGE, 7, true, true);
         opacity_container.entry.sensitive = true;
-        opacity_container.entry.text = (alpha / 255 * 100).to_string ();
+        opacity_container.entry.text = ((double) alpha / 255 * 100).to_string ();
         opacity_container.entry.bind_property (
             "text", model, "alpha",
             BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE,
             (binding, srcval, ref targetval) => {
                 double src = double.parse (srcval.dup_string ());
+
+                debug (@"Src: $(src)");
+
                 if (src > 100) {
+                    src = 100;
                     opacity_container.entry.text = "100";
-                    return false;
                 } else if (src < 0) {
+                    src = 0;
                     opacity_container.entry.text = "0";
-                    return false;
                 }
-                targetval.set_double (src / 100);
+
+                int alpha_int_value = (int) (src / 100 * 255);
+
+                debug (@"Alpha int value: $(alpha_int_value)");
+
+                targetval.set_int (alpha_int_value);
                 return true;
             }, (binding, srcval, ref targetval) => {
                 double src = (double) srcval / 255;
@@ -306,7 +315,7 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
     private void on_color_changed () {
         var selected_color = color_chooser_widget.rgba;
 
-        alpha = selected_color.alpha;
+        alpha = (int) (selected_color.alpha * 100);
 
         color = selected_color.to_string ();
     }

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -133,7 +133,7 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         color_container.width_chars = 8;
         color_container.max_length = 7;
         color_container.hexpand = true;
-        color_container.text = Utils.Color.rgba_to_hex (color);
+        //color_container.text = Utils.Color.rgba_to_hex (color);
 
         color_container.bind_property (
             "text", model, "color",
@@ -159,15 +159,21 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
             // model => this
             (binding, model_value, ref color_container_value) => {
                 var model_rgba = model_value.dup_string ();
+
                 old_color = model_rgba;
 
                 color_container_value.set_string (Utils.Color.rgba_to_hex (model_rgba));
-
                 return true;
             }
         );
 
         color_container.delete_text.connect ((start_pos, end_pos) => {
+            if (end_pos == -1) {
+                // We are replacing the string from the internal
+                // Not by manually selecting the text, so we don't need to check anything
+                return;
+            }
+
             string new_text = color_container.text.splice (start_pos, end_pos);
 
             if (!new_text.contains ("#")) {
@@ -307,18 +313,12 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         //  blending_mode_popover_items.row_selected.connect (on_popover_item_selected);
 
         color_chooser_widget.notify["rgba"].connect (on_color_changed);
-
-        model.notify.connect (on_model_changed);
     }
 
     private void on_color_changed () {
         var selected_color = color_chooser_widget.rgba;
 
         color = selected_color.to_string ();
-    }
-
-    private void on_model_changed () {
-        set_color_chooser_color ();
     }
 
     //  private void on_row_activated (Gtk.ListBoxRow? item) {

--- a/src/Layouts/Partials/FillsBoxPanel.vala
+++ b/src/Layouts/Partials/FillsBoxPanel.vala
@@ -82,7 +82,7 @@ public class Akira.Layouts.Partials.FillsBoxPanel : Gtk.Grid {
         attach (title_cont, 0, 0, 1, 1);
         attach (fills_list_container, 0, 1, 1, 1);
 
-        event_bus.selected_items_changed.connect (on_selected_items_changed);
+        window.event_bus.selected_items_changed.connect (on_selected_items_changed);
     }
 
     private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {

--- a/src/Layouts/Partials/FillsBoxPanel.vala
+++ b/src/Layouts/Partials/FillsBoxPanel.vala
@@ -89,7 +89,20 @@ public class Akira.Layouts.Partials.FillsBoxPanel : Gtk.Grid {
         if (selected_items.length () > 0) {
             if (selected_item == null || selected_item != selected_items.nth_data (0)) {
                 selected_item = selected_items.nth_data (0);
-                fills_list_model.add (selected_item);
+
+                debug (@"Setting::color: $(settings.fill_color)");
+                var rgba = Gdk.RGBA ();
+                rgba.parse (settings.fill_color);
+
+                debug (@"$rgba");
+
+                rgba.parse ("rgba(100,0, 100,0, 100,0, 0,0)");
+
+                debug (@"$rgba");
+
+
+                debug (@"SelectedItem::color: $(selected_item.color)");
+                fills_list_model.add.begin (selected_item);
             }
         } else {
             selected_item = null;

--- a/src/Layouts/Partials/FillsBoxPanel.vala
+++ b/src/Layouts/Partials/FillsBoxPanel.vala
@@ -90,18 +90,6 @@ public class Akira.Layouts.Partials.FillsBoxPanel : Gtk.Grid {
             if (selected_item == null || selected_item != selected_items.nth_data (0)) {
                 selected_item = selected_items.nth_data (0);
 
-                debug (@"Setting::color: $(settings.fill_color)");
-                var rgba = Gdk.RGBA ();
-                rgba.parse (settings.fill_color);
-
-                debug (@"$rgba");
-
-                rgba.parse ("rgba(100,0, 100,0, 100,0, 0,0)");
-
-                debug (@"$rgba");
-
-
-                debug (@"SelectedItem::color: $(selected_item.color)");
                 fills_list_model.add.begin (selected_item);
             }
         } else {

--- a/src/Layouts/Partials/FillsBoxPanel.vala
+++ b/src/Layouts/Partials/FillsBoxPanel.vala
@@ -86,15 +86,16 @@ public class Akira.Layouts.Partials.FillsBoxPanel : Gtk.Grid {
     }
 
     private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {
-        if (selected_items.length () > 0) {
-            if (selected_item == null || selected_item != selected_items.nth_data (0)) {
-                selected_item = selected_items.nth_data (0);
-
-                fills_list_model.add.begin (selected_item);
-            }
-        } else {
+        if (selected_items.length () == 0) {
             selected_item = null;
             fills_list_model.clear.begin ();
+            return;
+        }
+
+        if (selected_item == null || selected_item != selected_items.nth_data (0)) {
+            selected_item = selected_items.nth_data (0);
+
+            fills_list_model.add.begin (selected_item);
         }
     }
 }

--- a/src/Layouts/Partials/FillsBoxPanel.vala
+++ b/src/Layouts/Partials/FillsBoxPanel.vala
@@ -26,6 +26,7 @@ public class Akira.Layouts.Partials.FillsBoxPanel : Gtk.Grid {
     public Gtk.ListBox fills_list_container;
     public Akira.Models.FillsListModel fills_list_model;
     public Gtk.Grid title_cont;
+    private Lib.Models.CanvasItem selected_item;
 
     private int last_item_position;
 
@@ -80,5 +81,19 @@ public class Akira.Layouts.Partials.FillsBoxPanel : Gtk.Grid {
 
         attach (title_cont, 0, 0, 1, 1);
         attach (fills_list_container, 0, 1, 1, 1);
+
+        event_bus.selected_items_changed.connect (on_selected_items_changed);
+    }
+
+    private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {
+        if (selected_items.length () > 0) {
+            if (selected_item == null || selected_item != selected_items.nth_data (0)) {
+                selected_item = selected_items.nth_data (0);
+                fills_list_model.add (selected_item);
+            }
+        } else {
+            selected_item = null;
+            fills_list_model.clear.begin ();
+        }
     }
 }

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -52,11 +52,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         get {
             return _item;
         } set {
-
-            if (_item != null) {
-                _item.notify.disconnect (item_changed);
-            }
-
             _item = value;
 
             bool has_item = _item != null;
@@ -82,7 +77,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             scale.sensitive = has_item;
 
             if (_item != null) {
-                _item.notify.connect (item_changed);
                 update_fields ();
             }
         }
@@ -231,11 +225,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         item = selected_items.nth_data (0);
     }
 
-    private void item_changed (Object object, ParamSpec spec) {
-        //  debug ("item changed, param: %s", spec.name);
-        update_fields ();
-    }
-
     private void reset_values () {
         // Connecting and disconnecting are necessary in order
         // not to create infinite "jumps" between the value notify
@@ -318,30 +307,11 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
        transform.rotate (radians);
        transform.translate (-center_x, -center_y);
        item.set_transform (transform);
-
-       //window.main_window.main_canvas.canvas.update_decorations (item);
     }
 
     public void opacity_notify_value () {
-        var item_simple = (Goo.CanvasItemSimple) item;
-
-        int? fill_a = item.fill_alpha;
-        int? stroke_a = item.stroke_alpha;
-
-        var opacity_factor = double.parse (opacity_entry.entry.text) / 100;
-
-        uint fill_color_rgba = item_simple.fill_color_rgba;
-        uint stroke_color_rgba = item_simple.stroke_color_rgba;
-        fill_rgb = fill_color_rgba & 0xFFFFFF00;
-        stroke_rgb = stroke_color_rgba & 0xFFFFFF00;
-
-        item_simple.notify.disconnect (item_changed);
-
-        item.opacity = opacity_factor * 100;
-        item_simple.fill_color_rgba = (uint) (fill_rgb + (fill_a * opacity_factor));
-        item_simple.stroke_color_rgba = (uint) (stroke_rgb + (stroke_a * opacity_factor));
-
-        item_simple.notify.connect (item_changed);
+        var opacity_factor = double.parse (opacity_entry.entry.text);
+        item.opacity = opacity_factor;
     }
 
     public void y_notify_value () {

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -84,6 +84,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         window.event_bus.request_zoom.connect (on_request_zoom);
         window.event_bus.request_change_cursor.connect (on_request_change_cursor);
         window.event_bus.set_focus_on_canvas.connect (focus_canvas);
+        window.event_bus.set_focus_on_canvas.connect (on_set_focus_on_canvas);
     }
 
     public void update_bounds () {
@@ -140,6 +141,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     public override bool button_press_event (Gdk.EventButton event) {
+        focus_canvas ();
+
         holding = true;
 
         var temp_event_x = event.x / current_scale;
@@ -164,7 +167,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
                 if (clicked_item == null) {
                     selected_bound_manager.reset_selection ();
-
                     // TODO: allow for multi select with click & drag on canvas
                     // Workaround: when no item is clicked, there's no point in keeping holding active
                     holding = false;
@@ -231,8 +233,12 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         return true;
     }
 
-    public void focus_canvas () {
+    public void on_set_focus_on_canvas () {
         edit_mode = EditMode.MODE_SELECTION;
+        focus_canvas ();
+    }
+
+    public void focus_canvas () {
         grab_focus (get_root_item ());
     }
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -33,8 +33,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     private InsertType? insert_type { get; set; }
     private Goo.CanvasItem root;
     private double border_size;
-    private string border_color;
-    private string fill_color;
+    private Gdk.RGBA border_color;
+    private Gdk.RGBA fill_color;
 
     public ItemsManager (Akira.Lib.Canvas canvas) {
         Object (
@@ -45,6 +45,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     construct {
         root = canvas.get_root_item ();
         items = new List<Models.CanvasItem> ();
+
+        border_color = Gdk.RGBA ();
+        fill_color = Gdk.RGBA ();
 
         canvas.window.event_bus.insert_item.connect (set_item_to_insert);
     }
@@ -202,7 +205,11 @@ public class Akira.Lib.Managers.ItemsManager : Object {
 
     private void udpate_default_values () {
         border_size = settings.set_border ? settings.border_size : 0.0;
-        border_color = settings.set_border ? settings.border_color: "";
-        fill_color = settings.fill_color;
+
+        string border_color_str = settings.set_border ? settings.border_color : DEFAUL_BORDER_COLOR;
+        string fill_color_str = settings.fill_color;
+
+        border_color.parse (border_color_str);
+        fill_color.parse (fill_color_str);
     }
 }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -209,6 +209,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         string border_color_str = settings.set_border ? settings.border_color : DEFAUL_BORDER_COLOR;
         string fill_color_str = settings.fill_color;
 
+        debug (@"Settings::set-border: $(settings.set_border.to_string ())");
+        debug (@"Settings::border-color: $(settings.border_color.to_string ())");
+
         border_color.parse (border_color_str);
         fill_color.parse (fill_color_str);
     }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -209,9 +209,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         string border_color_str = settings.set_border ? settings.border_color : DEFAUL_BORDER_COLOR;
         string fill_color_str = settings.fill_color;
 
-        debug (@"Settings::set-border: $(settings.set_border.to_string ())");
-        debug (@"Settings::border-color: $(settings.border_color.to_string ())");
-
         border_color.parse (border_color_str);
         fill_color.parse (fill_color_str);
     }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -206,10 +206,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     private void udpate_default_values () {
         border_size = settings.set_border ? settings.border_size : 0.0;
 
-        string border_color_str = settings.set_border ? settings.border_color : DEFAUL_BORDER_COLOR;
-        string fill_color_str = settings.fill_color;
+        string border_color_str = settings.set_border ? settings.border_color : "";
 
         border_color.parse (border_color_str);
-        fill_color.parse (fill_color_str);
+        fill_color.parse (settings.fill_color);
     }
 }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -26,8 +26,8 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public double rotation { get; set; }
     public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
-    public string color { get; set; }
-    public string border_color { get; set; }
+    public Gdk.RGBA color { get; set; }
+    public Gdk.RGBA border_color { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasEllipse (
@@ -36,8 +36,8 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         double _radius_x = 0,
         double _radius_y = 0,
         double _border_size = 1.0,
-        string _border_color = "#aaa",
-        string _fill_color = "#ccc",
+        Gdk.RGBA _border_color,
+        Gdk.RGBA _fill_color,
         Goo.CanvasItem? parent = null
     ) {
         Object (

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -20,13 +20,14 @@
 */
 
 public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasItem {
-
     public string id { get; set; }
     public bool selected { get; set; }
     public double opacity { get; set; }
     public double rotation { get; set; }
     public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
+    public string color { get; set; }
+    public string border_color { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasEllipse (

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -21,13 +21,56 @@
 
 public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasItem {
     public string id { get; set; }
-    public bool selected { get; set; }
-    public double opacity { get; set; }
     public double rotation { get; set; }
-    public int fill_alpha { get; set; }
+    public bool selected { get; set; }
+
+    private double _opacity;
+    public double opacity {
+        get {
+            return _opacity;
+        }
+        public set {
+            _opacity = value;
+
+            reset_colors ();
+        }
+    }
+
+    private int _fill_alpha;
+    public int fill_alpha {
+        get {
+            return _fill_alpha;
+        }
+        set {
+            _fill_alpha = value;
+            reset_colors ();
+        }
+    }
     public int stroke_alpha { get; set; }
-    public Gdk.RGBA color { get; set; }
-    public Gdk.RGBA border_color { get; set; }
+
+    private Gdk.RGBA _color;
+    public Gdk.RGBA color {
+        get {
+            return _color;
+        }
+        set {
+            _color = value;
+
+            reset_colors ();
+        }
+    }
+
+    private Gdk.RGBA _border_color;
+    public Gdk.RGBA border_color {
+        get {
+            return _border_color;
+        }
+        set {
+            _border_color = value;
+
+            reset_colors ();
+        }
+    }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasEllipse (
@@ -62,8 +105,10 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         // move the entire coordinate system every time
         translate (_center_x, _center_y);
 
+        color = _fill_color;
+        border_color = _border_color;
+
         set ("line-width", _border_size);
-        set ("fill-color", _fill_color);
         set ("stroke-color", _border_color);
     }
 }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -107,8 +107,5 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
 
         color = _fill_color;
         border_color = _border_color;
-
-        set ("line-width", _border_size);
-        set ("stroke-color", _border_color);
     }
 }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -64,13 +64,19 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public void reset_colors () {
-        var rgba = Gdk.RGBA ();
+        var rgba_fill = Gdk.RGBA ();
+        var rgba_stroke = Gdk.RGBA ();
 
-        rgba = color;
-        rgba.alpha = ((double) fill_alpha) / 255 * opacity / 100;
+        rgba_fill = color;
+        rgba_fill.alpha = ((double) fill_alpha) / 255 * opacity / 100;
 
-        uint fill_color_rgba = Utils.Color.rgba_to_uint (rgba);
+        rgba_stroke = border_color;
+        rgba_stroke.alpha = ((double) stroke_alpha) / 255 * opacity / 100;
+
+        uint fill_color_rgba = Utils.Color.rgba_to_uint (rgba_fill);
+        uint stroke_color_rgba = Utils.Color.rgba_to_uint (rgba_stroke);
 
         set ("fill-color-rgba", fill_color_rgba);
+        set ("stroke-color-rgba", stroke_color_rgba);
     }
 }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -28,15 +28,15 @@ public enum Akira.Lib.Models.CanvasItemType {
 public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasItem {
     public static int global_id = 0;
 
-    public abstract string id { get; public set; }
-    public abstract bool selected { get; public set; }
-    public abstract double opacity { get; public set; }
-    public abstract double rotation { get; public set; }
-    public abstract int fill_alpha { get; public  set; }
-    public abstract int stroke_alpha { get; public set; }
-    public abstract Gdk.RGBA color { get; public set; }
-    public abstract Gdk.RGBA border_color { get; public set; }
-    public abstract Models.CanvasItemType item_type { get; protected set; }
+    public abstract string id { get; set; }
+    public abstract bool selected { get; set; }
+    public abstract double opacity { get; set; }
+    public abstract double rotation { get; set; }
+    public abstract int fill_alpha { get; set; }
+    public abstract int stroke_alpha { get; set; }
+    public abstract Gdk.RGBA color { get; set; }
+    public abstract Gdk.RGBA border_color { get; set; }
+    public abstract Models.CanvasItemType item_type { get; set; }
 
     public double get_coords (string coord_id, bool convert_to_item_space = false) {
         double _coord = 0.0;

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -34,6 +34,8 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItem {
     public abstract double rotation { get; public set; }
     public abstract int fill_alpha { get; public set; }
     public abstract int stroke_alpha { get; public set; }
+    public abstract string color { get; public set; }
+    public abstract string border_color { get; public set; }
     public abstract Models.CanvasItemType item_type { get; protected set; }
 
     public double get_coords (string coord_id, bool convert_to_item_space = false) {

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -25,17 +25,17 @@ public enum Akira.Lib.Models.CanvasItemType {
     TEXT
 }
 
-public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItem {
+public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasItem {
     public static int global_id = 0;
 
     public abstract string id { get; public set; }
     public abstract bool selected { get; public set; }
     public abstract double opacity { get; public set; }
     public abstract double rotation { get; public set; }
-    public abstract int fill_alpha { get; public set; }
+    public abstract int fill_alpha { get; public  set; }
     public abstract int stroke_alpha { get; public set; }
-    public abstract string color { get; public set; }
-    public abstract string border_color { get; public set; }
+    public abstract Gdk.RGBA color { get; public set; }
+    public abstract Gdk.RGBA border_color { get; public set; }
     public abstract Models.CanvasItemType item_type { get; protected set; }
 
     public double get_coords (string coord_id, bool convert_to_item_space = false) {
@@ -61,5 +61,16 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItem {
         item.set ("opacity", 100.0);
         item.set ("fill-alpha", 255);
         item.set ("stroke-alpha", 255);
+    }
+
+    public void reset_colors () {
+        var rgba = Gdk.RGBA ();
+
+        rgba = color;
+        rgba.alpha = ((double) fill_alpha) / 255 * opacity / 100;
+
+        uint fill_color_rgba = Utils.Color.rgba_to_uint (rgba);
+
+        set ("fill-color-rgba", fill_color_rgba);
     }
 }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -27,6 +27,18 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public double rotation { get; public set; }
     public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
+    private string _color;
+    public string color {
+        get {
+            return _color;
+        }
+        set {
+            _color = value;
+
+            set ("fill-color", _color);
+        }
+    }
+    public string border_color  { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasRect (
@@ -61,8 +73,9 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         // move the entire coordinate system every time
         translate (_x, _y);
 
+        color = _fill_color;
+        border_color = _border_color;
+
         set ("line-width", _border_size);
-        set ("fill-color", _fill_color);
-        set ("stroke-color", _border_color);
     }
 }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -59,7 +59,19 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
             reset_colors ();
         }
     }
-    public Gdk.RGBA border_color { get; set; }
+
+    private Gdk.RGBA _border_color;
+    public Gdk.RGBA border_color {
+        get {
+            return _border_color;
+        }
+        set {
+            _border_color = value;
+
+            reset_colors ();
+        }
+    }
+
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasRect (
@@ -97,6 +109,9 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         color = _fill_color;
         border_color = _border_color;
 
+        debug (@"BorderColor: $border_color");
+
         set ("line-width", _border_size);
+        set ("stroke-color", _border_color);
     }
 }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -109,8 +109,6 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         color = _fill_color;
         border_color = _border_color;
 
-        debug (@"BorderColor: $border_color");
-
         set ("line-width", _border_size);
         set ("stroke-color", _border_color);
     }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -108,8 +108,5 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
 
         color = _fill_color;
         border_color = _border_color;
-
-        set ("line-width", _border_size);
-        set ("stroke-color", _border_color);
     }
 }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -20,25 +20,46 @@
 */
 
 public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
-
     public string id { get; set; }
     public bool selected { get; set; }
-    public double opacity { get; public set; }
     public double rotation { get; public set; }
-    public int fill_alpha { get; set; }
+
+    private double _opacity;
+    public double opacity {
+        get {
+            return _opacity;
+        }
+        public set {
+            _opacity = value;
+
+            reset_colors ();
+        }
+    }
+
+    private int _fill_alpha;
+    public int fill_alpha {
+        get {
+            return _fill_alpha;
+        }
+        set {
+            _fill_alpha = value;
+            reset_colors ();
+        }
+    }
     public int stroke_alpha { get; set; }
-    private string _color;
-    public string color {
+
+    private Gdk.RGBA _color;
+    public Gdk.RGBA color {
         get {
             return _color;
         }
         set {
             _color = value;
 
-            set ("fill-color", _color);
+            reset_colors ();
         }
     }
-    public string border_color  { get; set; }
+    public Gdk.RGBA border_color { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasRect (
@@ -47,10 +68,10 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         double _radius_x = 0,
         double _radius_y = 0,
         double _border_size = 1.0,
-        string _border_color = "#aaa",
-        string _fill_color = "#ccc",
+        Gdk.RGBA _border_color,
+        Gdk.RGBA _fill_color,
         Goo.CanvasItem? parent = null
-    ) {
+        ) {
         Object (
             parent: parent
         );

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -27,6 +27,8 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public double rotation { get; set; }
     public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
+    public string color { get; set; }
+    public string border_color { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasText (

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -20,15 +20,14 @@
 */
 
 public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
-
     public string id { get; set; }
     public bool selected { get; set; }
     public double opacity { get; set; }
     public double rotation { get; set; }
     public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
-    public string color { get; set; }
-    public string border_color { get; set; }
+    public Gdk.RGBA color { get; set; }
+    public Gdk.RGBA border_color { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasText (

--- a/src/Models/FillsItemModel.vala
+++ b/src/Models/FillsItemModel.vala
@@ -22,36 +22,22 @@
 public class Akira.Models.FillsItemModel : GLib.Object {
     public string color {
         owned get {
-            debug (@"Getting color: $(item.color)");
-
-            return item.color;
+            return item.color.to_string ();
         } set {
-            debug (@"Setting color: $value");
             var new_rgba = Gdk.RGBA ();
             new_rgba.parse (value);
 
-            var alpha = item.fill_alpha * item.opacity;
-
-            new_rgba.alpha = alpha;
-
-            item.color = new_rgba.to_string ();
+            item.color = new_rgba;
         }
     }
-    public double alpha {
+    public int alpha {
         get {
+            debug (@"model::get::alpha::$(item.fill_alpha)");
             return item.fill_alpha;
         }
         set {
-            debug (@"Alpha: $(value)");
-            /*
-            var rgba = item.fill_color_rgba;
-            var fill_a = (int) (value * 255);
-            //  debug ("set alpha: %f", fill_a);
-            item.set_data<int?> ("fill-alpha", fill_a);
-            var opacity_factor = item.get_data<double?> ("opacity") / 100;
-            var alpha = fill_a * opacity_factor;
-            item.fill_color_rgba = (rgba & 0xFFFFFF00) + (uint) (alpha);
-            */
+            debug (@"Alpha in fills_model: $(value)");
+            item.fill_alpha = value;
         }
     }
 

--- a/src/Models/FillsItemModel.vala
+++ b/src/Models/FillsItemModel.vala
@@ -32,11 +32,9 @@ public class Akira.Models.FillsItemModel : GLib.Object {
     }
     public int alpha {
         get {
-            debug (@"model::get::alpha::$(item.fill_alpha)");
             return item.fill_alpha;
         }
         set {
-            debug (@"Alpha in fills_model: $(value)");
             item.fill_alpha = value;
         }
     }

--- a/src/Models/FillsItemModel.vala
+++ b/src/Models/FillsItemModel.vala
@@ -22,6 +22,9 @@
 public class Akira.Models.FillsItemModel : GLib.Object {
     public string color {
         owned get {
+            return item.color;
+
+            /*
             var rgba = item.fill_color_rgba;
             var result = "#%02x%02x%02x".printf (
                 (int) (Math.round (rgba >> 24 & 0xFF)),
@@ -29,25 +32,40 @@ public class Akira.Models.FillsItemModel : GLib.Object {
                 (int) (Math.round (rgba >> 8 & 0xFF))
             );
             return result;
+            */
         } set {
             var new_rgba = Gdk.RGBA ();
             new_rgba.parse (value);
-            var fill_a = item.get_data<int?> ("fill-alpha");
-            var opacity_factor = item.get_data<double?> ("opacity") / 100;
-            var alpha = fill_a * opacity_factor;
-            //  debug ("set color: real alpha: %f,%f,%f,%f", new_rgba.red, new_rgba.green, new_rgba.blue, alpha / 255);
-            uint rgba = (uint)Math.round (new_rgba.red * 255);
+
+            debug (@"R: $(new_rgba.red)");
+            debug (@"G: $(new_rgba.green)");
+            debug (@"B: $(new_rgba.blue)");
+
+            var alpha = item.fill_alpha * item.opacity;
+
+            uint rgba = (uint) Math.round (new_rgba.red * 255);
             rgba = (rgba << 8) + (uint)Math.round (new_rgba.green * 255);
             rgba = (rgba << 8) + (uint)Math.round (new_rgba.blue * 255);
             rgba = (rgba << 8) + (uint)Math.round (alpha);
-            item.fill_color_rgba = rgba;
+
+            var new_color_hex = "#%02x%02x%02x".printf (
+                (int) (Math.round (rgba >> 24 & 0xFF)),
+                (int) (Math.round (rgba >> 16 & 0xFF)),
+                (int) (Math.round (rgba >> 8 & 0xFF))
+            );
+
+            debug (@"New color: $(new_color_hex)");
+
+            item.color = new_color_hex;
         }
     }
     public double alpha {
         get {
-            return item.get_data<int?> ("fill-alpha");
+            return item.fill_alpha;
         }
         set {
+            debug (@"Alpha: $(value)");
+            /*
             var rgba = item.fill_color_rgba;
             var fill_a = (int) (value * 255);
             //  debug ("set alpha: %f", fill_a);
@@ -55,22 +73,25 @@ public class Akira.Models.FillsItemModel : GLib.Object {
             var opacity_factor = item.get_data<double?> ("opacity") / 100;
             var alpha = fill_a * opacity_factor;
             item.fill_color_rgba = (rgba & 0xFFFFFF00) + (uint) (alpha);
+            */
         }
     }
     public bool hidden { get; set; }
     public Akira.Utils.BlendingMode blending_mode { get; set; }
     public Akira.Models.FillsListModel list_model { get; set; }
-    public Goo.CanvasItemSimple item { get; construct; }
+    public Lib.Models.CanvasItem item { get; construct; }
 
-    public FillsItemModel (Goo.CanvasItemSimple item_simple,
-                           bool hidden,
-                           Akira.Utils.BlendingMode blending_mode,
-                           Akira.Models.FillsListModel list_model) {
+    public FillsItemModel (
+        Lib.Models.CanvasItem item,
+        bool hidden,
+        Akira.Utils.BlendingMode blending_mode,
+        Akira.Models.FillsListModel list_model
+    ) {
         Object (
             hidden: hidden,
             blending_mode: blending_mode,
             list_model: list_model,
-            item: item_simple
+            item: item
         );
     }
 

--- a/src/Models/FillsItemModel.vala
+++ b/src/Models/FillsItemModel.vala
@@ -22,41 +22,19 @@
 public class Akira.Models.FillsItemModel : GLib.Object {
     public string color {
         owned get {
-            return item.color;
+            debug (@"Getting color: $(item.color)");
 
-            /*
-            var rgba = item.fill_color_rgba;
-            var result = "#%02x%02x%02x".printf (
-                (int) (Math.round (rgba >> 24 & 0xFF)),
-                (int) (Math.round (rgba >> 16 & 0xFF)),
-                (int) (Math.round (rgba >> 8 & 0xFF))
-            );
-            return result;
-            */
+            return item.color;
         } set {
+            debug (@"Setting color: $value");
             var new_rgba = Gdk.RGBA ();
             new_rgba.parse (value);
 
-            debug (@"R: $(new_rgba.red)");
-            debug (@"G: $(new_rgba.green)");
-            debug (@"B: $(new_rgba.blue)");
-
             var alpha = item.fill_alpha * item.opacity;
 
-            uint rgba = (uint) Math.round (new_rgba.red * 255);
-            rgba = (rgba << 8) + (uint)Math.round (new_rgba.green * 255);
-            rgba = (rgba << 8) + (uint)Math.round (new_rgba.blue * 255);
-            rgba = (rgba << 8) + (uint)Math.round (alpha);
+            new_rgba.alpha = alpha;
 
-            var new_color_hex = "#%02x%02x%02x".printf (
-                (int) (Math.round (rgba >> 24 & 0xFF)),
-                (int) (Math.round (rgba >> 16 & 0xFF)),
-                (int) (Math.round (rgba >> 8 & 0xFF))
-            );
-
-            debug (@"New color: $(new_color_hex)");
-
-            item.color = new_color_hex;
+            item.color = new_rgba.to_string ();
         }
     }
     public double alpha {
@@ -76,6 +54,7 @@ public class Akira.Models.FillsItemModel : GLib.Object {
             */
         }
     }
+
     public bool hidden { get; set; }
     public Akira.Utils.BlendingMode blending_mode { get; set; }
     public Akira.Models.FillsListModel list_model { get; set; }

--- a/src/Models/FillsListModel.vala
+++ b/src/Models/FillsListModel.vala
@@ -43,13 +43,14 @@ public class Akira.Models.FillsListModel : GLib.Object, GLib.ListModel {
         return typeof (Akira.Models.FillsItemModel);
     }
 
-    public async void add (Goo.CanvasItemSimple item) {
-        var model_item = new Akira.Models.FillsItemModel (
+    public async void add (Lib.Models.CanvasItem item) {
+        var model_item = new Models.FillsItemModel (
             item,
             false,
             Akira.Utils.BlendingMode.NORMAL,
             this
         );
+
         fills_list.append (model_item);
 
         items_changed (get_n_items () - 1, 0, 1);

--- a/src/Utils/Color.vala
+++ b/src/Utils/Color.vala
@@ -24,7 +24,7 @@ public class Akira.Utils.Color : Object {
         var rgba = Gdk.RGBA ();
         rgba.parse (rgba_string);
 
-        return "#%02x%02x%02x".printf(
+        return "#%02x%02x%02x".printf (
             (int) (rgba.red * 255),
             (int) (rgba.green * 255),
             (int) (rgba.blue * 255)
@@ -49,5 +49,16 @@ public class Akira.Utils.Color : Object {
         // we can assume that, if it's arrived here
         // the content is only 0-9A-F
         return true;
+    }
+
+    public static uint rgba_to_uint (Gdk.RGBA rgba) {
+        uint uint_rgba = 0;
+
+        uint_rgba |= ((uint) (rgba.red * 255)) << 24;
+        uint_rgba |= ((uint) (rgba.green * 255)) << 16;
+        uint_rgba |= ((uint) (rgba.blue * 255)) << 8;
+        uint_rgba |= ((uint) (rgba.alpha * 255));
+
+        return uint_rgba;
     }
 }

--- a/src/Utils/Color.vala
+++ b/src/Utils/Color.vala
@@ -32,11 +32,22 @@ public class Akira.Utils.Color : Object {
     }
 
     public static string hex_to_rgba (string hex) {
-        debug (@"Hex: $(hex)");
+        var rgba = Gdk.RGBA ();
+        rgba.parse (hex);
+
+        return rgba.to_string ();
+    }
+
+    public static bool is_valid_hex (string hex) {
         var hex_values = hex.split ("#") [1];
 
-        debug (@"hex values: $(hex_values)");
+        if (hex_values.length != 3 && hex_values.length != 6) {
+            return false;
+        }
 
-        return hex_values;
+        // Since validation is done inside the insert-text
+        // we can assume that, if it's arrived here
+        // the content is only 0-9A-F
+        return true;
     }
 }

--- a/src/Utils/Color.vala
+++ b/src/Utils/Color.vala
@@ -1,0 +1,42 @@
+/*
+* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+*
+* This file is part of Akira.
+*
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+*
+* Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+*/
+
+public class Akira.Utils.Color : Object {
+    public static string rgba_to_hex (string rgba_string) {
+        var rgba = Gdk.RGBA ();
+        rgba.parse (rgba_string);
+
+        return "#%02x%02x%02x".printf(
+            (int) (rgba.red * 255),
+            (int) (rgba.green * 255),
+            (int) (rgba.blue * 255)
+        );
+    }
+
+    public static string hex_to_rgba (string hex) {
+        debug (@"Hex: $(hex)");
+        var hex_values = hex.split ("#") [1];
+
+        debug (@"hex values: $(hex_values)");
+
+        return hex_values;
+    }
+}

--- a/src/Utils/Color.vala
+++ b/src/Utils/Color.vala
@@ -39,6 +39,10 @@ public class Akira.Utils.Color : Object {
     }
 
     public static bool is_valid_hex (string hex) {
+        if (hex == "") {
+            return false;
+        }
+
         var hex_values = hex.split ("#") [1];
 
         if (hex_values.length != 3 && hex_values.length != 6) {

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -144,12 +144,17 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
 
         fill_color.color_set.connect (() => {
             var rgba = fill_color.get_rgba ();
+
             //Gdk.RGBA uses rgb() if alpha is 1.
-            string rgba_str = "rgba(%f,%f,%f,%f)" .printf (rgba.red * 255,
-                                                          rgba.green * 255,
-                                                          rgba.blue * 255,
-                                                          rgba.alpha);
+            string rgba_str = "rgba(%d,%d,%d,%d)" .printf (
+                (int) (rgba.red * 255),
+                (int) (rgba.green * 255),
+                (int) (rgba.blue * 255),
+                (int) (rgba.alpha)
+            );
+
             debug ("setting color: %s", rgba_str);
+
             settings.fill_color = rgba_str;
         });
 
@@ -169,12 +174,17 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
 
         border_color.color_set.connect (() => {
             var rgba = border_color.get_rgba ();
+
             //Gdk.RGBA uses rgb() if alpha is 1.
-            string rgba_str = "rgba(%f,%f,%f,%f)".printf (rgba.red * 255,
-                                                         rgba.green * 255,
-                                                         rgba.blue * 255,
-                                                         rgba.alpha);
+            string rgba_str = "rgba(%d,%d,%d,%d)".printf (
+                (int) (rgba.red * 255),
+                (int) (rgba.green * 255),
+                (int) (rgba.blue * 255),
+                (int) (rgba.alpha)
+            );
+
             debug ("setting color: %s", rgba_str);
+
             settings.border_color = rgba_str;
         });
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -32,6 +32,7 @@ sources = files(
     'Utils/Dialogs.vala',
     'Utils/BlendingMode.vala',
     'Utils/AffineTransform.vala',
+    'Utils/Color.vala',
 
     'Layouts/HeaderBar.vala',
     'Layouts/LeftSideBar.vala',


### PR DESCRIPTION
## Summary
This PR is intended for restoring the connection between the currently selected object and the fill item panel, with the new EventBus centric approach.

## Things To Do

- [x] Restore connection of fill-item on object selection
- [x] In color file-entry only 0-9A-F chars can be inserted
- [x] Background color change using color picker
- [x] Alpha change using color picker
- [x] Set color in color entry only with hex characters
- [x] Change color and opacity for Ellipse
- [x] Change color and opacity for Text

## Known Issues

* Opacity and alpha rounding: I think we should deal better with opacity and alpha values. I also think that having an integer range between 0 and 100 (backed by an uint) would be enough, as this would improve the rouding of the values between the sliders, the model and the entries. 

* The CanvasItem interface it's not the most suitable place to code the "common" logic, since it's not possible to set and get properties directly. I think we should modify the way in which we inherit the canvas item, maybe by defining a common class (not an interface) with all the common properties set (color, border_color, alpha, opacity, width, height, x, y, etc) and with a custom "item" that should be populated (together with the other specific properties) in the subclasses (like CanvasRect, CanvasEllipse, CanvasText, CanvasImage, CanvasPath, etc). This needs to be better discussed, but I think it's necessary to evolve organically and not being forced to dirty hacks and workarounds.