### PR TITLE
Fix fill item regressions

### DIFF
--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -14,7 +14,7 @@
  * GNU General Public License for more details.
 
  * You should have received a copy of the GNU General Public License
- * along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
  *
  * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
  * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -336,7 +336,6 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         var new_rgba = Gdk.RGBA ();
         new_rgba.parse (color);
         new_rgba.alpha = (double) alpha / 255;
-        debug ("set color chooser");
 
         color_chooser_widget.set_rgba (new_rgba);
     }

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -17,6 +17,7 @@
  * along with Akira.  If not, see <https://www.gnu.org/licenses/>.
  *
  * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+ * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
 public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
@@ -24,8 +25,6 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
     private Gtk.Button hidden_button;
     private Gtk.Button delete_button;
     private Gtk.Image hidden_button_icon;
-    //  private Gtk.Button selected_blending_mode_cont;
-    //  private Gtk.Label selected_blending_mode;
     private Gtk.MenuButton selected_color;
     public Akira.Partials.InputField opacity_container;
     public Gtk.Entry color_container;
@@ -35,16 +34,6 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
 
     public Akira.Models.FillsItemModel model { get; construct; }
 
-    //  private Akira.Utils.BlendingMode blending_mode {
-    //      owned get {
-    //          return model.blending_mode;
-    //      }
-    //      set {
-    //          model.blending_mode = value;
-    //          selected_blending_mode.label = model.blending_mode.get_name ();
-    //      }
-    //  }
-
     private string old_color;
     private bool color_set_manually = false;
     private string color {
@@ -52,8 +41,6 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
             return model.color;
         } set {
             model.color = value;
-
-            set_button_color ();
         }
     }
 
@@ -62,8 +49,6 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
             return model.alpha;
         } set {
             model.alpha = value;
-
-            set_button_color ();
         }
     }
 
@@ -72,13 +57,10 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
             return model.hidden;
         } set {
             model.hidden = value;
-
             set_hidden_button ();
             toggle_ui_visibility ();
         }
     }
-
-    private bool updating { get; set; default = false; }
 
     public signal void remove_item (Akira.Models.FillsItemModel model);
 
@@ -99,7 +81,6 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
 
     private void update_view () {
         hidden = model.hidden;
-        //  blending_mode = model.blending_mode;
         color = model.color;
         old_color = color;
     }
@@ -147,13 +128,8 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
                     return false;
                 }
 
-                color_set_manually = true;
-
                 var new_color_rgba = Utils.Color.hex_to_rgba (color_container_hex);
-
                 model_value.set_string (new_color_rgba);
-                set_button_color (color_container_hex);
-
                 return true;
             },
             // model => this
@@ -210,57 +186,41 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
             }
         });
 
-        //  selected_blending_mode = new Gtk.Label ("");
-        //  selected_blending_mode.hexpand = true;
-        //  selected_blending_mode.halign = Gtk.Align.START;
-
-        //  selected_blending_mode_cont = new Gtk.Button ();
-        //  selected_blending_mode_cont.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        //  selected_blending_mode_cont.can_focus = false;
-        //  selected_blending_mode_cont.hexpand = true;
-        //  selected_blending_mode_cont.add (selected_blending_mode);
-
         opacity_container = new Akira.Partials.InputField (
             Akira.Partials.InputField.Unit.PERCENTAGE, 7, true, true);
         opacity_container.entry.sensitive = true;
         opacity_container.entry.text = Math.round ((double) alpha / 255 * 100).to_string ();
