### PR TITLE
Segfault and CSS fixes

### DIFF
--- a/data/css/layer.css
+++ b/data/css/layer.css
@@ -13,7 +13,6 @@
     box-shadow: inset 4px 0 0 @primary;
 }
 
-
 .layer:selected image,
 .layer:selected button {
     background-color: transparent;

--- a/data/css/layer.css
+++ b/data/css/layer.css
@@ -6,13 +6,11 @@
 /* selected status */
 .layer,
 .layer:selected {
-    border: 1px solid @base_color;
     background-color: @base_color;
 }
 
 .layer:selected {
-    border-left-color: @primary;
-    box-shadow: inset 3px 0 0 @primary;
+    box-shadow: inset 4px 0 0 @primary;
 }
 
 
@@ -26,14 +24,13 @@
 .layer.even,
 .layer.even:focus,
 .layer.even:selected {
-    border: 1px solid shade (@bg_color, 1);
     background-color: shade (@bg_color, 1);
 }
 
 /* Hovered */
 .layer.hovered,
 .layer.even.hovered {
-  border: 1px solid @hovering;
+  box-shadow: inset 0 0 0 2px @highlight;
 }
 
 /* label */
@@ -47,7 +44,7 @@
 .layer-action {
     border: none;
     background: transparent;
-    padding: 2px;
+    padding: 0 2px;
     opacity: 0;
     box-shadow: none;
 }

--- a/data/css/layer.css
+++ b/data/css/layer.css
@@ -27,8 +27,8 @@
 }
 
 /* Hovered */
-.layer.hovered,
-.layer.even.hovered {
+.layer.hovered:not(:selected),
+.layer.even.hovered:not(:selected) {
   box-shadow: inset 0 0 0 2px @highlight;
 }
 

--- a/data/css/variables.css
+++ b/data/css/variables.css
@@ -1,3 +1,3 @@
 @define-color primary #ffa90e;
 @define-color secondary #feba13;
-@define-color hovering #41c9fd;
+@define-color highlight #41c9fd;

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -43,9 +43,9 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
 
     public LayersPanel (Akira.Window window) {
         Object (
-            window: window,
-            activate_on_single_click: false,
-            selection_mode: Gtk.SelectionMode.SINGLE
+        window: window,
+        activate_on_single_click: false,
+        selection_mode: Gtk.SelectionMode.SINGLE
         );
     }
 
@@ -60,8 +60,8 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
             // TODO: Differentiate between layer and artboard
             // based upon item "type" of some sort
             return new Akira.Layouts.Partials.Layer (
-                window,
-                (Akira.Models.LayerModel) item
+            window,
+            (Akira.Models.LayerModel) item
             );
         });
 
