### PR TITLE
Canvas pan with SPACE + drag and middle mouse drag

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -211,6 +211,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
             case EditMode.MODE_PAN:
                 set_cursor_by_edit_mode ();
+
+                canvas_scroll_set_origin (temp_event_x, temp_event_y);
                 break;
         }
 
@@ -260,6 +262,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 break;
 
             case EditMode.MODE_PAN:
+                canvas_moved (event_x, event_y);
                 break;
         }
 
@@ -303,7 +306,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     private void set_cursor (Gdk.CursorType? cursor_type) {
-        debug (@"Setting cursor: $cursor_type");
+        // debug (@"Setting cursor: $cursor_type");
         current_cursor = cursor_type;
 
         var cursor = new Gdk.Cursor.for_display (Gdk.Display.get_default (), cursor_type);

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -168,6 +168,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         hover_manager.remove_hover_effect ();
 
+        if (event.button == Gdk.BUTTON_MIDDLE) {
+            edit_mode = EditMode.MODE_PAN;
+        }
+
         switch (edit_mode) {
             case EditMode.MODE_INSERT:
                 selected_bound_manager.reset_selection ();
@@ -225,6 +229,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
 
         holding = false;
+
+        if (event.button == Gdk.BUTTON_MIDDLE) {
+            edit_mode = EditMode.MODE_SELECTION;
+        }
 
         //item_moved (selected_item);
         //add_hover_effect (selected_item);

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -28,6 +28,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
     private double initial_event_x;
     private double initial_event_y;
     private Goo.CanvasItem hover_effect;
+    private Lib.Managers.NobManager.Nob current_hovering_nob;
 
     public HoverManager (Akira.Lib.Canvas canvas) {
         Object (
@@ -42,11 +43,11 @@ public class Akira.Lib.Managers.HoverManager : Object {
 
     public void add_hover_effect (double event_x, double event_y) {
         remove_hover_effect ();
-        set_cursor_for_nob (Managers.NobManager.Nob.NONE);
 
         var target = canvas.get_item_at (event_x, event_y, true);
 
         if (target == null) {
+            set_cursor_for_nob (Managers.NobManager.Nob.NONE);
             return;
         }
 
@@ -86,6 +87,8 @@ public class Akira.Lib.Managers.HoverManager : Object {
                 hover_effect.set ("parent", canvas.get_root_item ());
                 hover_effect.can_focus = false;
             }
+
+            set_cursor_for_nob (Managers.NobManager.Nob.NONE);
         }
 
         if (target is Selection.Nob) {
@@ -103,7 +106,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
         }
     }
 
-    private void set_cursor_for_nob (int grabbed_id) {
+    private void set_cursor_for_nob (Lib.Managers.NobManager.Nob grabbed_id) {
         Gdk.CursorType? selected_cursor = null;
 
         switch (grabbed_id) {
@@ -139,6 +142,9 @@ public class Akira.Lib.Managers.HoverManager : Object {
                 break;
         }
 
-        canvas.window.event_bus.request_change_cursor (selected_cursor);
+        if (grabbed_id != current_hovering_nob) {
+            canvas.window.event_bus.request_change_cursor (selected_cursor);
+            current_hovering_nob = grabbed_id;
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR is intended for restoring canvas pan with space + drag and middle mouse drag.

## Things To Do

- [x] Add MODE_PAN to canvas
- [x] Add PAN with SPACE + drag
- [x] Add PAN with middle mouse button drag

## Known Issues

* `Gdk.CursorType` does not have the "grabbing" icon. In order to have it, we need to change the way in which we set the cursor (like changing from "set_cursor" to "set_cursor_from_name"). It is better to add a "set_cursor_by_name" method (doubling the "current_cursor" logic to prevent looping and repetition) or do we change the way in which we set the cursor? 