### PR TITLE
Fix item coordinates problem

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -224,7 +224,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
 
     private void enable () {
         canvas = selected_item.canvas as Akira.Lib.Canvas;
-        on_item_coord_changed.begin ();
+        on_item_coord_changed ();
 
         width.value = selected_item.get_coords ("width");
         height.value = selected_item.get_coords ("height");
@@ -293,7 +293,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             (binding, val, ref res) => {
                 res = val.get_boolean ();
                 window.event_bus.flip_item (true);
-                on_item_coord_changed.begin ();
+                on_item_coord_changed ();
                 return true;
             });
 
@@ -302,7 +302,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             (binding, val, ref res) => {
                 res = val.get_boolean ();
                 window.event_bus.flip_item (true, true);
-                on_item_coord_changed.begin ();
+                on_item_coord_changed ();
                 return true;
             });
 
@@ -313,17 +313,17 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         selected_item.notify["opacity"].connect (selected_item.reset_colors);
     }
 
-    private async void on_item_value_changed () {
+    private void on_item_value_changed () {
         if (selected_item == null) {
             return;
         }
 
-        yield on_item_coord_changed ();
         window.event_bus.item_value_changed ();
+        on_item_coord_changed ();
     }
 
     // We need to fetch new X and Y values to update the fields.
-    private async void on_item_coord_changed () {
+    private void on_item_coord_changed () {
         // Prevents X & Y AffineTransform callback loop.
         x.notify["value"].disconnect (x_notify_value);
         y.notify["value"].disconnect (y_notify_value);
@@ -348,7 +348,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         // will recalculate the right position.
         // Who knows why it needs a delay in order to work. This is gross...
         Timeout.add (1, () => {
-            on_item_value_changed.begin ();
+            on_item_value_changed ();
             return false;
         });
     }
@@ -361,7 +361,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         // will recalculate the right position.
         // Who knows why it needs a delay in order to work. This is gross...
         Timeout.add (1, () => {
-            on_item_value_changed.begin ();
+            on_item_value_changed ();
             return false;
         });
     }

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -281,7 +281,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
                 double src = (double) srcval;
                 targetval.set_double (src);
                 Utils.AffineTransform.set_rotation (src, selected_item);
-                on_item_coord_changed ();
                 return true;
             });
 
