### PR TITLE
Use toggle buttons for Transform Panel

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -119,11 +119,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         hflip_button.halign = Gtk.Align.CENTER;
         hflip_button.valign = Gtk.Align.CENTER;
         hflip_button.tooltip_markup =
-            Granite.markup_accel_tooltip ({"<Ctrl><Shift>bracketleft"}, _("Flip Horizontally"));
-        //  hflip_button.clicked.connect (() => {
-        //      Utils.AffineTransform.flip_item (selected_item, -1, 1);
-        //      on_item_value_changed ();
-        //  });
+            Granite.markup_accel_tooltip ({"<Ctrl>bracketleft"}, _("Flip Horizontally"));
 
         vflip_button = new Gtk.ToggleButton ();
         vflip_button.add (new Akira.Partials.ButtonImage ("object-flip-vertical"));
@@ -134,11 +130,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         vflip_button.halign = Gtk.Align.CENTER;
         vflip_button.valign = Gtk.Align.CENTER;
         vflip_button.tooltip_markup =
-            Granite.markup_accel_tooltip ({"<Ctrl><Shift>bracketright"}, _("Flip Vertically"));
-        //  vflip_button.clicked.connect (() => {
-        //      Utils.AffineTransform.flip_item (selected_item, 1, -1);
-        //      on_item_value_changed ();
-        //  });
+            Granite.markup_accel_tooltip ({"<Ctrl>bracketright"}, _("Flip Vertically"));
 
         var align_grid = new Gtk.Grid ();
         align_grid.hexpand = true;
@@ -312,8 +304,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             "active", selected_item, "flipped-h", BindingFlags.BIDIRECTIONAL,
             (binding, val, ref res) => {
                 res = val.get_boolean ();
-                Utils.AffineTransform.flip_item (selected_item, -1, 1);
-                on_item_value_changed ();
+                window.event_bus.flip_item ();
                 return true;
             });
 
@@ -321,8 +312,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             "active", selected_item, "flipped-v", BindingFlags.BIDIRECTIONAL,
             (binding, val, ref res) => {
                 res = val.get_boolean ();
-                Utils.AffineTransform.flip_item (selected_item, 1, -1);
-                on_item_value_changed ();
+                window.event_bus.flip_item (true);
                 return true;
             });
 

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -30,8 +30,8 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     private Akira.Partials.LinkedInput height;
     private Akira.Partials.LinkedInput rotation;
     private Gtk.ToggleButton lock_changes;
-    private Gtk.Button hflip_button;
-    private Gtk.Button vflip_button;
+    private Gtk.ToggleButton hflip_button;
+    private Gtk.ToggleButton vflip_button;
     private Gtk.Adjustment opacity_adj;
     private Akira.Partials.InputField opacity_entry;
     private Gtk.Scale scale;
