### PR TITLE
Improve SelectBound and FillPanel

### DIFF
--- a/src/Layouts/LeftSideBar.vala
+++ b/src/Layouts/LeftSideBar.vala
@@ -22,7 +22,7 @@
 public class Akira.Layouts.LeftSideBar : Gtk.Grid {
     public weak Akira.Window window { get; construct; }
     public Akira.Layouts.Partials.TransformPanel transform_panel;
-    public Akira.Layouts.Partials.FillsBoxPanel fill_box_panel;
+    public Akira.Layouts.Partials.FillsPanel fills_panel;
 
     public bool toggled {
         get {
@@ -47,7 +47,7 @@ public class Akira.Layouts.LeftSideBar : Gtk.Grid {
         var align_items_panel = new Akira.Layouts.Partials.AlignItemsPanel (window);
         transform_panel = new Akira.Layouts.Partials.TransformPanel (window);
         var style_panel = new Akira.Layouts.Partials.StylePanel ();
-        fill_box_panel = new Akira.Layouts.Partials.FillsBoxPanel (window);
+        fills_panel = new Akira.Layouts.Partials.FillsPanel (window);
 
         var scrolled_window = new Gtk.ScrolledWindow (null, null);
         scrolled_window.expand = true;
@@ -55,7 +55,7 @@ public class Akira.Layouts.LeftSideBar : Gtk.Grid {
         scrolled_grid.expand = true;
         scrolled_grid.attach (transform_panel, 0, 0, 1, 1);
         scrolled_grid.attach (style_panel, 0, 1, 1, 1);
-        scrolled_grid.attach (fill_box_panel, 0, 2, 1, 1);
+        scrolled_grid.attach (fills_panel, 0, 2, 1, 1);
         scrolled_window.add (scrolled_grid);
 
         attach (align_items_panel, 0, 0, 1, 1);

--- a/src/Layouts/LeftSideBar.vala
+++ b/src/Layouts/LeftSideBar.vala
@@ -14,7 +14,7 @@
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -21,6 +21,8 @@
  */
 
 public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
+    public weak Akira.Window window { get; construct; }
+
     private Gtk.Grid fill_chooser;
     private Gtk.Button hidden_button;
     private Gtk.Button delete_button;
@@ -65,10 +67,11 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         }
     }
 
-    public signal void remove_item (Akira.Models.FillsItemModel model);
-
-    public FillItem (Akira.Models.FillsItemModel model) {
-        Object (model: model);
+    public FillItem (Akira.Window window, Akira.Models.FillsItemModel model) {
+        Object (
+            window: window,
+            model: model
+        );
     }
 
     construct {
@@ -277,7 +280,9 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
     }
 
     private void on_delete_item () {
-        remove_item (model);
+        model.list_model.remove_item.begin (model);
+        model.item.reset_colors ();
+        window.event_bus.fill_deleted ();
     }
 
     private void set_hidden_button () {

--- a/src/Layouts/Partials/FillsPanel.vala
+++ b/src/Layouts/Partials/FillsPanel.vala
@@ -28,7 +28,14 @@ public class Akira.Layouts.Partials.FillsPanel : Gtk.Grid {
     public Gtk.Grid title_cont;
     private Lib.Models.CanvasItem selected_item;
 
-    private int last_item_position;
+    public bool toggled {
+        get {
+            return visible;
+        } set {
+            visible = value;
+            no_show_all = !value;
+        }
+    }
 
     public FillsPanel (Akira.Window window) {
         Object (
@@ -38,8 +45,6 @@ public class Akira.Layouts.Partials.FillsPanel : Gtk.Grid {
     }
 
     construct {
-        last_item_position = 0;
-
         title_cont = new Gtk.Grid ();
         title_cont.orientation = Gtk.Orientation.HORIZONTAL;
         title_cont.hexpand = true;
@@ -78,16 +83,13 @@ public class Akira.Layouts.Partials.FillsPanel : Gtk.Grid {
 
         attach (title_cont, 0, 0, 1, 1);
         attach (fills_list_container, 0, 1, 1, 1);
+        show_all ();
 
         create_event_bindings ();
     }
 
-    private void toggle_add_btn (bool show) {
-        add_btn.visible = show;
-        add_btn.no_show_all = !show;
-    }
-
     private void create_event_bindings () {
+        toggled = false;
         window.event_bus.selected_items_changed.connect (on_selected_items_changed);
         window.event_bus.fill_deleted.connect (() => {
             toggle_add_btn (true);
@@ -104,10 +106,12 @@ public class Akira.Layouts.Partials.FillsPanel : Gtk.Grid {
             selected_item = null;
             fills_list_model.clear.begin ();
             toggle_add_btn (false);
+            toggled = false;
             return;
         }
 
         if (selected_item == null || selected_item != selected_items.nth_data (0)) {
+            toggled = true;
             selected_item = selected_items.nth_data (0);
 
             if (!selected_item.has_fill) {
@@ -117,5 +121,10 @@ public class Akira.Layouts.Partials.FillsPanel : Gtk.Grid {
 
             fills_list_model.add.begin (selected_item);
         }
+    }
+
+    private void toggle_add_btn (bool show) {
+        add_btn.visible = show;
+        add_btn.no_show_all = !show;
     }
 }

--- a/src/Layouts/Partials/FillsPanel.vala
+++ b/src/Layouts/Partials/FillsPanel.vala
@@ -19,7 +19,7 @@
 * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
 */
 
-public class Akira.Layouts.Partials.FillsBoxPanel : Gtk.Grid {
+public class Akira.Layouts.Partials.FillsPanel : Gtk.Grid {
     public weak Akira.Window window { get; construct; }
 
     public Gtk.Button add_btn;
@@ -30,7 +30,7 @@ public class Akira.Layouts.Partials.FillsBoxPanel : Gtk.Grid {
 
     private int last_item_position;
 
-    public FillsBoxPanel (Akira.Window window) {
+    public FillsPanel (Akira.Window window) {
         Object (
             window: window,
             orientation: Gtk.Orientation.HORIZONTAL

--- a/src/Layouts/Partials/StylePanel.vala
+++ b/src/Layouts/Partials/StylePanel.vala
@@ -1,26 +1,26 @@
 /*
- * Copyright (c) 2019 Alecaddd (http://alecaddd.com)
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
- *
- * Authored by: Bilal Elmoussaoui <bil.elmoussaoui@gmail.com>
- */
+* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+*
+* This file is part of Akira.
+*
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
+*
+* Authored by: Bilal Elmoussaoui <bil.elmoussaoui@gmail.com>
+* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+*/
 
 public class Akira.Layouts.Partials.StylePanel : Gtk.Grid {
-
     public Gtk.Label label;
 
     private Gtk.Revealer options_revealer;
@@ -37,6 +37,15 @@ public class Akira.Layouts.Partials.StylePanel : Gtk.Grid {
     private Gtk.Switch autoscale_switch;
     private Gtk.Switch uniform_switch;
 
+    public bool toggled {
+        get {
+            return visible;
+        } set {
+            visible = value;
+            no_show_all = !value;
+        }
+    }
+
     public StylePanel () {
         Object (
             orientation: Gtk.Orientation.VERTICAL
@@ -44,7 +53,6 @@ public class Akira.Layouts.Partials.StylePanel : Gtk.Grid {
     }
 
     construct {
-
         var title_cont = new Gtk.Grid ();
         title_cont.get_style_context ().add_class ("option-panel");
 
@@ -172,11 +180,13 @@ public class Akira.Layouts.Partials.StylePanel : Gtk.Grid {
         uniform_label.halign = Gtk.Align.START;
         border_options_grid.attach (uniform_label, 1, 1, 1, 1);
         options_grid.attach (border_options_grid, 0, 1, 1, 1);
+        show_all ();
 
         bind_signals ();
     }
 
     private void bind_signals () {
+        toggled = false;
         border_radius_scale.value_changed.connect ( () => {
             double border_value = border_radius_scale.get_value ();
             border_radius_entry.entry.text = ((int)border_value).to_string ();
@@ -196,6 +206,4 @@ public class Akira.Layouts.Partials.StylePanel : Gtk.Grid {
             }
         });
     }
-
-
 }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -83,7 +83,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         window.event_bus.request_zoom.connect (on_request_zoom);
         window.event_bus.request_change_cursor.connect (on_request_change_cursor);
-        window.event_bus.set_focus_on_canvas.connect (focus_canvas);
         window.event_bus.set_focus_on_canvas.connect (on_set_focus_on_canvas);
     }
 

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -20,7 +20,6 @@
 */
 
 public class Akira.Lib.Managers.SelectedBoundManager : Object {
-
     public weak Akira.Lib.Canvas canvas { get; construct; }
 
     private unowned List<Models.CanvasItem> _selected_items;
@@ -30,9 +29,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         }
         set {
             _selected_items = value;
-
             update_selected_items ();
-
         }
     }
 
@@ -114,6 +111,10 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     }
 
     public void add_item_to_selection (Models.CanvasItem item) {
+        // Don't clear and reselect the same element if it's already selected.
+        if (selected_items.index (item) != -1) {
+            return;
+        }
         // Just 1 selected element at the same time
         // TODO: allow for multi selection with shift pressed
         reset_selection ();
@@ -124,6 +125,10 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     }
 
     public void delete_selection () {
+        if (selected_items.length () == 0) {
+            return;
+        }
+
         foreach (var item in selected_items) {
             item.delete ();
         }
@@ -133,6 +138,10 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     }
 
     public void reset_selection () {
+        if (selected_items.length () == 0) {
+            return;
+        }
+
         foreach (var item in selected_items) {
             item.selected = false;
         }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -30,6 +30,7 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public Gdk.RGBA color { get; set; }
     public double border_size { get; set; }
     public Gdk.RGBA border_color { get; set; }
+    public bool hidden_fill { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasEllipse (

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -27,6 +27,7 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public double opacity { get; set; }
     public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
+    public bool has_fill { get; set; default = true; }
     public Gdk.RGBA color { get; set; }
     public double border_size { get; set; }
     public Gdk.RGBA border_color { get; set; }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -10,7 +10,7 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -31,13 +31,21 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
 
     public abstract string id { get; set; }
     public abstract bool selected { get; set; }
+
+    // Transform Panel attributes.
     public abstract double opacity { get; set; }
     public abstract double rotation { get; set; }
+
+    // Fill Panel attributes.
     public abstract int fill_alpha { get; set; }
     public abstract int stroke_alpha { get; set; }
     public abstract Gdk.RGBA color { get; set; }
+    public abstract bool hidden_fill { get; set; default = false; }
+
+    // Border Panel attributes.
     public abstract double border_size { get; set; }
     public abstract Gdk.RGBA border_color { get; set; }
+
     public abstract Models.CanvasItemType item_type { get; set; }
 
     public double get_coords (string coord_id, bool convert_to_item_space = false) {
@@ -66,6 +74,32 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public void reset_colors () {
+        reset_fill ();
+        reset_border ();
+    }
+
+    private void reset_border () {
+        if (!settings.set_border) {
+            set ("stroke-color-rgba", null);
+            set ("line-width", null);
+            return;
+        }
+
+        var rgba_stroke = Gdk.RGBA ();
+        rgba_stroke = border_color;
+        rgba_stroke.alpha = ((double) stroke_alpha) / 255 * opacity / 100;
+
+        uint stroke_color_rgba = Utils.Color.rgba_to_uint (rgba_stroke);
+        set ("stroke-color-rgba", stroke_color_rgba);
+        set ("line-width", border_size);
+    }
+
+    private void reset_fill () {
+        if (hidden_fill) {
+            set ("fill-color-rgba", null);
+            return;
+        }
+
         var rgba_fill = Gdk.RGBA ();
         rgba_fill = color;
         //  debug (fill_alpha.to_string ());
@@ -74,18 +108,5 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
 
         uint fill_color_rgba = Utils.Color.rgba_to_uint (rgba_fill);
         set ("fill-color-rgba", fill_color_rgba);
-
-        if (settings.set_border) {
-            var rgba_stroke = Gdk.RGBA ();
-            rgba_stroke = border_color;
-            rgba_stroke.alpha = ((double) stroke_alpha) / 255 * opacity / 100;
-
-            uint stroke_color_rgba = Utils.Color.rgba_to_uint (rgba_stroke);
-            set ("stroke-color-rgba", stroke_color_rgba);
-            set ("line-width", border_size);
-        } else {
-            set ("stroke-color-rgba", null);
-            set ("line-width", null);
-        }
     }
 }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -37,6 +37,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public abstract double rotation { get; set; }
 
     // Fill Panel attributes.
+    public abstract bool has_fill { get; set; default = true; }
     public abstract int fill_alpha { get; set; }
     public abstract int stroke_alpha { get; set; }
     public abstract Gdk.RGBA color { get; set; }
@@ -78,6 +79,22 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         reset_border ();
     }
 
+    private void reset_fill () {
+        if (hidden_fill || !has_fill) {
+            set ("fill-color-rgba", null);
+            return;
+        }
+
+        var rgba_fill = Gdk.RGBA ();
+        rgba_fill = color;
+        //  debug (fill_alpha.to_string ());
+        rgba_fill.alpha = ((double) fill_alpha) / 255 * opacity / 100;
+        //  debug (rgba_fill.alpha.to_string ());
+
+        uint fill_color_rgba = Utils.Color.rgba_to_uint (rgba_fill);
+        set ("fill-color-rgba", fill_color_rgba);
+    }
+
     private void reset_border () {
         if (!settings.set_border) {
             set ("stroke-color-rgba", null);
@@ -92,21 +109,5 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         uint stroke_color_rgba = Utils.Color.rgba_to_uint (rgba_stroke);
         set ("stroke-color-rgba", stroke_color_rgba);
         set ("line-width", border_size);
-    }
-
-    private void reset_fill () {
-        if (hidden_fill) {
-            set ("fill-color-rgba", null);
-            return;
-        }
-
-        var rgba_fill = Gdk.RGBA ();
-        rgba_fill = color;
-        //  debug (fill_alpha.to_string ());
-        rgba_fill.alpha = ((double) fill_alpha) / 255 * opacity / 100;
-        //  debug (rgba_fill.alpha.to_string ());
-
-        uint fill_color_rgba = Utils.Color.rgba_to_uint (rgba_fill);
-        set ("fill-color-rgba", fill_color_rgba);
     }
 }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -23,13 +23,14 @@
 public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public string id { get; set; }
     public bool selected { get; set; }
-    public double rotation { get; public set; }
+    public double rotation { get; set; }
     public double opacity { get; set; }
     public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
     public Gdk.RGBA color { get; set; }
     public double border_size { get; set; }
     public Gdk.RGBA border_color { get; set; }
+    public bool hidden_fill { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasRect (

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -25,6 +25,7 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public bool selected { get; set; }
     public double rotation { get; set; }
     public double opacity { get; set; }
+    public bool has_fill { get; set; default = true; }
     public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
     public Gdk.RGBA color { get; set; }

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -24,6 +24,7 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public bool selected { get; set; }
     public double opacity { get; set; }
     public double rotation { get; set; }
+    public bool has_fill { get; set; default = true; }
     public int fill_alpha { get; set; }
     public int stroke_alpha { get; set; }
     public Gdk.RGBA color { get; set; }

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -29,6 +29,7 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public Gdk.RGBA color { get; set; }
     public double border_size { get; set; }
     public Gdk.RGBA border_color { get; set; }
+    public bool hidden_fill { get; set; }
     public Models.CanvasItemType item_type { get; set; }
 
     public CanvasText (

--- a/src/Models/FillsItemModel.vala
+++ b/src/Models/FillsItemModel.vala
@@ -40,19 +40,24 @@ public class Akira.Models.FillsItemModel : GLib.Object {
         }
     }
 
-    public bool hidden { get; set; }
+    public bool hidden {
+        get {
+            return item.hidden_fill;
+        }
+        set {
+            item.hidden_fill = value;
+        }
+    }
     public Akira.Utils.BlendingMode blending_mode { get; set; }
     public Akira.Models.FillsListModel list_model { get; set; }
     public Lib.Models.CanvasItem item { get; construct; }
 
     public FillsItemModel (
         Lib.Models.CanvasItem item,
-        bool hidden,
         Akira.Utils.BlendingMode blending_mode,
         Akira.Models.FillsListModel list_model
     ) {
         Object (
-            hidden: hidden,
             blending_mode: blending_mode,
             list_model: list_model,
             item: item

--- a/src/Models/FillsItemModel.vala
+++ b/src/Models/FillsItemModel.vala
@@ -10,7 +10,7 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
@@ -31,6 +31,7 @@ public class Akira.Models.FillsItemModel : GLib.Object {
             item.color = new_rgba;
         }
     }
+
     public int alpha {
         get {
             return item.fill_alpha;
@@ -48,6 +49,7 @@ public class Akira.Models.FillsItemModel : GLib.Object {
             item.hidden_fill = value;
         }
     }
+
     public Akira.Utils.BlendingMode blending_mode { get; set; }
     public Akira.Models.FillsListModel list_model { get; set; }
     public Lib.Models.CanvasItem item { get; construct; }

--- a/src/Models/FillsListModel.vala
+++ b/src/Models/FillsListModel.vala
@@ -54,7 +54,6 @@ public class Akira.Models.FillsListModel : GLib.Object, GLib.ListModel {
         fills_list.append (model_item);
 
         items_changed (get_n_items () - 1, 0, 1);
-        debug (model_item.to_string ());
     }
 
     public async void remove_item (Akira.Models.FillsItemModel? item) {

--- a/src/Models/FillsListModel.vala
+++ b/src/Models/FillsListModel.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -10,13 +10,14 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+* Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
 public class Akira.Models.FillsListModel : GLib.Object, GLib.ListModel {
@@ -53,13 +54,23 @@ public class Akira.Models.FillsListModel : GLib.Object, GLib.ListModel {
         fills_list.append (model_item);
 
         items_changed (get_n_items () - 1, 0, 1);
+        item.has_fill = true;
     }
 
     public async void remove_item (Akira.Models.FillsItemModel? item) {
-        if (item != null) {
-            var position = fills_list.index (item);
-            fills_list.remove (item);
-            items_changed (position, 1, 0);
+        if (item == null) {
+            return;
+        }
+
+        var position = fills_list.index (item);
+        fills_list.remove (item);
+        items_changed (position, 1, 0);
+
+        // Update has_fill only if no fills are present and the item is still
+        // selected. This is necessary to be sure we're removing the fill only
+        // if the user specifically clicked on the trash icon.
+        if (get_n_items () == 0 && item.item.selected) {
+            item.item.has_fill = false;
         }
     }
 

--- a/src/Models/FillsListModel.vala
+++ b/src/Models/FillsListModel.vala
@@ -46,7 +46,6 @@ public class Akira.Models.FillsListModel : GLib.Object, GLib.ListModel {
     public async void add (Lib.Models.CanvasItem item) {
         var model_item = new Models.FillsItemModel (
             item,
-            false,
             Akira.Utils.BlendingMode.NORMAL,
             this
         );

--- a/src/Models/FillsListModel.vala
+++ b/src/Models/FillsListModel.vala
@@ -54,6 +54,7 @@ public class Akira.Models.FillsListModel : GLib.Object, GLib.ListModel {
         fills_list.append (model_item);
 
         items_changed (get_n_items () - 1, 0, 1);
+        debug (model_item.to_string ());
     }
 
     public async void remove_item (Akira.Models.FillsItemModel? item) {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -33,6 +33,7 @@ public class Akira.Services.EventBus : Object {
     public signal void request_change_cursor (Gdk.CursorType? cursor_type);
     public signal void request_selection_bound_transform (string property, double amount);
     public signal void set_focus_on_canvas ();
+    public signal void fill_deleted ();
 
     public void test (string caller_id) {
         debug (@"Test from EventBus called by $(caller_id)");

--- a/src/meson.build
+++ b/src/meson.build
@@ -43,7 +43,7 @@ sources = files(
     'Layouts/Partials/PagesPanel.vala',
     'Layouts/Partials/Artboard.vala',
     'Layouts/Partials/Layer.vala',
-    'Layouts/Partials/FillsBoxPanel.vala',
+    'Layouts/Partials/FillsPanel.vala',
     'Layouts/Partials/FillItem.vala',
     'Layouts/Partials/BlendingModeItem.vala',
     'Layouts/Partials/TransformPanel.vala',

--- a/tests/canvas/test-fills-item.vala
+++ b/tests/canvas/test-fills-item.vala
@@ -40,7 +40,7 @@ public class Akira.FillsItemTest : Akira.TestSuite {
             assert (canvas is Akira.Lib.Canvas);
 
             var root = canvas.get_root_item ();
-            var fills_list_model = window.main_window.left_sidebar.fill_box_panel.fills_list_model;
+            var fills_list_model = window.main_window.left_sidebar.fills_panel.fills_list_model;
 
             // Create 1000 Items and quickly select/deselect them to stress test the canvas.
             for (var i = 0; i < 1000; i++) {


### PR DESCRIPTION
Continuing the code improvements started in #238 this PR is taking care of:

- [x] Avoid triggering `reset_selection ()` when clicking on an already selected item.
- [x] Avoid triggering `reset_selection ()` when clicking on the canvas if not item was selected.
- [x] Avoid loop segfault when adding/removing a fill item model.
- [x] Remember the `hidden_fill` option.
- [x] Allow deletion of the Fill model.
- [x] Allow adding a Fill model if the list is empty.
- [x] Show/hide the Fill Panel based on selected item.

I wanted to keep this PR as small as possible, but while working on the `hidden_fill` option, I stumbled upon some regressions, so I decided to tackle those as well since they were causing segfaults. 