### PR TITLE
Use the signal return value to stop its emission

### DIFF
--- a/src/Partials/InputField.vala
+++ b/src/Partials/InputField.vala
@@ -118,7 +118,7 @@ public class Akira.Partials.InputField : Gtk.EventBox {
     private bool handle_scroll_event (Gdk.EventScroll event) {
         // If the input field is not focused, don't change the value.
         if (!entry.has_focus) {
-            GLib.Signal.stop_emission_by_name (entry, "scroll-event");
+            return true;
         }
         return false;
     }


### PR DESCRIPTION

<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
Event-related signals in GTK widgets have a return value which control
the signal emission chain. Returning a false value means "continue the
signal emission", whereas returning a true value means "I handled the
event, please stop the emission chain here".

Instead of forcibly stopping the signal emission using the
`GLib.Signal.stop_emission_by_name()` method, we can return `true` to
stop the signal emission.