@@ -108,6 +108,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         bind_property (
             "size-lock", lock_changes, "image", BindingFlags.SYNC_CREATE,
             (binding, val, ref res) => {
+                //  lock_changes.active = val.get_boolean ();
                 var icon = val.get_boolean () ? "changes-prevent-symbolic" : "changes-allow-symbolic";
                 var image = new Gtk.Image.from_icon_name (icon, Gtk.IconSize.BUTTON);
                 res = image;
@@ -121,37 +122,35 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
 
         rotation = new Akira.Partials.LinkedInput (_("R"), _("Rotation degrees"), "°");
 
-        hflip_button = new Gtk.Button ();
+        hflip_button = new Gtk.ToggleButton ();
         hflip_button.add (new Akira.Partials.ButtonImage ("object-flip-horizontal"));
         hflip_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        hflip_button.get_style_context ().add_class ("button-rounded");
         hflip_button.hexpand = false;
+        hflip_button.can_focus = false;
+        hflip_button.sensitive = false;
         hflip_button.halign = Gtk.Align.CENTER;
         hflip_button.valign = Gtk.Align.CENTER;
-        hflip_button.can_focus = false;
         hflip_button.tooltip_markup =
             Granite.markup_accel_tooltip ({"<Ctrl><Shift>bracketleft"}, _("Flip Horizontally"));
         hflip_button.clicked.connect (() => {
             Utils.AffineTransform.flip_item (selected_item, -1, 1);
             on_item_value_changed ();
         });
-        hflip_button.sensitive = false;
 
-        vflip_button = new Gtk.Button ();
+        vflip_button = new Gtk.ToggleButton ();
         vflip_button.add (new Akira.Partials.ButtonImage ("object-flip-vertical"));
         vflip_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        vflip_button.get_style_context ().add_class ("button-rounded");
         vflip_button.hexpand = false;
+        vflip_button.can_focus = false;
+        vflip_button.sensitive = false;
         vflip_button.halign = Gtk.Align.CENTER;
         vflip_button.valign = Gtk.Align.CENTER;
-        vflip_button.can_focus = false;
         vflip_button.tooltip_markup =
             Granite.markup_accel_tooltip ({"<Ctrl><Shift>bracketright"}, _("Flip Vertically"));
         vflip_button.clicked.connect (() => {
             Utils.AffineTransform.flip_item (selected_item, 1, -1);
             on_item_value_changed ();
         });
-        vflip_button.sensitive = false;
 
         var align_grid = new Gtk.Grid ();
         align_grid.hexpand = true;
@@ -259,6 +258,9 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         rotation.value = selected_item.rotation;
         opacity_adj.value = selected_item.opacity;
         size_lock = selected_item.size_locked;
+
+        hflip_button.bind_property (
+            "active", selected_item, "flipped_h", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
         // Property binding doesn't work for X and Y as these attributes are not
         // directly accessible from the CanvasItem. (goocanvas shenanigans)

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019-202 Alecaddd (https://alecaddd.com)
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -17,6 +17,7 @@
 * along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
+* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
 public class Akira.Lib.Managers.SelectedBoundManager : Object {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019-202 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -10,11 +10,11 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
 */
@@ -46,6 +46,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         canvas.window.event_bus.change_z_selected.connect (change_z_selected);
         canvas.window.event_bus.item_value_changed.connect (update_selected_items);
+        canvas.window.event_bus.flip_item.connect (on_flip_item);
     }
 
     construct {
@@ -186,5 +187,23 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         }
 
         canvas.window.event_bus.z_selected_changed ();
+    }
+
+    private void on_flip_item (bool vertical) {
+        if (selected_items.length () == 0) {
+            return;
+        }
+
+        selected_items.foreach ((item) => {
+            if (vertical) {
+                item.flipped_v = !item.flipped_v;
+                Utils.AffineTransform.flip_item (item, 1, -1);
+                canvas.window.event_bus.item_value_changed ();
+                return;
+            }
+            item.flipped_h = !item.flipped_h;
+            Utils.AffineTransform.flip_item (item, -1, 1);
+            canvas.window.event_bus.item_value_changed ();
+        });
     }
 }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -35,6 +35,8 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public int stroke_alpha { get; set; }
     public bool hidden_border { get; set; }
     public bool size_locked { get; set; }
+    public bool flipped_h { get; set; }
+    public bool flipped_v { get; set; }
     public bool show_border_radius_panel { get; set; }
     public bool show_fill_panel { get; set; }
     public bool show_border_panel { get; set; }

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -44,6 +44,8 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
     public int stroke_alpha { get; set; }
     public bool hidden_border { get; set; }
     public bool size_locked { get; set; }
+    public bool flipped_h { get; set; }
+    public bool flipped_v { get; set; }
     public bool show_border_radius_panel { get; set; }
     public bool show_fill_panel { get; set; }
     public bool show_border_panel { get; set; }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -54,6 +54,8 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
 
     // Style Panel attributes.
     public abstract bool size_locked { get; set; default = false; }
+    public abstract bool flipped_h { get; set; default = false; }
+    public abstract bool flipped_v { get; set; default = false; }
     public abstract bool show_border_radius_panel { get; set; default = false; }
     public abstract bool show_fill_panel { get; set; default = false; }
     public abstract bool show_border_panel { get; set; default = false; }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -35,6 +35,8 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public int stroke_alpha { get; set; }
     public bool hidden_border { get; set; }
     public bool size_locked { get; set; }
+    public bool flipped_h { get; set; }
+    public bool flipped_v { get; set; }
     public bool show_border_radius_panel { get; set; }
     public bool show_fill_panel { get; set; }
     public bool show_border_panel { get; set; }

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -34,6 +34,8 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public int stroke_alpha { get; set; }
     public bool hidden_border { get; set; }
     public bool size_locked { get; set; }
+    public bool flipped_h { get; set; }
+    public bool flipped_v { get; set; }
     public bool show_border_radius_panel { get; set; }
     public bool show_fill_panel { get; set; }
     public bool show_border_panel { get; set; }

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -10,11 +10,11 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
@@ -49,6 +49,8 @@ public class Akira.Services.ActionManager : Object {
     public const string ACTION_IMAGE_TOOL = "action_image_tool";
     public const string ACTION_SELECTION_TOOL = "action_selection_tool";
     public const string ACTION_DELETE = "action_delete";
+    public const string ACTION_FLIP_H = "action_flip_h";
+    public const string ACTION_FLIP_V = "action_flip_v";
 
     public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 
@@ -76,6 +78,8 @@ public class Akira.Services.ActionManager : Object {
         { ACTION_IMAGE_TOOL, action_image_tool },
         { ACTION_SELECTION_TOOL, action_selection_tool },
         { ACTION_DELETE, action_delete },
+        { ACTION_FLIP_H, action_flip_h },
+        { ACTION_FLIP_V, action_flip_v },
     };
 
     public ActionManager (Akira.Application akira_app, Akira.Window window) {
@@ -104,6 +108,8 @@ public class Akira.Services.ActionManager : Object {
         action_accelerators.set (ACTION_MOVE_DOWN, "<Control>Down");
         action_accelerators.set (ACTION_MOVE_TOP, "<Control><Shift>Up");
         action_accelerators.set (ACTION_MOVE_BOTTOM, "<Control><Shift>Down");
+        action_accelerators.set (ACTION_FLIP_H, "<Control>bracketleft");
+        action_accelerators.set (ACTION_FLIP_V, "<Control>bracketright");
     }
 
     construct {
@@ -199,6 +205,14 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_delete () {}
+
+    private void action_flip_h () {
+        window.event_bus.flip_item ();
+    }
+
+    private void action_flip_v () {
+        window.event_bus.flip_item (true);
+    }
 
     private void action_ellipse_tool () {
         window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -38,6 +38,7 @@ public class Akira.Services.EventBus : Object {
     public signal void border_deleted ();
     public signal void change_z_selected (bool raise, bool total);
     public signal void z_selected_changed ();
+    public signal void flip_item (bool vertical = false);
 
     public void test (string caller_id) {
         debug (@"Test from EventBus called by $(caller_id)");


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Let's use `Gtk.ToggleButton` elements for the those properties that can be toggled, like size lock and flip.
Flip buttons need to be toggled if they were activated since the `select_effect` flips as well and maintains the new orientation. The active toggle button will let the user know in which status the shape currently is.

## Screenshots 
![toggle-buttons](https://user-images.githubusercontent.com/2527103/72656917-9d28ff80-3953-11ea-989b-9e00baa491fb.gif)