-        opacity_container.entry.bind_property (
-            "text", model, "alpha",
-            BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE,
-            (binding, entry_text_val, ref model_alpha_val) => {
-                double src = double.parse (entry_text_val.dup_string ());
+        //  opacity_container.entry.bind_property (
+        //      "text", model, "alpha",
+        //      BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE,
+        //      (binding, entry_text_val, ref model_alpha_val) => {
+        //          double src = double.parse (entry_text_val.dup_string ());
 
-                if (src > 100) {
-                    src = 100.0;
-                    opacity_container.entry.text = "100";
-                } else if (src < 0) {
-                    src = 0.0;
-                    opacity_container.entry.text = "0";
-                }
+        //          if (src > 100) {
+        //              src = 100.0;
+        //              opacity_container.entry.text = "100";
+        //          } else if (src < 0) {
+        //              src = 0.0;
+        //              opacity_container.entry.text = "0";
+        //          }
+        //          int alpha_int_value = (int) (src / 100 * 255);
 
-                color_set_manually = true;
+        //          model_alpha_val.set_int (alpha_int_value);
 
-                int alpha_int_value = (int) (src / 100 * 255);
+        //          return true;
+        //      }, (binding, model_alpha_val, ref entry_text_val) => {
+        //          double src = (double) model_alpha_val.get_int () / 255;
 
-                model_alpha_val.set_int (alpha_int_value);
+        //          src = Math.round (src * 100);
 
-                set_button_color (null, alpha_int_value);
+        //          entry_text_val.set_string (("%f").printf (src));
 
-                return true;
-            }, (binding, model_alpha_val, ref entry_text_val) => {
-                double src = (double) model_alpha_val.get_int () / 255;
-
-                src = Math.round (src * 100);
-
-                entry_text_val.set_string (("%f").printf (src));
-
-                return true;
-            }
-        );
+        //          return true;
+        //      }
+        //  );
 
         fill_chooser.attach (picker_container, 0, 0, 1, 1);
         fill_chooser.attach (color_container, 1, 0, 1, 1);
-        //  fill_chooser.attach (selected_blending_mode_cont, 1, 0, 1, 1);
         fill_chooser.attach (opacity_container, 2, 0, 1, 1);
 
         hidden_button = new Gtk.Button ();
@@ -277,9 +237,6 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         delete_button.add (new Gtk.Image.from_icon_name ("user-trash-symbolic",
             Gtk.IconSize.SMALL_TOOLBAR));
 
-        //  blending_mode_popover_items = new Gtk.ListBox ();
-        //  blending_mode_popover_items.get_style_context ().add_class ("popover-list");
-
         color_chooser_widget = new Gtk.ColorChooserWidget ();
         color_chooser_widget.hexpand = true;
         color_chooser_widget.show_editor = true;
@@ -291,15 +248,6 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         color_picker.show_all ();
         color_popover.add (color_picker);
 
-        //  var popover_item_index = 0;
-
-        //  foreach (Akira.Utils.BlendingMode mode in Akira.Utils.BlendingMode.all () ) {
-        //      blending_mode_popover_items.insert (
-        //          new Akira.Layouts.Partials.BlendingModeItem (mode),
-        //          popover_item_index++
-        //      );
-        //  }
-
         attach (fill_chooser, 0, 0, 1, 1);
         attach (hidden_button, 1, 0, 1, 1);
         attach (delete_button, 2, 0, 1, 1);
@@ -308,25 +256,22 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
     private void create_event_bindings () {
         delete_button.clicked.connect (on_delete_item);
         hidden_button.clicked.connect (toggle_visibility);
-
-        //  blending_mode_popover_items.row_activated.connect (on_row_activated);
-        //  blending_mode_popover_items.row_selected.connect (on_popover_item_selected);
-
+        model.notify.connect (on_model_changed);
         color_chooser_widget.notify["rgba"].connect (on_color_changed);
     }
 