@@ -96,40 +96,40 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
     }
 
     private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {
-      if (selected_items.length () == 0) {
-        var current_selected_item = item_model_map.@get (current_selected_item_id);
+        if (selected_items.length () == 0) {
+            var current_selected_item = item_model_map.@get (current_selected_item_id);
 
-        if (current_selected_item != null) {
-          current_selected_item.selected = false;
+            if (current_selected_item != null) {
+                current_selected_item.selected = false;
+            }
+
+            current_selected_item_id = null;
+            return;
         }
 
-        current_selected_item_id = null;
-        return;
-      }
+        var selected_item = selected_items.nth_data (0);
 
-      var selected_item = selected_items.nth_data (0);
+        if (selected_item.id == current_selected_item_id) {
+            return;
+        }
 
-      if (selected_item.id == current_selected_item_id) {
-        return;
-      }
+        var new_selected_model = item_model_map.@get (selected_item.id);
 
-      var new_selected_model = item_model_map.@get (selected_item.id);
+        if (new_selected_model != null) {
+            new_selected_model.selected = true;
+        }
 
-      if (new_selected_model != null) {
-        new_selected_model.selected = true;
-      }
+        var current_selected_model = item_model_map.@get (current_selected_item_id);
 
-      var current_selected_model = item_model_map.@get (current_selected_item_id);
+        if (current_selected_model != null) {
+            current_selected_model.selected = false;
+        }
 
-      if (current_selected_model != null) {
-        current_selected_model.selected = false;
-      }
+        current_selected_item_id = selected_item.id;
 
-      current_selected_item_id = selected_item.id;
-
-      // After activating a row it is necessary to
-      // put (keyboard) focus back to the canvas
-      window.event_bus.set_focus_on_canvas ();
+        // After activating a row it is necessary to
+        // put (keyboard) focus back to the canvas
+        window.event_bus.set_focus_on_canvas ();
     }
 
     private void build_drag_and_drop () {
@@ -141,7 +141,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
     }
 
     private void on_drag_data_received (Gdk.DragContext context, int x, int y, Gtk.SelectionData selection_data,
-        uint target_type, uint time) {
+    uint target_type, uint time) {
         Akira.Layouts.Partials.Artboard target;
         Gtk.Widget row;
         Akira.Layouts.Partials.Artboard source;
@@ -225,8 +225,8 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
 
         @foreach (row => {
             if (!(row is Akira.Layouts.Partials.Artboard)) {
-              zebra_layer ((Akira.Layouts.Partials.Layer) row);
-              return;
+                zebra_layer ((Akira.Layouts.Partials.Layer) row);
+                return;
             }
 
             zebra_artboard ((Akira.Layouts.Partials.Artboard) row);

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -43,9 +43,9 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
 
     public LayersPanel (Akira.Window window) {
         Object (
-        window: window,
-        activate_on_single_click: false,
-        selection_mode: Gtk.SelectionMode.SINGLE
+            window: window,
+            activate_on_single_click: false,
+            selection_mode: Gtk.SelectionMode.SINGLE
         );
     }
 
@@ -59,10 +59,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         bind_model (list_model, item => {
             // TODO: Differentiate between layer and artboard
             // based upon item "type" of some sort
-            return new Akira.Layouts.Partials.Layer (
-            window,
-            (Akira.Models.LayerModel) item
-            );
+            return new Akira.Layouts.Partials.Layer (window, (Akira.Models.LayerModel) item);
         });
 
         build_drag_and_drop ();
@@ -140,8 +137,8 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         drag_leave.connect (on_drag_leave);
     }
 
-    private void on_drag_data_received (Gdk.DragContext context, int x, int y, Gtk.SelectionData selection_data,
-    uint target_type, uint time) {
+    private void on_drag_data_received (Gdk.DragContext context, int x, int y,
+        Gtk.SelectionData selection_data, uint target_type, uint time) {
         Akira.Layouts.Partials.Artboard target;
         Gtk.Widget row;
         Akira.Layouts.Partials.Artboard source;

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -254,6 +254,9 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 nob_manager.selected_nob = clicked_nob_name;
 
                 if (clicked_item is Models.CanvasItem) {
+                    if ((clicked_item as Models.CanvasItem).locked) {
+                        return true;
+                    }
                     // Item has been selected
                     selected_bound_manager.add_item_to_selection (clicked_item as Models.CanvasItem);
                 }
@@ -273,7 +276,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     public override bool button_release_event (Gdk.EventButton event) {
         if (!holding) {
-            return false;
+            return true;
         }
 
         holding = false;
@@ -292,7 +295,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 break;
         }
 
-        return false;
+        return true;
     }
 
     public override bool motion_notify_event (Gdk.EventMotion event) {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -83,6 +83,10 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     public void transform_bound (double event_x, double event_y, Managers.NobManager.Nob selected_nob) {
         Models.CanvasItem selected_item = selected_items.nth_data (0);
 
+        if (selected_item == null) {
+            return;
+        }
+
         switch (selected_nob) {
             case Managers.NobManager.Nob.NONE:
                 Utils.AffineTransform.move_from_event (

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -84,7 +84,16 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         string[] type_slug_tokens = item.item_type.to_string ().split ("_");
         string type_slug = type_slug_tokens[type_slug_tokens.length - 1];
 
-        return "%s%d".printf (type_slug, global_id++);
+        return "%s %d".printf (capitalize (type_slug.down ()), global_id++);
+    }
+
+    public static string capitalize (string s) {
+        string back = s;
+        if (s.get_char (0).islower ()) {
+            back = s.get_char (0).toupper ().to_string () + s.substring (1);
+        }
+
+        return back;
     }
 
     public static void init_item (Goo.CanvasItem item) {

--- a/src/Models/LayerModel.vala
+++ b/src/Models/LayerModel.vala
@@ -50,17 +50,23 @@ public class Akira.Models.LayerModel : Models.ItemModel {
         get {
             return item.locked;
         }
-
         set {
             item.locked = value;
 
-            if (item.locked && item.selected) {
-                item.selected = false;
+            if (item.locked) {
+                selected = false;
             }
         }
     }
 
-    public bool selected { get; set; }
+    public bool selected {
+        get {
+            return item.selected;
+        }
+        set {
+            item.selected = value;
+        }
+    }
 
     public LayerModel (
         Lib.Models.CanvasItem item,

--- a/src/Models/LayerModel.vala
+++ b/src/Models/LayerModel.vala
@@ -22,11 +22,7 @@
 public class Akira.Models.LayerModel : Models.ItemModel {
     public string name {
         owned get {
-            if (item.name != null) {
-                return item.name;
-            }
-
-            return item.id;
+            return item.name != null ? item.name : item.id;
         }
         set {
             item.name = value;


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
I stumbled upon a nasty segfault happening when quickly clicking on a locked shape.
We were triggering the `AffineTransform` before checking if we had a selected item and if the item wasn't locked.

Also, an itty bitty update to use box shadows instead of border colors for layer effects.
Box shadows are faster attributes to animate, don't cause the widget to grow in size, and don't force us to manage the left border color when selected.

## Screenshots 
![layers-panel](https://user-images.githubusercontent.com/2527103/73125845-758ff380-3f60-11ea-97a8-29e3d8b92b85.gif)