@@ -314,6 +313,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
 
     private void on_item_value_changed () {
         window.event_bus.item_value_changed ();
+        on_item_coord_changed ();
     }
 
     // We need to fetch new X and Y values to update the fields.

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -342,28 +342,12 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
 
     public void x_notify_value () {
         Utils.AffineTransform.set_position (selected_item, x.value);
-
-        // Hack! In case the item is rotated, the actual X & Y values might be
-        // different from what we have stored in the input field. This method
-        // will recalculate the right position.
-        // Who knows why it needs a delay in order to work. This is gross...
-        Idle.add (() => {
-            on_item_value_changed ();
-            return false;
-        });
+        window.event_bus.item_value_changed ();
     }
 
     public void y_notify_value () {
         Utils.AffineTransform.set_position (selected_item, 0, y.value);
-
-        // Hack! In case the item is rotated, the actual X & Y values might be
-        // different from what we have stored in the input field. This method
-        // will recalculate the right position.
-        // Who knows why it needs a delay in order to work. This is gross...
-        Idle.add (() => {
-            on_item_value_changed ();
-            return false;
-        });
+        window.event_bus.item_value_changed ();
     }
 
     public void update_size_ratio () {

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -347,7 +347,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         // different from what we have stored in the input field. This method
         // will recalculate the right position.
         // Who knows why it needs a delay in order to work. This is gross...
-        Timeout.add (1, () => {
+        Idle.add (() => {
             on_item_value_changed ();
             return false;
         });
@@ -360,7 +360,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         // different from what we have stored in the input field. This method
         // will recalculate the right position.
         // Who knows why it needs a delay in order to work. This is gross...
-        Timeout.add (1, () => {
+        Idle.add (() => {
             on_item_value_changed ();
             return false;
         });

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -338,8 +338,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             return;
         }
 
-        debug ("update Y");
-        Utils.AffineTransform.set_position (null, y.value, selected_item);
+        Utils.AffineTransform.set_position (selected_item, 0, y.value);
         on_item_value_changed ();
     }
 
@@ -348,8 +347,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             return;
         }
 
-        debug ("update X");
-        Utils.AffineTransform.set_position (x.value, null, selected_item);
+        Utils.AffineTransform.set_position (selected_item, x.value);
         on_item_value_changed ();
     }
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -101,7 +101,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
 
         items_manager.add_item (item);
-        Utils.AffineTransform.set_position (start_x, start_y, item);
+        Utils.AffineTransform.set_position (item, start_x, start_y);
 
         if (select) {
             selected_bound_manager.reset_selection ();

--- a/src/Partials/InputField.vala
+++ b/src/Partials/InputField.vala
@@ -117,7 +117,9 @@ public class Akira.Partials.InputField : Gtk.EventBox {
     }
 
     private bool handle_key_release (Gdk.EventKey key) {
-        if (key.keyval != Gdk.Key.Up && key.keyval != Gdk.Key.Down) {
+        if (key.keyval != Gdk.Key.Up && key.keyval != Gdk.Key.Down &&
+            key.keyval != Gdk.Key.Right && key.keyval != Gdk.Key.Left &&
+            key.is_modifier != 1) {
             entry.update ();
         }
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -25,11 +25,22 @@ using Akira.Lib.Managers;
 public class Akira.Utils.AffineTransform : Object {
     private const int MIN_SIZE = 1;
     private const int MIN_POS = 10;
-    private const int BOUNDS_H = 10000;
-    private const int BOUNDS_W = 10000;
     private const double ROTATION_FIXED_STEP = 15.0;
 
     public static double prev_rotation_difference = 0.0;
+
+    public static HashTable<string, double?> get_position (CanvasItem item) {
+        HashTable<string, double?> array = new HashTable<string, double?> (str_hash, str_equal);
+        double item_x = item.get_coords ("x");
+        double item_y = item.get_coords ("y");
+
+        item.canvas.convert_from_item_space (item, ref item_x, ref item_y);
+
+        array.insert ("x", item_x);
+        array.insert ("y", item_y);
+
+        return array;
+    }
 
     public static void move_from_event (
         double x,
@@ -273,12 +284,12 @@ public class Akira.Utils.AffineTransform : Object {
         prev_rotation_difference = 0.0;
     }
 
-    public static void set_position (CanvasItem item, double x = 0, double y = 0) {
+    public static void set_position (CanvasItem item, double? x = null, double? y = null) {
         Cairo.Matrix matrix;
         item.get_transform (out matrix);
 
-        double new_x = (x > 0) ? x : matrix.x0;
-        double new_y = (y > 0) ? y : matrix.y0;
+        double new_x = (x != null) ? x : matrix.x0;
+        double new_y = (y != null) ? y : matrix.y0;
 
         var new_matrix = Cairo.Matrix (matrix.xx, matrix.yx, matrix.xy, matrix.yy, new_x, new_y);
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -280,10 +280,15 @@ public class Akira.Utils.AffineTransform : Object {
 
         canvas.convert_from_item_space (item, ref current_x, ref current_y);
 
-        double move_x_amount = (x > 0) ? x - current_x : 0;
-        double move_y_amount = (y > 0) ? y - current_y: 0;
+        double move_x = (x > 0) ? x - current_x : 0;
+        double move_y = (y > 0) ? y - current_y: 0;
 
-        item.translate (move_x_amount, move_y_amount);
+        //  double move_x = (x < 1 && x > -1) ? 0 : x;
+        //  double move_y = (y < 1 && y > -1) ? 0 : y;
+        move_x = (move_x < 1 && move_x > -1) ? 0 : move_x;
+        move_y = (move_y < 1 && move_y > -1) ? 0 : move_y;
+
+        item.translate (move_x, move_y);
     }
 
     public static void set_size (double? width, double? height, CanvasItem item) {

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -273,17 +273,16 @@ public class Akira.Utils.AffineTransform : Object {
         prev_rotation_difference = 0.0;
     }
 
-    public static void set_position (CanvasItem item, double? x = 0, double? y = 0) {
-        var canvas = item.canvas;
-        double current_x = item.get_coords ("x");
-        double current_y = item.get_coords ("y");
+    public static void set_position (CanvasItem item, double x = 0, double y = 0) {
+        Cairo.Matrix matrix;
+        item.get_transform (out matrix);
 
-        canvas.convert_from_item_space (item, ref current_x, ref current_y);
+        double new_x = (x > 0) ? x : matrix.x0;
+        double new_y = (y > 0) ? y : matrix.y0;
 
-        double move_x = (x > 0) ? x - current_x : 0;
-        double move_y = (y > 0) ? y - current_y: 0;
+        var new_matrix = Cairo.Matrix (matrix.xx, matrix.yx, matrix.xy, matrix.yy, new_x, new_y);
 
-        item.translate (GLib.Math.round (move_x), GLib.Math.round (move_y));
+        item.set_transform (new_matrix);
     }
 
     public static void set_size (double? width, double? height, CanvasItem item) {

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -283,8 +283,10 @@ public class Akira.Utils.AffineTransform : Object {
         double move_x = (x > 0) ? x - current_x : 0;
         double move_y = (y > 0) ? y - current_y: 0;
 
-        //  double move_x = (x < 1 && x > -1) ? 0 : x;
-        //  double move_y = (y < 1 && y > -1) ? 0 : y;
+        // If the value is less than the minimum allowed, round it to 0
+        // to prevent subpixel shifts.
+        // Deliberately not using Math.round () because we will need
+        // to account for subpixel if the user enables it in the settings.
         move_x = (move_x < 1 && move_x > -1) ? 0 : move_x;
         move_y = (move_y < 1 && move_y > -1) ? 0 : move_y;
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -283,14 +283,7 @@ public class Akira.Utils.AffineTransform : Object {
         double move_x = (x > 0) ? x - current_x : 0;
         double move_y = (y > 0) ? y - current_y: 0;
 
-        // If the value is less than the minimum allowed, round it to 0
-        // to prevent subpixel shifts.
-        // Deliberately not using Math.round () because we will need
-        // to account for subpixel if the user enables it in the settings.
-        move_x = (move_x < 1 && move_x > -1) ? 0 : move_x;
-        move_y = (move_y < 1 && move_y > -1) ? 0 : move_y;
-
-        item.translate (move_x, move_y);
+        item.translate (GLib.Math.round (move_x), GLib.Math.round (move_y));
     }
 
     public static void set_size (double? width, double? height, CanvasItem item) {

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -17,6 +17,7 @@
 * along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
 using Akira.Lib.Models;

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -273,24 +273,15 @@ public class Akira.Utils.AffineTransform : Object {
         prev_rotation_difference = 0.0;
     }
 
-    public static void set_position (double? x, double? y, CanvasItem item) {
+    public static void set_position (CanvasItem item, double? x = 0, double? y = 0) {
         var canvas = item.canvas;
-
         double current_x = item.get_coords ("x");
         double current_y = item.get_coords ("y");
 
         canvas.convert_from_item_space (item, ref current_x, ref current_y);
 
-        var move_x_amount = 0.0;
-        var move_y_amount = 0.0;
-
-        if (x != null) {
-            move_x_amount = x - current_x;
-        }
-
-        if (y != null) {
-            move_y_amount = y - current_y;
-        }
+        double move_x_amount = (x > 0) ? x - current_x : 0;
+        double move_y_amount = (y > 0) ? y - current_y: 0;
 
         item.translate (move_x_amount, move_y_amount);
     }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
The X and Y coordinates of an item don't always work as expected when the item is rotated.
It seems that updating those values via the Transform panel causes unexpected outcomes and repositioning.

## Steps to Test
- Create a shape.
- Rotate it (the bigger the rotation the more evident is the problem).
- Change its X or Y position via the Transform Panel multiple times.
- The item gets moved exponentially and the value in the input field doesn't match.

## Screenshots 
![coords-fix](https://user-images.githubusercontent.com/2527103/72853236-a244c200-3c65-11ea-80f7-967dda6dec88.gif)

## Known Issues / Things To Do
- [x] Refresh X & Y when rotating or resizing.
- [x] Prevent callback loops.
- [x] Fix X & Y issue when translating a rotated item.

~Probably regressed by #271, but maybe it was there the whole time and we didn't notice.~

**Update**
~I tested this with an old build and the problem persists.
The `AffineTransform` doesn't account for the current rotation. 
Eg. Increasing the Y it actually means decrease when the item is rotated, and vice-versa. Tricky.~

**Second Update**
Everything is fixed now.
I'm using the Cairo Matrix transform to ensure the translation is always calculated by the world's coordinates and not the (sometimes rotated) object's coordinates.

