### PR TITLE
Build on vala >= 0.44.2

### DIFF
--- a/src/FileFormat/JsonObject.vala
+++ b/src/FileFormat/JsonObject.vala
@@ -31,7 +31,7 @@ public abstract class Akira.FileFormat.JsonObject : GLib.Object {
 
     private ObjectClass obj_class;
 
-    public JsonObject.from_object (Json.Object object) {
+    protected JsonObject.from_object (Json.Object object) {
         Object (object: object);
     }
 

--- a/src/FileFormat/JsonObjectArray.vala
+++ b/src/FileFormat/JsonObjectArray.vala
@@ -31,7 +31,7 @@ public abstract class Akira.FileFormat.JsonObjectArray : Object {
      *
      * Your JsonObject implementation should have it's own list of items
      */
-    public JsonObjectArray (Json.Object object, string property_name) {
+    protected JsonObjectArray (Json.Object object, string property_name) {
         Object (object: object, property_name: property_name);
     }
 

--- a/src/FileFormat/ZipArchiveHandler.vala
+++ b/src/FileFormat/ZipArchiveHandler.vala
@@ -266,11 +266,17 @@ public class Akira.FileFormat.ZipArchiveHandler : GLib.Object {
                 continue;
             }
 
+            Posix.off_t offset;
+#if VALA_0_42
+            uint8[] buffer;
+            while (archive.read_data_block (out buffer, out offset) == Archive.Result.OK) {
+                if (extractor.write_data_block (buffer, offset) != Archive.Result.OK) {
+#else
             void* buffer = null;
             size_t buffer_length;
-            Posix.off_t offset;
             while (archive.read_data_block (out buffer, out buffer_length, out offset) == Archive.Result.OK) {
                 if (extractor.write_data_block (buffer, buffer_length, offset) != Archive.Result.OK) {
+#endif
                     break;
                 }
             }
@@ -321,9 +327,15 @@ public class Akira.FileFormat.ZipArchiveHandler : GLib.Object {
                     // Add an entry to the archive
                     Archive.Entry entry = new Archive.Entry ();
                     entry.set_pathname (initial_folder.get_relative_path (current_file));
+#if VALA_0_42
+                    entry.set_size ((Archive.int64_t) file_info.get_size ());
+                    entry.set_filetype (Archive.FileType.IFREG);
+                    entry.set_perm (Archive.FileType.IFREG);
+#else
                     entry.set_size (file_info.get_size ());
                     entry.set_filetype ((uint) Posix.S_IFREG);
                     entry.set_perm (0644);
+#endif
 
                     if (archive.write_header (entry) != Archive.Result.OK) {
                         critical (
@@ -343,7 +355,11 @@ public class Akira.FileFormat.ZipArchiveHandler : GLib.Object {
                             break;
                         }
 
+#if VALA_0_42
+                        archive.write_data (buffer[0:bytes_read]);
+#else
                         archive.write_data (buffer, bytes_read);
+#endif
                     }
                 }
             }


### PR DESCRIPTION
Our primary OS is elementary which right now depends on Ubuntu LTS 18.04 and offer vala 0.40

If we are gonna land code depending on vala version as https://github.com/akiraux/Akira/issues/243 we can land this too which allow others to build Akira in recent versions of vala.

## Summary / How this PR fixes the problem?
Code dependant on vala version

## Steps to Test
Build Akira on vala version equal or above 0.44.2

## TODOs

Our dependency from elementary theme can cause a wrong expectation.

## This PR fixes/implements the following **bugs/features**:

- Fixes #191
- Fixes #182 
- Fixes #156 
- Fixes #137