### PR TITLE
Allow scale item in any direction

### DIFF
--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -177,6 +177,16 @@ public class Akira.Utils.AffineTransform : Object {
             origin_move_delta_y = 0.0;
         }
 
+        if (new_width < MIN_SIZE) {
+            canvas.window.event_bus.flip_item ();
+            return;
+        }
+
+        if (new_height < MIN_SIZE) {
+            canvas.window.event_bus.flip_item (true);
+            return;
+        }
+
         // Before translating, recover the original "canvas" position of
         // initial_event, in order to convert it to the "new" translated
         // item space after the transformation has been applied.
@@ -356,7 +366,6 @@ public class Akira.Utils.AffineTransform : Object {
     */
 
     private static double fix_size (double size) {
-        var new_size = GLib.Math.round (size);
-        return new_size > MIN_SIZE ? new_size : MIN_SIZE;
+        return GLib.Math.round (size);
     }
 }


### PR DESCRIPTION
Creating new items, right now there's only a direction to scale, bottom/right

Scaling existing items each nob stops at its counter part

This PR allows to scale in any direction
 
## Steps to Test
Create a new item and scale bypassing other border

## Screenshots 

![scale-in-any-direction](https://user-images.githubusercontent.com/220968/72152668-f4efc580-33ab-11ea-9ce3-41425c4a46ad.gif)

## Known Issues / Things To Do
This still do not reset correctly the size so more refinement is still needed

## This PR fixes/implements the following **bugs/features**:

- Relates to #206
