### PR TITLE
Flatpak: bump runtime to 3.34

### DIFF
--- a/build-aux/flatpak/com.github.akiraux.akira.json
+++ b/build-aux/flatpak/com.github.akiraux.akira.json
@@ -1,10 +1,10 @@
 {
    "app-id": "com.github.akiraux.akiraDevel",
    "runtime": "org.gnome.Platform",
-   "runtime-version": "3.32",
+   "runtime-version": "3.34",
    "sdk": "org.gnome.Sdk",
    "base":"io.elementary.BaseApp",
-   "base-version": "juno",
+   "base-version": "juno-19.08",
    "command": "com.github.akiraux.akiraDevel",
    "cleanup": [
       "/include",
@@ -27,6 +27,7 @@
    "modules": [
       {
          "name": "goocanvas",
+         "config-opts": ["--enable-python=no"],
          "build-options" : {
              "make-install-args" : [
                  "girdir=/app/share/gir-1.0",


### PR DESCRIPTION
this also patches goocanvas to bump the used gettext
and re-indent the json file with 4 spaces so it's more readable
