### PR TITLE
Listen globally to the Escape key

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -87,6 +87,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         window.event_bus.request_zoom.connect (on_request_zoom);
         window.event_bus.request_change_cursor.connect (on_request_change_cursor);
         window.event_bus.set_focus_on_canvas.connect (on_set_focus_on_canvas);
+        window.event_bus.request_escape.connect (on_set_focus_on_canvas);
     }
 
     public void insert_item_default (Akira.Lib.Models.CanvasItem item, bool select) {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -51,6 +51,7 @@ public class Akira.Services.ActionManager : Object {
     public const string ACTION_DELETE = "action_delete";
     public const string ACTION_FLIP_H = "action_flip_h";
     public const string ACTION_FLIP_V = "action_flip_v";
+    public const string ACTION_ESCAPE = "action_escape";
 
     public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 
@@ -80,6 +81,7 @@ public class Akira.Services.ActionManager : Object {
         { ACTION_DELETE, action_delete },
         { ACTION_FLIP_H, action_flip_h },
         { ACTION_FLIP_V, action_flip_v },
+        { ACTION_ESCAPE, action_escape },
     };
 
     public ActionManager (Akira.Application akira_app, Akira.Window window) {
@@ -110,6 +112,7 @@ public class Akira.Services.ActionManager : Object {
         action_accelerators.set (ACTION_MOVE_BOTTOM, "<Control><Shift>Down");
         action_accelerators.set (ACTION_FLIP_H, "<Control>bracketleft");
         action_accelerators.set (ACTION_FLIP_V, "<Control>bracketright");
+        action_accelerators.set (ACTION_ESCAPE, "Escape");
     }
 
     construct {
@@ -256,6 +259,10 @@ public class Akira.Services.ActionManager : Object {
         default:
             break;
         }
+    }
+
+    private void action_escape () {
+        window.event_bus.request_escape ();
     }
 
     public static void action_from_group (string action_name, ActionGroup? action_group) {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -39,6 +39,7 @@ public class Akira.Services.EventBus : Object {
     public signal void change_z_selected (bool raise, bool total);
     public signal void z_selected_changed ();
     public signal void flip_item (bool clicked, bool vertical = false);
+    public signal void request_escape ();
 
     public void test (string caller_id) {
         debug (@"Test from EventBus called by $(caller_id)");


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Listen to the <kbd>Escape</kbd> key and move back the focus to the canvas.
This is necessary when interacting with input fields or other widgets that catch the focus. 

## Steps to Test
- Create a shape
- Interact with any other part of the app (input fields, colors, toolbar buttons)
- Press <kbd>Escape</kbd>
- The focus gets moved back to the canvas and the cursor is back on `MODE_SELECTION`

## Screenshots 
![escape-focus](https://user-images.githubusercontent.com/2527103/72945810-d2599700-3d31-11ea-9709-84fe70307947.gif)

- Fixes #22
