### PR TITLE
Improve EventBus

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -31,7 +31,7 @@ public class Akira.Application : Gtk.Application {
     construct {
         flags |= ApplicationFlags.HANDLES_OPEN;
 
-        event_bus = new Akira.Services.EventBus ();
+        event_bus = Akira.Services.EventBus.get_default ();
         settings = new Akira.Services.Settings ();
         windows = new GLib.List<Window> ();
         opened_files = new Gee.HashMap<string, Akira.Window> ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -21,7 +21,6 @@
 
 namespace Akira {
     public Akira.Services.Settings settings;
-    public Akira.Services.EventBus event_bus;
 }
 
 public class Akira.Application : Gtk.Application {
@@ -31,7 +30,6 @@ public class Akira.Application : Gtk.Application {
     construct {
         flags |= ApplicationFlags.HANDLES_OPEN;
 
-        event_bus = Akira.Services.EventBus.get_default ();
         settings = new Akira.Services.Settings ();
         windows = new GLib.List<Window> ();
         opened_files = new Gee.HashMap<string, Akira.Window> ();

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -75,41 +75,41 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 
         zoom = new Akira.Partials.ZoomButton (window);
 
-        group = new Akira.Partials.HeaderBarButton ("object-group", _("Group"), {"<Ctrl>g"}, "multiple");
-        ungroup = new Akira.Partials.HeaderBarButton ("object-ungroup", _("Ungroup"), {"<Ctrl><Shift>g"}, "group");
+        group = new Akira.Partials.HeaderBarButton (window, "object-group", _("Group"), {"<Ctrl>g"}, "multiple");
+        ungroup = new Akira.Partials.HeaderBarButton (window, "object-ungroup", _("Ungroup"), {"<Ctrl><Shift>g"}, "group");
 
-        move_up = new Akira.Partials.HeaderBarButton ("selection-raise", _("Up"), {"<Ctrl>Up"}, "single");
+        move_up = new Akira.Partials.HeaderBarButton (window, "selection-raise", _("Up"), {"<Ctrl>Up"}, "single");
         move_up.button.clicked.connect (() => {
             //window.main_window.main_canvas.canvas.change_z_selected (true, false);
         });
-        move_down = new Akira.Partials.HeaderBarButton ("selection-lower", _("Down"), {"<Ctrl>Down"}, "single");
+        move_down = new Akira.Partials.HeaderBarButton (window, "selection-lower", _("Down"), {"<Ctrl>Down"}, "single");
         move_down.button.clicked.connect (() => {
             //window.main_window.main_canvas.canvas.change_z_selected (false, false);
         });
-        move_top = new Akira.Partials.HeaderBarButton ("selection-top", _("Top"), {"<Ctrl><Shift>Up"}, "single");
+        move_top = new Akira.Partials.HeaderBarButton (window, "selection-top", _("Top"), {"<Ctrl><Shift>Up"}, "single");
         move_top.button.clicked.connect (() => {
             //window.main_window.main_canvas.canvas.change_z_selected (true, true);
         });
-        move_bottom = new Akira.Partials.HeaderBarButton ("selection-bottom", _("Bottom"), {"<Ctrl><Shift>Down"},
+        move_bottom = new Akira.Partials.HeaderBarButton (window, "selection-bottom", _("Bottom"), {"<Ctrl><Shift>Down"},
             "single");
         move_bottom.button.clicked.connect (() => {
             //window.main_window.main_canvas.canvas.change_z_selected (false, true);
         });
 
-        preferences = new Akira.Partials.HeaderBarButton ("open-menu", _("Settings"), {"<Ctrl>comma"});
+        preferences = new Akira.Partials.HeaderBarButton (window, "open-menu", _("Settings"), {"<Ctrl>comma"});
         preferences.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX
             + Akira.Services.ActionManager.ACTION_PREFERENCES;
         preferences.sensitive = true;
 
-        export = new Akira.Partials.HeaderBarButton ("document-export", _("Export"), {"<Ctrl><Shift>E"});
+        export = new Akira.Partials.HeaderBarButton (window, "document-export", _("Export"), {"<Ctrl><Shift>E"});
         export.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX
             + Akira.Services.ActionManager.ACTION_EXPORT;
         export.sensitive = true;
 
-        path_difference = new Akira.Partials.HeaderBarButton ("path-difference", _("Difference"), null, "multiple");
-        path_exclusion = new Akira.Partials.HeaderBarButton ("path-exclusion", _("Exclusion"), null, "multiple");
-        path_intersect = new Akira.Partials.HeaderBarButton ("path-intersection", _("Intersect"), null, "multiple");
-        path_union = new Akira.Partials.HeaderBarButton ("path-union", _("Union"), null, "multiple");
+        path_difference = new Akira.Partials.HeaderBarButton (window, "path-difference", _("Difference"), null, "multiple");
+        path_exclusion = new Akira.Partials.HeaderBarButton (window, "path-exclusion", _("Exclusion"), null, "multiple");
+        path_intersect = new Akira.Partials.HeaderBarButton (window, "path-intersection", _("Intersect"), null, "multiple");
+        path_union = new Akira.Partials.HeaderBarButton (window, "path-union", _("Union"), null, "multiple");
 
         pack_start (menu);
         pack_start (items);
@@ -305,7 +305,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 
     private void build_signals () {
         // TODO: deal with signals not part of accelerators
-        event_bus.close_popover.connect (() => {
+        window.event_bus.close_popover.connect (() => {
             popover_insert.closed ();
         });
     }

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -75,41 +75,52 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 
         zoom = new Akira.Partials.ZoomButton (window);
 
-        group = new Akira.Partials.HeaderBarButton (window, "object-group", _("Group"), {"<Ctrl>g"}, "multiple");
-        ungroup = new Akira.Partials.HeaderBarButton (window, "object-ungroup", _("Ungroup"), {"<Ctrl><Shift>g"}, "group");
+        group =new Akira.Partials.HeaderBarButton (window, "object-group",
+            _("Group"), {"<Ctrl>g"}, "multiple");
+        ungroup = new Akira.Partials.HeaderBarButton (window, "object-ungroup",
+            _("Ungroup"), {"<Ctrl><Shift>g"}, "group");
 
-        move_up = new Akira.Partials.HeaderBarButton (window, "selection-raise", _("Up"), {"<Ctrl>Up"}, "single");
+        move_up = new Akira.Partials.HeaderBarButton (window, "selection-raise",
+            _("Up"), {"<Ctrl>Up"}, "single");
         move_up.button.clicked.connect (() => {
             //window.main_window.main_canvas.canvas.change_z_selected (true, false);
         });
-        move_down = new Akira.Partials.HeaderBarButton (window, "selection-lower", _("Down"), {"<Ctrl>Down"}, "single");
+        move_down = new Akira.Partials.HeaderBarButton (window, "selection-lower",
+            _("Down"), {"<Ctrl>Down"}, "single");
         move_down.button.clicked.connect (() => {
             //window.main_window.main_canvas.canvas.change_z_selected (false, false);
         });
-        move_top = new Akira.Partials.HeaderBarButton (window, "selection-top", _("Top"), {"<Ctrl><Shift>Up"}, "single");
+        move_top = new Akira.Partials.HeaderBarButton (window, "selection-top",
+            _("Top"), {"<Ctrl><Shift>Up"}, "single");
         move_top.button.clicked.connect (() => {
             //window.main_window.main_canvas.canvas.change_z_selected (true, true);
         });
-        move_bottom = new Akira.Partials.HeaderBarButton (window, "selection-bottom", _("Bottom"), {"<Ctrl><Shift>Down"},
-            "single");
+        move_bottom = new Akira.Partials.HeaderBarButton (window, "selection-bottom",
+            _("Bottom"), {"<Ctrl><Shift>Down"}, "single");
         move_bottom.button.clicked.connect (() => {
             //window.main_window.main_canvas.canvas.change_z_selected (false, true);
         });
 
-        preferences = new Akira.Partials.HeaderBarButton (window, "open-menu", _("Settings"), {"<Ctrl>comma"});
+        preferences = new Akira.Partials.HeaderBarButton (window, "open-menu",
+            _("Settings"), {"<Ctrl>comma"});
         preferences.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX
             + Akira.Services.ActionManager.ACTION_PREFERENCES;
         preferences.sensitive = true;
 
-        export = new Akira.Partials.HeaderBarButton (window, "document-export", _("Export"), {"<Ctrl><Shift>E"});
+        export = new Akira.Partials.HeaderBarButton (window, "document-export",
+            _("Export"), {"<Ctrl><Shift>E"});
         export.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX
             + Akira.Services.ActionManager.ACTION_EXPORT;
         export.sensitive = true;
 
-        path_difference = new Akira.Partials.HeaderBarButton (window, "path-difference", _("Difference"), null, "multiple");
-        path_exclusion = new Akira.Partials.HeaderBarButton (window, "path-exclusion", _("Exclusion"), null, "multiple");
-        path_intersect = new Akira.Partials.HeaderBarButton (window, "path-intersection", _("Intersect"), null, "multiple");
-        path_union = new Akira.Partials.HeaderBarButton (window, "path-union", _("Union"), null, "multiple");
+        path_difference = new Akira.Partials.HeaderBarButton (window, "path-difference",
+            _("Difference"), null, "multiple");
+        path_exclusion = new Akira.Partials.HeaderBarButton (window, "path-exclusion",
+            _("Exclusion"), null, "multiple");
+        path_intersect = new Akira.Partials.HeaderBarButton (window, "path-intersection",
+            _("Intersect"), null, "multiple");
+        path_union = new Akira.Partials.HeaderBarButton (window, "path-union",
+            _("Union"), null, "multiple");
 
         pack_start (menu);
         pack_start (items);

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -219,7 +219,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         attach (group_title (_("Opacity")), 0, 9, 3);
         attach (opacity_grid, 0, 10, 3);
 
-        event_bus.selected_items_changed.connect (on_selected_items_changed);
+        window.event_bus.selected_items_changed.connect (on_selected_items_changed);
     }
 
     private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {
@@ -345,19 +345,19 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     }
 
     public void y_notify_value () {
-        event_bus.request_selection_bound_transform ("y", y.value);
+        window.event_bus.request_selection_bound_transform ("y", y.value);
     }
 
     public void x_notify_value () {
-        event_bus.request_selection_bound_transform ("x", x.value);
+        window.event_bus.request_selection_bound_transform ("x", x.value);
     }
 
     public void rotation_notify_value () {
-        event_bus.request_selection_bound_transform ("rotation", rotation.value);
+        window.event_bus.request_selection_bound_transform ("rotation", rotation.value);
     }
 
     public void height_notify_value () {
-        event_bus.request_selection_bound_transform ("height", height.value);
+        window.event_bus.request_selection_bound_transform ("height", height.value);
 
         if (size_lock) {
             width.value = height.value * size_ratio;
@@ -367,7 +367,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     }
 
     public void width_notify_value () {
-        event_bus.request_selection_bound_transform ("width", width.value);
+        window.event_bus.request_selection_bound_transform ("width", width.value);
 
         if (size_lock) {
             height.value = width.value / size_ratio;

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -81,9 +81,9 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         nob_manager = new Managers.NobManager (this);
         hover_manager = new Managers.HoverManager (this);
 
-        event_bus.request_zoom.connect (on_request_zoom);
-        event_bus.request_change_cursor.connect (on_request_change_cursor);
-        event_bus.set_focus_on_canvas.connect (focus_canvas);
+        window.event_bus.request_zoom.connect (on_request_zoom);
+        window.event_bus.request_change_cursor.connect (on_request_change_cursor);
+        window.event_bus.set_focus_on_canvas.connect (focus_canvas);
     }
 
     public void update_bounds () {
@@ -212,7 +212,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         var event_x = event.x / current_scale;
         var event_y = event.y / current_scale;
 
-        event_bus.coordinate_change (event_x, event_y);
+        window.event_bus.coordinate_change (event_x, event_y);
 
         if (!holding) {
             // Only motion_hover_effect
@@ -251,7 +251,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         set_scale (current_scale);
 
-        event_bus.zoom (current_scale);
+        window.event_bus.zoom (current_scale);
     }
 
     private void on_request_change_cursor (Gdk.CursorType? cursor_type) {

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -23,13 +23,13 @@ public class Akira.Lib.Managers.HoverManager : Object {
     private const string STROKE_COLOR = "#41c9fd";
     private const double LINE_WIDTH = 2.0;
 
-    public weak Goo.Canvas canvas { get; construct; }
+    public weak Akira.Lib.Canvas canvas { get; construct; }
 
     private double initial_event_x;
     private double initial_event_y;
     private Goo.CanvasItem hover_effect;
 
-    public HoverManager (Goo.Canvas canvas) {
+    public HoverManager (Akira.Lib.Canvas canvas) {
         Object (
             canvas: canvas
         );
@@ -139,6 +139,6 @@ public class Akira.Lib.Managers.HoverManager : Object {
                 break;
         }
 
-        event_bus.request_change_cursor (selected_cursor);
+        canvas.window.event_bus.request_change_cursor (selected_cursor);
     }
 }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -21,7 +21,7 @@
 
 
 public class Akira.Lib.Managers.ItemsManager : Object {
-    public weak Goo.Canvas canvas { get; construct; }
+    public weak Akira.Lib.Canvas canvas { get; construct; }
 
     public enum InsertType {
         RECT,
@@ -36,7 +36,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     private string border_color;
     private string fill_color;
 
-    public ItemsManager (Goo.Canvas canvas) {
+    public ItemsManager (Akira.Lib.Canvas canvas) {
         Object (
             canvas: canvas
         );
@@ -46,7 +46,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         root = canvas.get_root_item ();
         items = new List<Models.CanvasItem> ();
 
-        event_bus.insert_item.connect (set_item_to_insert);
+        canvas.window.event_bus.insert_item.connect (set_item_to_insert);
     }
 
     public bool set_insert_type_from_key (uint keyval) {

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -44,7 +44,7 @@ public class Akira.Lib.Managers.NobManager : Object {
         ROTATE
     }
 
-    public weak Goo.Canvas canvas { get; construct; }
+    public weak Akira.Lib.Canvas canvas { get; construct; }
 
     public Nob selected_nob;
 
@@ -59,7 +59,7 @@ public class Akira.Lib.Managers.NobManager : Object {
     private double nob_size;
     private double current_scale = 1.0;
 
-    public NobManager (Goo.Canvas canvas) {
+    public NobManager (Akira.Lib.Canvas canvas) {
         Object (
             canvas: canvas
         );
@@ -68,8 +68,8 @@ public class Akira.Lib.Managers.NobManager : Object {
     construct {
         root = canvas.get_root_item ();
 
-        event_bus.selected_items_changed.connect (on_add_select_effect);
-        event_bus.zoom.connect (on_zoom);
+        canvas.window.event_bus.selected_items_changed.connect (on_add_select_effect);
+        canvas.window.event_bus.zoom.connect (on_zoom);
     }
 
     public void set_selected_by_name (Nob selected_nob) {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -21,7 +21,7 @@
 
 public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
-    public weak Goo.Canvas canvas { get; construct; }
+    public weak Akira.Lib.Canvas canvas { get; construct; }
 
     private unowned List<Models.CanvasItem> _selected_items;
     public unowned List<Models.CanvasItem> selected_items {
@@ -42,12 +42,14 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     private double initial_width;
     private double initial_height;
 
-    public SelectedBoundManager (Goo.Canvas canvas) {
+    public SelectedBoundManager (Akira.Lib.Canvas canvas) {
         Object (
             canvas: canvas
         );
 
-        event_bus.request_selection_bound_transform.connect (on_request_selection_bound_transform);
+        canvas.window.event_bus.request_selection_bound_transform.connect (
+            on_request_selection_bound_transform
+        );
     }
 
     construct {
@@ -139,7 +141,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     }
 
     private void update_selected_items () {
-        event_bus.selected_items_changed (selected_items);
+        canvas.window.event_bus.selected_items_changed (selected_items);
     }
 
     private void on_request_selection_bound_transform (string property, double amount) {

--- a/src/Lib/Selection/Nob.vala
+++ b/src/Lib/Selection/Nob.vala
@@ -43,7 +43,7 @@ public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
 
         set_rectangle ();
 
-        event_bus.zoom.connect (on_zoom);
+        (root.get_canvas () as Akira.Lib.Canvas).window.event_bus.zoom.connect (on_zoom);
     }
 
     construct {

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -51,7 +51,7 @@ public class Akira.Partials.AlignBoxButton : Gtk.Button {
 
     private void connect_signals () {
         clicked.connect (() => {
-            event_bus.align_items (action);
+            window.event_bus.align_items (action);
         });
     }
 }

--- a/src/Partials/AlignBoxButton.vala
+++ b/src/Partials/AlignBoxButton.vala
@@ -51,7 +51,7 @@ public class Akira.Partials.AlignBoxButton : Gtk.Button {
 
     private void connect_signals () {
         clicked.connect (() => {
-            event_bus.emit ("align-items", action);
+            event_bus.align_items (action);
         });
     }
 }

--- a/src/Partials/HeaderBarButton.vala
+++ b/src/Partials/HeaderBarButton.vala
@@ -20,12 +20,15 @@
 */
 
 public class Akira.Partials.HeaderBarButton : Gtk.Grid {
+    public weak Akira.Window window;
     public Gtk.Button button;
     private Gtk.Label label_btn;
     public Akira.Partials.ButtonImage image;
     public string? sensitive_type;
 
-    public HeaderBarButton (string icon_name, string name, string[]? accels = null, string? type = null) {
+    public HeaderBarButton (Akira.Window _window, string icon_name, string name,
+        string[]? accels = null,string? type = null) {
+        window = _window;
         sensitive_type = type;
         label_btn = new Gtk.Label (name);
         label_btn.get_style_context ().add_class ("headerbar-label");
@@ -59,7 +62,7 @@ public class Akira.Partials.HeaderBarButton : Gtk.Grid {
     }
 
     private void build_signals () {
-        event_bus.change_sensitivity.connect ((type) => {
+        window.event_bus.change_sensitivity.connect ((type) => {
             if (type == sensitive_type) {
                 sensitive = !sensitive;
             }

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -92,7 +92,7 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         zoom_out_button.sensitive = true;
         zoom_default_button.label = "%.0f%%".printf (zoom);
 
-        event_bus.emit ("request-zoom", "out");
+        event_bus.request_zoom ("out");
 
         /*
         window.main_window.main_canvas.canvas.set_scale (window.main_window.main_canvas.canvas.get_scale () - 0.1);
@@ -110,7 +110,7 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         zoom_in_button.sensitive = true;
         zoom_default_button.label = "%.0f%%".printf (zoom);
 
-        event_bus.emit ("request-zoom", "in");
+        event_bus.request_zoom ("in");
 
         /*
         window.main_window.main_canvas.canvas.set_scale (window.main_window.main_canvas.canvas.get_scale () + 0.1);
@@ -123,7 +123,7 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         zoom_out_button.sensitive = true;
         zoom_default_button.label = "100%";
 
-        event_bus.emit ("request-zoom", "reset");
+        event_bus.request_zoom ("reset");
         /*
         window.main_window.main_canvas.canvas.set_scale (1);
         window.main_window.main_canvas.canvas.reset_select ();

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -92,7 +92,7 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         zoom_out_button.sensitive = true;
         zoom_default_button.label = "%.0f%%".printf (zoom);
 
-        event_bus.request_zoom ("out");
+        window.event_bus.request_zoom ("out");
 
         /*
         window.main_window.main_canvas.canvas.set_scale (window.main_window.main_canvas.canvas.get_scale () - 0.1);
@@ -110,7 +110,7 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         zoom_in_button.sensitive = true;
         zoom_default_button.label = "%.0f%%".printf (zoom);
 
-        event_bus.request_zoom ("in");
+        window.event_bus.request_zoom ("in");
 
         /*
         window.main_window.main_canvas.canvas.set_scale (window.main_window.main_canvas.canvas.get_scale () + 0.1);
@@ -123,7 +123,7 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         zoom_out_button.sensitive = true;
         zoom_default_button.label = "100%";
 
-        event_bus.request_zoom ("reset");
+        window.event_bus.request_zoom ("reset");
         /*
         window.main_window.main_canvas.canvas.set_scale (1);
         window.main_window.main_canvas.canvas.reset_select ();

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -189,8 +189,8 @@ public class Akira.Services.ActionManager : Object {
     private void action_rect_tool () {
         window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
         //window.main_window.main_canvas.canvas.insert_type = Akira.Lib.Canvas.InsertType.RECT;
-        event_bus.emit ("insert-item", "rectangle");
-        event_bus.emit ("close-popover", "insert");
+        event_bus.insert_item ("rectangle");
+        event_bus.close_popover ("insert");
     }
 
     private void action_selection_tool () {
@@ -205,15 +205,15 @@ public class Akira.Services.ActionManager : Object {
     private void action_ellipse_tool () {
         window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
         //window.main_window.main_canvas.canvas.insert_type = Akira.Lib.Canvas.InsertType.ELLIPSE;
-        event_bus.emit ("insert-item", "ellipse");
-        event_bus.emit ("close-popover", "insert");
+        event_bus.insert_item ("ellipse");
+        event_bus.close_popover ("insert");
     }
 
     private void action_text_tool () {
         window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
         //window.main_window.main_canvas.canvas.insert_type = Akira.Lib.Canvas.InsertType.TEXT;
-        event_bus.emit ("insert-item", "text");
-        event_bus.emit ("close-popover", "insert");
+        event_bus.insert_item ("text");
+        event_bus.close_popover ("insert");
     }
 
     public static void action_from_group (string action_name, ActionGroup? action_group) {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -148,8 +148,7 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_preferences () {
-        var settings_dialog = new Akira.Widgets.SettingsDialog ();
-        settings_dialog.transient_for = window;
+        var settings_dialog = new Akira.Widgets.SettingsDialog (window);
         settings_dialog.show_all ();
         settings_dialog.present ();
     }
@@ -189,8 +188,8 @@ public class Akira.Services.ActionManager : Object {
     private void action_rect_tool () {
         window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
         //window.main_window.main_canvas.canvas.insert_type = Akira.Lib.Canvas.InsertType.RECT;
-        event_bus.insert_item ("rectangle");
-        event_bus.close_popover ("insert");
+        window.event_bus.insert_item ("rectangle");
+        window.event_bus.close_popover ("insert");
     }
 
     private void action_selection_tool () {
@@ -205,15 +204,15 @@ public class Akira.Services.ActionManager : Object {
     private void action_ellipse_tool () {
         window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
         //window.main_window.main_canvas.canvas.insert_type = Akira.Lib.Canvas.InsertType.ELLIPSE;
-        event_bus.insert_item ("ellipse");
-        event_bus.close_popover ("insert");
+        window.event_bus.insert_item ("ellipse");
+        window.event_bus.close_popover ("insert");
     }
 
     private void action_text_tool () {
         window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
         //window.main_window.main_canvas.canvas.insert_type = Akira.Lib.Canvas.InsertType.TEXT;
-        event_bus.insert_item ("text");
-        event_bus.close_popover ("insert");
+        window.event_bus.insert_item ("text");
+        window.event_bus.close_popover ("insert");
     }
 
     public static void action_from_group (string action_name, ActionGroup? action_group) {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -21,16 +21,6 @@
  */
 
 public class Akira.Services.EventBus : Object {
-    static Akira.Services.EventBus? instance = null;
-    public static unowned Akira.Services.EventBus get_default () {
-        if (instance == null) {
-            instance = new Akira.Services.EventBus ();
-        }
-
-        return instance;
-    }
-
-    // List of signals.
     public signal void update_icons_style ();
     public signal void align_items (string align_action);
     public signal void close_popover (string popover);

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -21,6 +21,16 @@
  */
 
 public class Akira.Services.EventBus : Object {
+    static Akira.Services.EventBus? instance = null;
+    public static unowned Akira.Services.EventBus get_default () {
+        if (instance == null) {
+            instance = new Akira.Services.EventBus ();
+        }
+
+        return instance;
+    }
+
+    // List of signals.
     public signal void update_icons_style ();
     public signal void align_items (string align_action);
     public signal void close_popover (string popover);

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Alecaddd (http://alecaddd.com)
+ * Copyright (c) 2019 Alecaddd (https://alecaddd.com)
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
@@ -17,6 +17,7 @@
  * Boston, MA 02110-1301 USA
  *
  * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+ * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
 public class Akira.Services.EventBus : Object {
@@ -32,39 +33,6 @@ public class Akira.Services.EventBus : Object {
     public signal void request_change_cursor (Gdk.CursorType? cursor_type);
     public signal void request_selection_bound_transform (string property, double amount);
     public signal void set_focus_on_canvas ();
-
-    public EventBus () {
-        Object ();
-    }
-
-    public void emit (string signal_id, string param = "") {
-        switch (signal_id) {
-            case "update-icons-style":
-                update_icons_style ();
-                break;
-
-            case "align-items":
-                align_items (param);
-                break;
-
-            case "close-popover":
-                close_popover (param);
-                break;
-
-            case "change-sensitivity":
-                change_sensitivity (param);
-                break;
-
-            case "insert-item":
-                insert_item (param);
-                break;
-
-            case "request-zoom":
-                request_zoom (param);
-                break;
-
-        }
-    }
 
     public void test (string caller_id) {
         debug (@"Test from EventBus called by $(caller_id)");

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -20,7 +20,7 @@
 */
 
 public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
-
+    public weak Akira.Window window { get; construct; }
     private Gtk.Stack stack;
     private Gtk.Switch dark_theme_switch;
     private Gtk.Switch label_switch;
@@ -34,8 +34,9 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
         ICONTYPE
     }
 
-    public SettingsDialog () {
+    public SettingsDialog (Akira.Window _window) {
         Object (
+            window: _window,
             border_width: 5,
             deletable: false,
             resizable: false,
@@ -45,6 +46,7 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
     }
 
     construct {
+        transient_for = window;
         stack = new Gtk.Stack ();
         stack.margin = 6;
         stack.margin_bottom = 15;
@@ -68,7 +70,7 @@ public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
 
         close_button.clicked.connect (() => {
             destroy ();
-            event_bus.set_focus_on_canvas ();
+            window.event_bus.set_focus_on_canvas ();
         });
 
         add_action_widget (close_button, 0);

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -23,6 +23,7 @@ public class Akira.Window : Gtk.ApplicationWindow {
     public FileFormat.AkiraFile? akira_file = null;
 
     public weak Akira.Application app { get; construct; }
+    public Akira.Services.EventBus event_bus;
 
     public Akira.Services.ActionManager action_manager;
     public Akira.Layouts.HeaderBar headerbar;
@@ -47,6 +48,7 @@ public class Akira.Window : Gtk.ApplicationWindow {
         accel_group = new Gtk.AccelGroup ();
         add_accel_group (accel_group);
 
+        event_bus = new Akira.Services.EventBus ();
         action_manager = new Akira.Services.ActionManager (app, this);
         headerbar = new Akira.Layouts.HeaderBar (this);
         main_window = new Akira.Layouts.MainWindow (this);

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -103,7 +103,11 @@ public class Akira.Window : Gtk.ApplicationWindow {
         }
 
         if (edited) {
-            confirmed = dialogs.message_dialog (_("Are you sure you want to quit?"), _("All unsaved data will be lost and impossible to recover."), "system-shutdown", _("Yes, Quit!"));
+            confirmed = dialogs.message_dialog (
+                _("Are you sure you want to quit?"),
+                _("All unsaved data will be lost and impossible to recover."),
+                "system-shutdown",
+                _("Yes, Quit!"));
 
             if (confirmed) {
                 app.get_active_window ().destroy ();


### PR DESCRIPTION
I experimented a lot with the `EventBus` and tried multiple solutions, but ended up going with the easiest and cleaner one by simply calling the signal directly from the `event_bus` singleton.

I think this is the better approach since it doesn't cause us issues in handling a different amount of arguments per signal, and keeps the file clean and easy to update.
I'm not concerned about the lost of logging or history in that file as those can happen directly in the classes receiving those signals.

Just for posterity, here's a list of methods I tried and failed:
- Base everything on anonymous functions to remove the necessity of creating signals.
- Use the `Signal.emit_by_name` to call the signal from its string reference, and passing variable arguments:https://valadoc.org/gobject-2.0/GLib.Signal.emit_by_name.html
- Convert the EventBus into a Subscriber that handles each signal as an anonymous callback method.

All these attempted approaches were kind of OK, but the code was getting pretty verbose and not linear.
I prefer to stick with the default signal emission approach of Vala, which is clean and simple to read and write.

**EventBus as Window's singleton**
Since all our canvas interactions will be based on signals, the `EventBus` can't be a property of the `Gtk.Application` as all the signals will be emitted throughout every single opened Window instance.
I moved the `EventBus` to the `Akira.Window` class and turned it into a singleton.
Now events are containerized and limited to the currently active window.