### PR TITLE
Move objects in canvas

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -242,11 +242,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         hflip_button.active = selected_item.flipped_h;
         vflip_button.active = selected_item.flipped_v;
 
-        // Property binding doesn't work for X and Y as these attributes are not
-        // directly accessible from the CanvasItem. (goocanvas shenanigans)
-        x.notify["value"].connect (x_notify_value);
-        y.notify["value"].connect (y_notify_value);
-
         ratio_bind = lock_changes.bind_property (
             "active", selected_item, "size-locked",
             BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL,

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -168,6 +168,13 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 ctrl_is_pressed = true;
                 return true;
 
+            case Gdk.Key.Up:
+            case Gdk.Key.Down:
+            case Gdk.Key.Right:
+            case Gdk.Key.Left:
+                window.event_bus.move_item_from_canvas (event);
+                return true;
+
             default:
                 // Send to ItemsManager to deal with custom user shape
                 // hotkey preferences from settings

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -214,7 +214,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
             return;
         }
 
-        var amount = event.state == Gdk.ModifierType.SHIFT_MASK ? 10 : 1;
+        var amount = (event.state & Gdk.ModifierType.SHIFT_MASK) > 0 ? 10 : 1;
 
         selected_items.foreach ((item) => {
             var position = Akira.Utils.AffineTransform.get_position (item);

--- a/src/Partials/InputField.vala
+++ b/src/Partials/InputField.vala
@@ -99,15 +99,15 @@ public class Akira.Partials.InputField : Gtk.EventBox {
         entry.set_range (min_value, max_value);
     }
 
-    private bool handle_key_press (Gdk.EventKey key) {
+    private bool handle_key_press (Gdk.EventKey event) {
         // Arrow UP
-        if (key.keyval == Gdk.Key.Up && key.state == Gdk.ModifierType.SHIFT_MASK) {
+        if (event.keyval == Gdk.Key.Up && (event.state & Gdk.ModifierType.SHIFT_MASK) > 0) {
             entry.spin (Gtk.SpinType.STEP_FORWARD, 10);
             return true;
         }
 
         // Arrow DOWN
-        if (key.keyval == Gdk.Key.Down && key.state == Gdk.ModifierType.SHIFT_MASK) {
+        if (event.keyval == Gdk.Key.Down && (event.state & Gdk.ModifierType.SHIFT_MASK) > 0) {
             entry.spin (Gtk.SpinType.STEP_BACKWARD, 10);
             return true;
         }

--- a/src/Partials/InputField.vala
+++ b/src/Partials/InputField.vala
@@ -100,11 +100,6 @@ public class Akira.Partials.InputField : Gtk.EventBox {
     }
 
     private bool handle_key_press (Gdk.EventKey key) {
-        //  debug (key.state.to_string ());
-        //  debug (Gdk.ModifierType.SHIFT_MASK.to_string ());
-
-        //  debug ((key.state.to_string () == Gdk.ModifierType.SHIFT_MASK.to_string ()).to_string ());
-        //  debug ((key.state == Gdk.ModifierType.SHIFT_MASK).to_string ());
         // Arrow UP
         if (key.keyval == Gdk.Key.Up && key.state == Gdk.ModifierType.SHIFT_MASK) {
             entry.spin (Gtk.SpinType.STEP_FORWARD, 10);

--- a/src/Partials/InputField.vala
+++ b/src/Partials/InputField.vala
@@ -59,7 +59,6 @@ public class Akira.Partials.InputField : Gtk.EventBox {
         entry.sensitive = false;
 
         entry.key_press_event.connect (handle_key_press);
-        entry.key_release_event.connect (handle_key_release);
         entry.scroll_event.connect (handle_scroll_event);
 
         switch (unit) {
@@ -101,6 +100,11 @@ public class Akira.Partials.InputField : Gtk.EventBox {
     }
 
     private bool handle_key_press (Gdk.EventKey key) {
+        //  debug (key.state.to_string ());
+        //  debug (Gdk.ModifierType.SHIFT_MASK.to_string ());
+
+        //  debug ((key.state.to_string () == Gdk.ModifierType.SHIFT_MASK.to_string ()).to_string ());
+        //  debug ((key.state == Gdk.ModifierType.SHIFT_MASK).to_string ());
         // Arrow UP
         if (key.keyval == Gdk.Key.Up && key.state == Gdk.ModifierType.SHIFT_MASK) {
             entry.spin (Gtk.SpinType.STEP_FORWARD, 10);
@@ -111,16 +115,6 @@ public class Akira.Partials.InputField : Gtk.EventBox {
         if (key.keyval == Gdk.Key.Down && key.state == Gdk.ModifierType.SHIFT_MASK) {
             entry.spin (Gtk.SpinType.STEP_BACKWARD, 10);
             return true;
-        }
-
-        return false;
-    }
-
-    private bool handle_key_release (Gdk.EventKey key) {
-        if (key.keyval != Gdk.Key.Up && key.keyval != Gdk.Key.Down &&
-            key.keyval != Gdk.Key.Right && key.keyval != Gdk.Key.Left &&
-            key.is_modifier != 1) {
-            entry.update ();
         }
 
         return false;

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -39,6 +39,7 @@ public class Akira.Services.EventBus : Object {
     public signal void change_z_selected (bool raise, bool total);
     public signal void z_selected_changed ();
     public signal void flip_item (bool clicked, bool vertical = false);
+    public signal void move_item_from_canvas (Gdk.EventKey event);
 
     public void test (string caller_id) {
         debug (@"Test from EventBus called by $(caller_id)");


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Enable the ability to move the object with the arrow keys when the focus is on the canvas.

## Steps to Test
- Create an object.
- Use the arrow up, down, right, and left to move it around.
- Do a flip.

## Screenshots 
![canvas-arrows](https://user-images.githubusercontent.com/2527103/72953977-bd89fd00-3d4b-11ea-8368-19bbc9328b0a.gif)

