### PR TITLE
Lock resize ratio

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -29,7 +29,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     private Akira.Partials.LinkedInput width;
     private Akira.Partials.LinkedInput height;
     private Akira.Partials.LinkedInput rotation;
-    private Gtk.Button lock_changes;
+    private Gtk.ToggleButton lock_changes;
     private Gtk.Button hflip_button;
     private Gtk.Button vflip_button;
     private Gtk.Adjustment opacity_adj;
@@ -97,13 +97,14 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         width = new Akira.Partials.LinkedInput (_("W"), _("Width"));
         height = new Akira.Partials.LinkedInput (_("H"), _("Height"));
 
-        lock_changes = new Gtk.Button.from_icon_name ("changes-allow-symbolic");
-        lock_changes.can_focus = false;
-        lock_changes.sensitive = false;
+        var lock_image = new Gtk.Image.from_icon_name ("changes-allow-symbolic", Gtk.IconSize.BUTTON);
+        lock_changes = new Gtk.ToggleButton ();
         lock_changes.tooltip_text = _("Lock Ratio");
         lock_changes.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        lock_changes.get_style_context ().add_class ("button-rounded");
         lock_changes.get_style_context ().add_class ("label-colors");
+        lock_changes.image = lock_image;
+        lock_changes.can_focus = false;
+        lock_changes.sensitive = false;
         bind_property (
             "size-lock", lock_changes, "image", BindingFlags.SYNC_CREATE,
             (binding, val, ref res) => {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -84,7 +84,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
                     initial_event_x, initial_event_y,
                     selected_item
                 );
-                canvas.window.event_bus.item_coord_changed ();
                 update_selected_items ();
                 break;
 
@@ -106,6 +105,9 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
                 );
                 break;
         }
+
+        // Notify the X & Y values in the transform panel.
+        canvas.window.event_bus.item_coord_changed ();
     }
 
     public void add_item_to_selection (Models.CanvasItem item) {

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -77,5 +77,8 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
         });
 
         reset_colors ();
+
+        // Imported images should keep their aspect ratio by default.
+        size_locked = true;
     }
 }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -76,7 +76,11 @@ public class Akira.Utils.AffineTransform : Object {
         switch (selected_nob) {
             case NobManager.Nob.TOP_LEFT:
                 new_height = initial_height - delta_y;
-                new_width = initial_width - delta_x;
+                if (canvas.ctrl_is_pressed || selected_item.size_locked) {
+                    new_width = GLib.Math.round (new_height * canvas.size_ratio);
+                } else {
+                    new_width = initial_width - delta_x;
+                }
 
                 if (item_height > MIN_SIZE) {
                     origin_move_delta_y = item_height - new_height;
@@ -89,6 +93,9 @@ public class Akira.Utils.AffineTransform : Object {
 
             case NobManager.Nob.TOP_CENTER:
                 new_height = initial_height - delta_y;
+                if (canvas.ctrl_is_pressed || selected_item.size_locked) {
+                    new_width = GLib.Math.round (new_height * canvas.size_ratio);
+                }
 
                 if (item_height > MIN_SIZE) {
                     origin_move_delta_y = item_height - new_height;
@@ -97,7 +104,11 @@ public class Akira.Utils.AffineTransform : Object {
 
             case NobManager.Nob.TOP_RIGHT:
                 new_width = initial_width + delta_x;
-                new_height = initial_height - delta_y;
+                if (canvas.ctrl_is_pressed || selected_item.size_locked) {
+                    new_height = GLib.Math.round (new_width / canvas.size_ratio);
+                } else {
+                    new_height = initial_height - delta_y;
+                }
 
                 if (item_height > MIN_SIZE) {
                     origin_move_delta_y = item_height - new_height;
@@ -124,13 +135,16 @@ public class Akira.Utils.AffineTransform : Object {
                 new_height = initial_height + delta_y;
                 if (canvas.ctrl_is_pressed || selected_item.size_locked) {
                     new_width = GLib.Math.round (new_height * canvas.size_ratio);
-                    break;
                 }
                 break;
 
             case NobManager.Nob.BOTTOM_LEFT:
                 new_height = initial_height + delta_y;
-                new_width = initial_width - delta_x;
+                if (canvas.ctrl_is_pressed || selected_item.size_locked) {
+                    new_width = GLib.Math.round (new_height * canvas.size_ratio);
+                } else {
+                    new_width = initial_width - delta_x;
+                }
 
                 if (item_width > MIN_SIZE) {
                     origin_move_delta_x = item_width - new_width;
@@ -139,6 +153,9 @@ public class Akira.Utils.AffineTransform : Object {
 
             case NobManager.Nob.LEFT_CENTER:
                 new_width = initial_width - delta_x;
+                if (canvas.ctrl_is_pressed || selected_item.size_locked) {
+                    new_height = GLib.Math.round (new_width / canvas.size_ratio);
+                }
 
                 if (item_width > MIN_SIZE) {
                     origin_move_delta_x = item_width - new_width;

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -106,13 +106,15 @@ public class Akira.Utils.AffineTransform : Object {
 
             case NobManager.Nob.RIGHT_CENTER:
                 new_width = initial_width + delta_x;
+                if (canvas.ctrl_is_pressed || selected_item.size_locked) {
+                    new_height = GLib.Math.round (new_width / canvas.size_ratio);
+                }
                 break;
 
             case NobManager.Nob.BOTTOM_RIGHT:
                 new_width = initial_width + delta_x;
                 if (canvas.ctrl_is_pressed || selected_item.size_locked) {
-                    new_height = GLib.Math.round (
-                        new_width / canvas.size_ratio);
+                    new_height = GLib.Math.round (new_width / canvas.size_ratio);
                     break;
                 }
                 new_height = initial_height + delta_y;
@@ -120,6 +122,10 @@ public class Akira.Utils.AffineTransform : Object {
 
             case NobManager.Nob.BOTTOM_CENTER:
                 new_height = initial_height + delta_y;
+                if (canvas.ctrl_is_pressed || selected_item.size_locked) {
+                    new_width = GLib.Math.round (new_height * canvas.size_ratio);
+                    break;
+                }
                 break;
 
             case NobManager.Nob.BOTTOM_LEFT:


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Enable locking the resize ratio is <kbd>CTRL</kbd> is pressed and hold, or if the lock icon was activated in the Transform Panel.

## Screenshots 
![lock-resize](https://user-images.githubusercontent.com/2527103/72640328-81eecd80-391c-11ea-8e9e-279a84e2ca42.gif)