-    private void on_color_changed () {
-        color = color_chooser_widget.rgba.to_string ();
+    private void on_model_changed () {
+        model.item.reset_colors ();
+        set_button_color ();
+        set_color_chooser_color ();
     }
 
-    //  private void on_row_activated (Gtk.ListBoxRow? item) {
-    //      var fillItem = (Akira.Layouts.Partials.BlendingModeItem)item.get_child ();
-    //      blending_mode = fillItem.mode;
-    //      popover.hide ();
-    //  }
-
-    //  private void on_popover_item_selected (Gtk.ListBoxRow? item) {
-    //  }
+    private void on_color_changed () {
+        color_set_manually = true;
+        color = color_chooser_widget.rgba.to_string ();
+        //  alpha = ((int)(color_chooser_widget.rgba.alpha * 100));
+        //  debug (color);
+    }
 
     private void on_delete_item () {
         remove_item (model);
@@ -353,42 +298,22 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
     private void toggle_ui_visibility () {
         if (hidden) {
             get_style_context ().add_class ("disabled");
-        } else {
-            get_style_context ().remove_class ("disabled");
+            return;
         }
+
+        get_style_context ().remove_class ("disabled");
     }
 
-    private void set_button_color (string? _button_color = null, int? _alpha_int = null) {
-        var button_color = color;
-        var button_alpha = (double) alpha / 255;
-
-        if (_button_color != null) {
-            button_color = (string) _button_color;
-        }
-
-        if (_alpha_int != null) {
-            button_alpha = (double) ((int) _alpha_int) / 255;
-        }
-
-        // Ensure button_color has alpha = 1
-        // real alpha is given by item's alpha
-        var button_color_rgba_no_alpha = Gdk.RGBA ();
-        button_color_rgba_no_alpha.parse (button_color);
-
-        button_color_rgba_no_alpha.alpha = 1.0;
-
-        button_color = button_color_rgba_no_alpha.to_string ();
-
+    private void set_button_color () {
         try {
             var provider = new Gtk.CssProvider ();
             var context = selected_color.get_style_context ();
-
-            var alpha_dot_separator = button_alpha.to_string ().replace (",", ".");
+            var new_alpha = ((double) alpha / 100);
 
             var css = """.selected-color {
-                    background-color: alpha (%s, %s);
-                    border-color: alpha (shade (%s, 0.75), %s);
-                }""".printf (button_color, alpha_dot_separator, button_color, alpha_dot_separator);
+                    background-color: alpha (%s, %f);
+                    border-color: alpha (shade (%s, 0.75), %f);
+                }""".printf (color, new_alpha, color, new_alpha);
 
             provider.load_from_data (css, css.length);
 
@@ -406,10 +331,10 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
             return;
         }
 
+        debug ("set");
         var new_rgba = Gdk.RGBA ();
-
-        new_rgba.parse (model.color);
-        new_rgba.alpha = (double) alpha / 255;
+        new_rgba.parse (color);
+        //  new_rgba.alpha = (double) alpha / 255;
 
         color_chooser_widget.set_rgba (new_rgba);
     }

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -178,7 +178,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
                 return true;
             }, (binding, srcval, ref targetval) => {
                 double src = (double) srcval;
-                targetval.set_string (("%0.1f").printf (src));
+                targetval.set_string (("%0.0f").printf (src));
                 return true;
             }
         );
@@ -312,6 +312,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     public void opacity_notify_value () {
         var opacity_factor = double.parse (opacity_entry.entry.text);
         item.opacity = opacity_factor;
+        item.reset_colors ();
     }
 
     public void y_notify_value () {

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -1,23 +1,23 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019 Alecaddd (https://alecaddd.com)
 *
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
+* This file is part of Akira.
 *
-* This program is distributed in the hope that it will be useful,
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Ana Gelez <ana@gelez.xyz>
-* Edited by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     public weak Akira.Window window { get; construct; }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -204,11 +204,12 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     }
 
     private void udpate_default_values () {
-        border_size = settings.set_border ? settings.border_size : 0.0;
-
-        string border_color_str = settings.set_border ? settings.border_color : "";
-
-        border_color.parse (border_color_str);
         fill_color.parse (settings.fill_color);
+
+        // Do not set the border if the user disabled it.
+        if (settings.set_border) {
+            border_size = settings.border_size;
+            border_color.parse (settings.border_color);
+        }
     }
 }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -24,47 +24,12 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public string id { get; set; }
     public double rotation { get; set; }
     public bool selected { get; set; }
-
-    private double _opacity;
-    public double opacity {
-        get {
-            return _opacity;
-        }
-        set {
-            _opacity = value;
-        }
-    }
-
-    private int _fill_alpha;
-    public int fill_alpha {
-        get {
-            return _fill_alpha;
-        }
-        set {
-            _fill_alpha = value;
-        }
-    }
+    public double opacity { get; set; }
+    public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
-
-    private Gdk.RGBA _color;
-    public Gdk.RGBA color {
-        get {
-            return _color;
-        }
-        set {
-            _color = value;
-        }
-    }
-
-    private Gdk.RGBA _border_color;
-    public Gdk.RGBA border_color {
-        get {
-            return _border_color;
-        }
-        set {
-            _border_color = value;
-        }
-    }
+    public Gdk.RGBA color { get; set; }
+    public double border_size { get; set; }
+    public Gdk.RGBA border_color { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasEllipse (
@@ -100,7 +65,10 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         translate (_center_x, _center_y);
 
         color = _fill_color;
-        border_color = _border_color;
+        if (settings.set_border) {
+            border_color = _border_color;
+            border_size = _border_size;
+        }
         reset_colors ();
     }
 }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -29,10 +29,8 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         get {
             return _opacity;
         }
-        public set {
+        set {
             _opacity = value;
-
-            reset_colors ();
         }
     }
 
@@ -43,7 +41,6 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         }
         set {
             _fill_alpha = value;
-            reset_colors ();
         }
     }
     public int stroke_alpha { get; set; }
@@ -55,8 +52,6 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         }
         set {
             _color = value;
-
-            reset_colors ();
         }
     }
 
@@ -67,8 +62,6 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         }
         set {
             _border_color = value;
-
-            reset_colors ();
         }
     }
     public Models.CanvasItemType item_type { get; set; }
@@ -107,5 +100,6 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
 
         color = _fill_color;
         border_color = _border_color;
+        reset_colors ();
     }
 }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -14,9 +14,10 @@
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
+* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
 public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasItem {

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -36,6 +36,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public abstract int fill_alpha { get; set; }
     public abstract int stroke_alpha { get; set; }
     public abstract Gdk.RGBA color { get; set; }
+    public abstract double border_size { get; set; }
     public abstract Gdk.RGBA border_color { get; set; }
     public abstract Models.CanvasItemType item_type { get; set; }
 
@@ -66,21 +67,25 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
 
     public void reset_colors () {
         var rgba_fill = Gdk.RGBA ();
-        var rgba_stroke = Gdk.RGBA ();
-
-        //  debug (fill_alpha.to_string ());
-
         rgba_fill = color;
+        //  debug (fill_alpha.to_string ());
         rgba_fill.alpha = ((double) fill_alpha) / 255 * opacity / 100;
         //  debug (rgba_fill.alpha.to_string ());
 
-        rgba_stroke = border_color;
-        rgba_stroke.alpha = ((double) stroke_alpha) / 255 * opacity / 100;
-
         uint fill_color_rgba = Utils.Color.rgba_to_uint (rgba_fill);
-        uint stroke_color_rgba = Utils.Color.rgba_to_uint (rgba_stroke);
-
         set ("fill-color-rgba", fill_color_rgba);
-        set ("stroke-color-rgba", stroke_color_rgba);
+
+        if (settings.set_border) {
+            var rgba_stroke = Gdk.RGBA ();
+            rgba_stroke = border_color;
+            rgba_stroke.alpha = ((double) stroke_alpha) / 255 * opacity / 100;
+
+            uint stroke_color_rgba = Utils.Color.rgba_to_uint (rgba_stroke);
+            set ("stroke-color-rgba", stroke_color_rgba);
+            set ("line-width", border_size);
+        } else {
+            set ("stroke-color-rgba", null);
+            set ("line-width", null);
+        }
     }
 }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -14,9 +14,10 @@
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
+* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
 public enum Akira.Lib.Models.CanvasItemType {

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -67,8 +67,11 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         var rgba_fill = Gdk.RGBA ();
         var rgba_stroke = Gdk.RGBA ();
 
+        //  debug (fill_alpha.to_string ());
+
         rgba_fill = color;
         rgba_fill.alpha = ((double) fill_alpha) / 255 * opacity / 100;
+        //  debug (rgba_fill.alpha.to_string ());
 
         rgba_stroke = border_color;
         rgba_stroke.alpha = ((double) stroke_alpha) / 255 * opacity / 100;

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -14,7 +14,7 @@
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
 * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -17,6 +17,7 @@
 * along with Akira.  If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
+* Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
 public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
@@ -29,10 +30,8 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         get {
             return _opacity;
         }
-        public set {
+        set {
             _opacity = value;
-
-            reset_colors ();
         }
     }
 
@@ -43,7 +42,6 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         }
         set {
             _fill_alpha = value;
-            reset_colors ();
         }
     }
     public int stroke_alpha { get; set; }
@@ -55,8 +53,6 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         }
         set {
             _color = value;
-
-            reset_colors ();
         }
     }
 
@@ -67,8 +63,6 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         }
         set {
             _border_color = value;
-
-            reset_colors ();
         }
     }
 
@@ -108,5 +102,6 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
 
         color = _fill_color;
         border_color = _border_color;
+        reset_colors ();
     }
 }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -24,48 +24,12 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public string id { get; set; }
     public bool selected { get; set; }
     public double rotation { get; public set; }
-
-    private double _opacity;
-    public double opacity {
-        get {
-            return _opacity;
-        }
-        set {
-            _opacity = value;
-        }
-    }
-
-    private int _fill_alpha;
-    public int fill_alpha {
-        get {
-            return _fill_alpha;
-        }
-        set {
-            _fill_alpha = value;
-        }
-    }
+    public double opacity { get; set; }
+    public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
-
-    private Gdk.RGBA _color;
-    public Gdk.RGBA color {
-        get {
-            return _color;
-        }
-        set {
-            _color = value;
-        }
-    }
-
-    private Gdk.RGBA _border_color;
-    public Gdk.RGBA border_color {
-        get {
-            return _border_color;
-        }
-        set {
-            _border_color = value;
-        }
-    }
-
+    public Gdk.RGBA color { get; set; }
+    public double border_size { get; set; }
+    public Gdk.RGBA border_color { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasRect (
@@ -101,7 +65,10 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         translate (_x, _y);
 
         color = _fill_color;
-        border_color = _border_color;
+        if (settings.set_border) {
+            border_color = _border_color;
+            border_size = _border_size;
+        }
         reset_colors ();
     }
 }

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -27,6 +27,7 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
     public Gdk.RGBA color { get; set; }
+    public double border_size { get; set; }
     public Gdk.RGBA border_color { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 

--- a/src/Lib/Selection/Nob.vala
+++ b/src/Lib/Selection/Nob.vala
@@ -20,7 +20,7 @@
 */
 public class Akira.Lib.Selection.Nob : Goo.CanvasRect {
     public const double NOB_SIZE = 10;
-    public const double LINE_WIDTH = 2;
+    public const double LINE_WIDTH = 1;
 
     public Managers.NobManager.Nob handle_id;
 

--- a/src/Models/FillsItemModel.vala
+++ b/src/Models/FillsItemModel.vala
@@ -23,10 +23,10 @@ public class Akira.Models.FillsItemModel : GLib.Object {
     public string color {
         owned get {
             return item.color.to_string ();
-        } set {
+        }
+        set {
             var new_rgba = Gdk.RGBA ();
             new_rgba.parse (value);
-
             item.color = new_rgba;
         }
     }

--- a/src/Models/FillsItemModel.vala
+++ b/src/Models/FillsItemModel.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -14,9 +14,10 @@
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+* Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
 public class Akira.Models.FillsItemModel : GLib.Object {


### PR DESCRIPTION
After the merge of #233, lots of regressions were introduced.

Here's a list of what I discovered so far:
- [x] `reset_colors()` method called multiple times at every item selection.
- [x] `set_button_color()` called multiple times at every item selection.
- [x] Alpha value ignored when edited from color picker.
- [x] Border size and color issues from settings since conversion from `string` to `Gdk.RGBA`.

I'm gonna work on this and tackle these issues.
The majority of these issues are due to the verbose code style of handling items, models, and managers. There's a lot of repetition and things can be simplified a lot.