### PR TITLE
WIP: Layer Panel Z Ordering with D&D

### DIFF
--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -430,7 +430,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         }
 
         var new_margin_top = 0;
-        var new_margin_right = 0;
 
         if (y > (alloc.height / 2)) {
           // We are trying to move this into the *next* layer
@@ -460,7 +459,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     }
 
     public void clear_indicator (Gdk.DragContext context) {
-        debug ("Clear indicator");
         window.main_window.right_sidebar.indicator.visible = false;
     }
 

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -355,8 +355,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
         ((Gtk.Widget[])data)[0] = widget;
 
-        debug ("On drag data get");
-
         selection_data.set (
             Gdk.Atom.intern_static_string ("LAYER"), 32, data
         );
@@ -370,9 +368,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         } else {
             window.main_window.right_sidebar.indicator.visible = false;
         }
-
-        //var layers_panel = (Akira.Layouts.Partials.LayersPanel) artboard.get_ancestor (typeof
-        //    (Akira.Layouts.Partials.LayersPanel));
 
         int row_index = get_index ();
 
@@ -406,16 +401,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
             window.main_window.right_sidebar.indicator.margin_start = 40;
         } else {
             window.main_window.right_sidebar.indicator.margin_start = 20;
-
-            // Account for nested grouping
-            /*
-            for (int i = index; i >= 1; i--) {
-                var past_layer = (Akira.Layouts.Partials.Layer) row.container.get_row_at_index (i);
-                if (past_layer.grouped) {
-                    group_y = past_layer.get_allocated_height () - alloc.height;
-                }
-            }
-            */
         }
 
         vadjustment = window.main_window.right_sidebar.layers_scroll.vadjustment;
@@ -475,6 +460,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     }
 
     public void clear_indicator (Gdk.DragContext context) {
+        debug ("Clear indicator");
         window.main_window.right_sidebar.indicator.visible = false;
     }
 

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -366,7 +366,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
             window.main_window.right_sidebar.indicator.no_show_all = false;
             window.main_window.right_sidebar.indicator.show_all ();
         } else {
-            window.main_window.right_sidebar.indicator.visible = false;
+            window.event_bus.toggle_sidebar_indicator (false);
         }
 
         int row_index = get_index ();
@@ -380,12 +380,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         Gtk.Allocation alloc;
         get_allocation (out alloc);
 
-        //debug (@"RowIndex: $(row_index)");
-
         Gtk.Allocation row_alloc;
         row.get_allocation (out row_alloc);
-
-        //debug (@"Alloc: $(alloc.width) * $(alloc.height)");
 
         int real_y = (row_index * alloc.height) + y;
 
@@ -419,7 +415,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
             if (y >= (alloc.height / 2)) {
                 get_style_context ().add_class ("highlight");
-                //window.main_window.right_sidebar.indicator.visible = false;
             } else {
                 get_style_context ().remove_class ("highlight");
                 window.main_window.right_sidebar.indicator.margin_top =
@@ -451,15 +446,13 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     }
 
     public void on_drag_leave (Gdk.DragContext context, uint time) {
-        //debug ("On drag leave");
         get_style_context ().remove_class ("highlight");
-        // Remove this visible to prevent indicator flickering between 2 layers
-        //window.main_window.right_sidebar.indicator.visible = false;
+
         should_scroll = false;
     }
 
     public void clear_indicator (Gdk.DragContext context) {
-        window.main_window.right_sidebar.indicator.visible = false;
+        window.event_bus.toggle_sidebar_indicator (false);
     }
 
     public bool on_click_event (Gdk.Event event) {

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -216,7 +216,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
             (parent as Gtk.ListBox).unselect_row (this);
         });
 
-
         lock_actions ();
         hide_actions ();
         reveal_actions ();

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -68,6 +68,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         window.event_bus.item_inserted.connect (on_item_inserted);
         window.event_bus.item_deleted.connect (on_item_deleted);
         window.event_bus.selected_items_changed.connect (on_selected_items_changed);
+        window.event_bus.z_selected_changed.connect (on_z_selected_changed);
     }
 
     private void on_item_inserted (Lib.Models.CanvasItem new_item) {
@@ -127,6 +128,25 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         // After activating a row it is necessary to
         // put (keyboard) focus back to the canvas
         window.event_bus.set_focus_on_canvas ();
+    }
+
+    private void on_z_selected_changed () {
+      debug ("On z-selected-changed");
+
+      foreach (var model in list_model) {
+        Lib.Models.CanvasItem.update_z_index (model.item);
+      }
+
+      list_model.sort ((a, b) => {
+        return a.item.z_index - b.item.z_index;
+      });
+
+      foreach (var model in list_model) {
+        debug (@"Id: $(model.item.id) z_index: $(model.item.z_index)");
+      }
+
+      invalidate_sort ();
+
     }
 
     private void build_drag_and_drop () {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -69,6 +69,19 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         window.event_bus.item_deleted.connect (on_item_deleted);
         window.event_bus.selected_items_changed.connect (on_selected_items_changed);
         window.event_bus.z_selected_changed.connect (on_z_selected_changed);
+
+        set_sort_func (sort_by_z_index);
+    }
+
+    private int sort_by_z_index (Gtk.ListBoxRow a, Gtk.ListBoxRow b) {
+        var row_a = a as Akira.Layouts.Partials.Layer;
+        var row_b = b as Akira.Layouts.Partials.Layer;
+
+        if (row_a != null && row_b != null) {
+            return row_a.model.item.z_index - row_b.model.item.z_index;
+        }
+
+        return 0;
     }
 
     private void on_item_inserted (Lib.Models.CanvasItem new_item) {
@@ -131,22 +144,17 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
     }
 
     private void on_z_selected_changed () {
-      debug ("On z-selected-changed");
+        debug ("On z-selected-changed");
 
-      foreach (var model in list_model) {
-        Lib.Models.CanvasItem.update_z_index (model.item);
-      }
+        var n_items = list_model.get_n_items ();
+        for (int i = 0; i < n_items; i++) {
+            var layer = list_model.get_item (i) as Akira.Models.LayerModel;
+            if (layer != null) {
+                Lib.Models.CanvasItem.update_z_index (layer.item);
+            }
+        }
 
-      list_model.sort ((a, b) => {
-        return a.item.z_index - b.item.z_index;
-      });
-
-      foreach (var model in list_model) {
-        debug (@"Id: $(model.item.id) z_index: $(model.item.z_index)");
-      }
-
-      invalidate_sort ();
-
+        invalidate_sort ();
     }
 
     private void build_drag_and_drop () {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -202,10 +202,8 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
     }
 
     public bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {
-        //  var row = (Akira.Layouts.Partials.Artboard) get_row_at_y (y);
-        return true;
-
         check_scroll (y);
+
         if (should_scroll && !scrolling) {
             scrolling = true;
             Timeout.add (SCROLL_DELAY, scroll);

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -94,7 +94,6 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         item_model_map.@set (new_item.id, model);
 
         reload_zebra ();
-
         show_all ();
     }
 
@@ -144,9 +143,8 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
     }
 
     private void on_z_selected_changed () {
-        debug ("On z-selected-changed");
-
         var n_items = list_model.get_n_items ();
+
         for (int i = 0; i < n_items; i++) {
             var layer = list_model.get_item (i) as Akira.Models.LayerModel;
             if (layer != null) {
@@ -155,6 +153,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         }
 
         invalidate_sort ();
+        reload_zebra ();
     }
 
     private void build_drag_and_drop () {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -38,7 +38,8 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
     private const int SCROLL_DELAY = 50;
 
     private const Gtk.TargetEntry TARGET_ENTRIES[] = {
-        { "ARTBOARD", Gtk.TargetFlags.SAME_APP, 0 }
+        { "ARTBOARD", Gtk.TargetFlags.SAME_APP, 0 },
+        { "LAYER", Gtk.TargetFlags.SAME_APP, 0 }
     };
 
     public LayersPanel (Akira.Window window) {
@@ -161,14 +162,17 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         drag_leave.connect (on_drag_leave);
     }
 
-    private void on_drag_data_received (Gdk.DragContext context, int x, int y,
-        Gtk.SelectionData selection_data, uint target_type, uint time) {
-        Akira.Layouts.Partials.Artboard target;
+    private void on_drag_data_received (
+      Gdk.DragContext context,
+      int x, int y,
+      Gtk.SelectionData selection_data,
+      uint target_type, uint time) {
+        Akira.Layouts.Partials.Layer? target;
         Gtk.Widget row;
-        Akira.Layouts.Partials.Artboard source;
+        Akira.Layouts.Partials.Layer? source;
         int new_position;
 
-        target = (Akira.Layouts.Partials.Artboard) get_row_at_y (y);
+        target = (Akira.Layouts.Partials.Layer) get_row_at_y (y);
 
         if (target == null) {
             new_position = -1;
@@ -178,18 +182,21 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
 
         row = ((Gtk.Widget[]) selection_data.get_data ())[0];
 
-        source = (Akira.Layouts.Partials.Artboard) row.get_ancestor (typeof (Akira.Layouts.Partials.Artboard));
+        //source = (Akira.Layouts.Partials.Artboard) row.get_ancestor (typeof (Akira.Layouts.Partials.Artboard));
+
+        source = row as Akira.Layouts.Partials.Layer;
+
+        debug (@"Source: $(source.model.item.id)");
+        debug (@"Target: $(target.model.item.id)");
 
         if (source == target) {
             return;
         }
-
-        remove (source);
-        insert (source, new_position);
     }
 
     public bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {
         //  var row = (Akira.Layouts.Partials.Artboard) get_row_at_y (y);
+        return true;
 
         check_scroll (y);
         if (should_scroll && !scrolling) {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -69,19 +69,6 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         window.event_bus.item_deleted.connect (on_item_deleted);
         window.event_bus.selected_items_changed.connect (on_selected_items_changed);
         window.event_bus.z_selected_changed.connect (on_z_selected_changed);
-
-        set_sort_func (sort_by_z_index);
-    }
-
-    private int sort_by_z_index (Gtk.ListBoxRow a, Gtk.ListBoxRow b) {
-        var row_a = a as Akira.Layouts.Partials.Layer;
-        var row_b = b as Akira.Layouts.Partials.Layer;
-
-        if (row_a != null && row_b != null) {
-            return row_a.model.item.z_index - row_b.model.item.z_index;
-        }
-
-        return 0;
     }
 
     private void on_item_inserted (Lib.Models.CanvasItem new_item) {
@@ -152,8 +139,18 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
             }
         }
 
-        invalidate_sort ();
+        list_model.sort ((a, b) => {
+          return a.item.z_index - b.item.z_index;
+        });
+
         reload_zebra ();
+
+        show_all ();
+
+        // Activate the selected items again
+        var model = item_model_map.@get (current_selected_item_id);
+
+        model.selected = true;
     }
 
     private void build_drag_and_drop () {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -172,7 +172,19 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         Akira.Layouts.Partials.Layer? source;
         int new_position;
 
-        target = (Akira.Layouts.Partials.Layer) get_row_at_y (y);
+        row = ((Gtk.Widget[]) selection_data.get_data ())[0];
+        source = row as Akira.Layouts.Partials.Layer;
+
+        Gtk.Allocation alloc;
+        source.get_allocation (out alloc);
+
+        // In order to determine which position should the dragged
+        // item occupy, we need to check in which gap it is.
+        // By adding half of the height of a row we know between which
+        // rows we want to inser the dragged layer
+        var target_row_y = y + alloc.height / 2;
+
+        target = (Akira.Layouts.Partials.Layer) get_row_at_y (target_row_y);
 
         if (target == null) {
             new_position = -1;
@@ -180,18 +192,13 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
             new_position = target.get_index ();
         }
 
-        row = ((Gtk.Widget[]) selection_data.get_data ())[0];
-
-        //source = (Akira.Layouts.Partials.Artboard) row.get_ancestor (typeof (Akira.Layouts.Partials.Artboard));
-
-        source = row as Akira.Layouts.Partials.Layer;
-
-        debug (@"Source: $(source.model.item.id)");
-        debug (@"Target: $(target.model.item.id)");
-
         if (source == target) {
             return;
         }
+
+        window.event_bus.change_item_z_index (source.model.item, new_position);
+
+        window.main_window.right_sidebar.indicator.visible = false;
     }
 
     public bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -197,8 +197,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         }
 
         window.event_bus.change_item_z_index (source.model.item, new_position);
-
-        window.main_window.right_sidebar.indicator.visible = false;
+        window.event_bus.toggle_sidebar_indicator (false);
     }
 
     public bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -74,7 +74,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
 
     private void on_item_inserted (Lib.Models.CanvasItem new_item) {
         var model = new Akira.Models.LayerModel (new_item, list_model);
-        list_model.add_item.begin (model);
+        list_model.add_item.begin (model, false);
 
         // This map is necessary for easily knowing which
         // item is related to which model, since the canvas knows only
@@ -141,7 +141,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         }
 
         list_model.sort ((a, b) => {
-          return a.item.z_index - b.item.z_index;
+          return b.item.z_index - a.item.z_index;
         });
 
         reload_zebra ();
@@ -189,7 +189,11 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         if (target == null) {
             new_position = -1;
         } else {
-            new_position = target.get_index ();
+            // New position needs to take into account the fact
+            // that the higher the item in the canvas the lower the index
+            // in the list. So the actual new position is the length of the
+            // list minus the index of the element
+            new_position = (int) list_model.get_n_items () - target.get_index ();
         }
 
         if (source == target) {

--- a/src/Layouts/RightSideBar.vala
+++ b/src/Layouts/RightSideBar.vala
@@ -113,6 +113,10 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         pages_scroll.add (pages_panel);
 
         attach (pane, 0 , 0 , 1, 1);
+
+        window.event_bus.toggle_sidebar_indicator.connect ((show_indicator) => {
+            indicator.visible = show_indicator;
+        });
     }
 
     private Gtk.Grid build_search_bar () {

--- a/src/Layouts/RightSideBar.vala
+++ b/src/Layouts/RightSideBar.vala
@@ -80,6 +80,7 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         indicator.margin_start = 20;
         indicator.margin_end = 5;
         indicator.height_request = 1;
+        indicator.can_focus = false;
 
         var circle = new Gtk.Grid ();
         circle.get_style_context ().add_class ("indicator-circle");

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -211,12 +211,15 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 break;
 
             default:
-                var item_at_position = root_item.get_child (position);
+                Goo.CanvasItem item_at_position = null;
+
                 var current_position = root_item.find_child (item);
 
                 if (current_position > position) {
+                    item_at_position = root_item.get_child (position);
                     item.lower (item_at_position);
                 } else {
+                    item_at_position = root_item.get_child (position - 1);
                     item.raise (item_at_position);
                 }
                 break;

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -197,13 +197,13 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         var root_item = item.get_canvas ().get_root_item ();
 
         switch (position) {
-            case 0:
-                // Put the item at the bottom of the stack
+            case -1:
+                // Put the item at the top of the stack
                 item.lower (null);
                 break;
 
-            case -1:
-                // Put the item on top of the stack
+            case 0:
+                // Put the item on bottom of the stack
                 var canvas_item_at_top_position = root_item.get_n_children () - 11;
                 var canvas_item_at_top = root_item.get_child (canvas_item_at_top_position);
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -211,8 +211,14 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 break;
 
             default:
-                var item_at_position = root_item.get_child (position - 1);
-                item.raise (item_at_position);
+                var item_at_position = root_item.get_child (position);
+                var current_position = root_item.find_child (item);
+
+                if (current_position > position) {
+                    item.lower (item_at_position);
+                } else {
+                    item.raise (item_at_position);
+                }
                 break;
         }
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -51,6 +51,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
 
         canvas.window.event_bus.insert_item.connect (set_item_to_insert);
         canvas.window.event_bus.request_delete_item.connect (on_request_delete_item);
+        canvas.window.event_bus.change_item_z_index.connect (on_change_item_z_index);
     }
 
     public bool set_insert_type_from_key (uint keyval) {
@@ -189,4 +190,33 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             border_color.parse (settings.border_color);
         }
     }
+
+    private void on_change_item_z_index (Lib.Models.CanvasItem item, int position) {
+        // Lower `item` behind the item at index `position` or raise
+        // it above the item at index `position - 1`
+        var root_item = item.get_canvas ().get_root_item ();
+
+        switch (position) {
+            case 0:
+                // Put the item at the bottom of the stack
+                item.lower (null);
+                break;
+
+            case -1:
+                // Put the item on top of the stack
+                var canvas_item_at_top_position = root_item.get_n_children () - 11;
+                var canvas_item_at_top = root_item.get_child (canvas_item_at_top_position);
+
+                item.raise (canvas_item_at_top);
+                break;
+
+            default:
+                var item_at_position = root_item.get_child (position - 1);
+                item.raise (item_at_position);
+                break;
+        }
+
+        canvas.window.event_bus.z_selected_changed ();
+    }
+
 }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -56,6 +56,7 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public bool selected { get; set; }
     public bool locked { get; set; }
     public string layer_icon { get; set; default = "shape-circle-symbolic"; }
+    public int z_index { get; set; }
 
     public CanvasEllipse (
         double _center_x = 0,

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -64,6 +64,7 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
     public bool selected { get; set; }
     public bool locked { get; set; }
     public string layer_icon { get; set; default = "shape-image-symbolic"; }
+    public int z_index { get; set; }
 
     public CanvasImage (Akira.Services.ImageProvider provider, Goo.CanvasItem? parent = null) {
         Object (

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -107,7 +107,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public static void update_z_index (Goo.CanvasItem item) {
         var z_index = item.get_canvas ().get_root_item ().find_child (item);
 
-        item.set ("z_index", z_index);
+        item.set ("z-index", z_index);
     }
 
     public virtual void reset_colors () {

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -66,6 +66,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public abstract bool selected { get; set; }
     public abstract bool locked { get; set; default = false; }
     public abstract string layer_icon { get; set; }
+    public abstract int z_index { get; set; }
 
     public double get_coords (string coord_id) {
         double _coord = 0.0;
@@ -99,6 +100,14 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         item.set ("opacity", 100.0);
         item.set ("fill-alpha", 255);
         item.set ("stroke-alpha", 255);
+
+        update_z_index (item);
+    }
+
+    public static void update_z_index (Goo.CanvasItem item) {
+        var z_index = item.get_canvas ().get_root_item ().find_child (item);
+
+        item.set ("z_index", z_index);
     }
 
     public virtual void reset_colors () {

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -56,6 +56,7 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public bool selected { get; set; }
     public bool locked { get; set; }
     public string layer_icon { get; set; default = "shape-rectangle-symbolic"; }
+    public int z_index { get; set; }
 
     // Shape's unique identifiers.
     public bool is_radius_uniform { get; set; }

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -56,6 +56,7 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public bool selected { get; set; }
     public bool locked { get; set; }
     public string layer_icon { get; set; default = "shape-text-symbolic"; }
+    public int z_index { get; set; }
 
     public CanvasText (
         string _text = "",

--- a/src/Models/LayerModel.vala
+++ b/src/Models/LayerModel.vala
@@ -22,7 +22,7 @@
 public class Akira.Models.LayerModel : Models.ItemModel {
     public string name {
         owned get {
-            return item.name != null ? item.name : item.id;
+            return item.name != null ? item.name : @"$(item.id) $(item.z_index)";
         }
         set {
             item.name = value;

--- a/src/Models/LayerModel.vala
+++ b/src/Models/LayerModel.vala
@@ -22,7 +22,7 @@
 public class Akira.Models.LayerModel : Models.ItemModel {
     public string name {
         owned get {
-            return item.name != null ? item.name : @"$(item.id) $(item.z_index)";
+            return item.name != null ? item.name : item.id;
         }
         set {
             item.name = value;

--- a/src/Models/ListModel.vala
+++ b/src/Models/ListModel.vala
@@ -20,6 +20,25 @@
 * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
+public class Iterator {
+  private int index;
+  private weak GLib.List<Akira.Models.ItemModel?> list;
+
+  public Iterator (GLib.List<Akira.Models.ItemModel?> list) {
+    index = 0;
+    this.list = list;
+  }
+
+  public bool next () {
+    return index < list.length ();
+  }
+
+  public Akira.Models.ItemModel? get () {
+    index++;
+    return this.list.nth_data (index - 1);
+  }
+}
+
 public class Akira.Models.ListModel : GLib.Object, GLib.ListModel {
     private GLib.List<Akira.Models.ItemModel?> list;
 
@@ -65,5 +84,14 @@ public class Akira.Models.ListModel : GLib.Object, GLib.ListModel {
         list.foreach ((item) => {
             remove_item.begin (item);
         });
+    }
+
+    public Iterator iterator () {
+      return new Iterator(list);
+    }
+
+    public void sort (CompareFunc<Akira.Models.ItemModel?> sort_fn) {
+      list.sort (sort_fn);
+      items_changed (0, 0, 0);
     }
 }

--- a/src/Models/ListModel.vala
+++ b/src/Models/ListModel.vala
@@ -20,25 +20,6 @@
 * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
-public class Iterator {
-  private int index;
-  private weak GLib.List<Akira.Models.ItemModel?> list;
-
-  public Iterator (GLib.List<Akira.Models.ItemModel?> list) {
-    index = 0;
-    this.list = list;
-  }
-
-  public bool next () {
-    return index < list.length ();
-  }
-
-  public Akira.Models.ItemModel? get () {
-    index++;
-    return this.list.nth_data (index - 1);
-  }
-}
-
 public class Akira.Models.ListModel : GLib.Object, GLib.ListModel {
     private GLib.List<Akira.Models.ItemModel?> list;
 
@@ -84,14 +65,5 @@ public class Akira.Models.ListModel : GLib.Object, GLib.ListModel {
         list.foreach ((item) => {
             remove_item.begin (item);
         });
-    }
-
-    public Iterator iterator () {
-      return new Iterator(list);
-    }
-
-    public void sort (CompareFunc<Akira.Models.ItemModel?> sort_fn) {
-      list.sort (sort_fn);
-      items_changed (0, 0, 0);
     }
 }

--- a/src/Models/ListModel.vala
+++ b/src/Models/ListModel.vala
@@ -66,4 +66,10 @@ public class Akira.Models.ListModel : GLib.Object, GLib.ListModel {
             remove_item.begin (item);
         });
     }
+
+    public void sort (CompareFunc<Akira.Models.ItemModel?> sort_fn) {
+        list.sort (sort_fn);
+
+        items_changed (0, list.length (), list.length ());
+    }
 }

--- a/src/Models/ListModel.vala
+++ b/src/Models/ListModel.vala
@@ -45,9 +45,15 @@ public class Akira.Models.ListModel : GLib.Object, GLib.ListModel {
         return typeof (Akira.Models.ItemModel);
     }
 
-    public async void add_item (Akira.Models.ItemModel model_item) {
-        list.append (model_item);
-        items_changed (get_n_items () - 1, 0, 1);
+    public async void add_item (Akira.Models.ItemModel model_item, bool append = true) {
+        if (append) {
+            list.append (model_item);
+            items_changed (get_n_items () - 1, 0, 1);
+            return;
+        }
+
+        list.prepend (model_item);
+        items_changed (0, 0, 1);
     }
 
     public async void remove_item (Object? item_model) {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -57,6 +57,7 @@ public class Akira.Services.EventBus : Object {
     public signal void hover_over_item (Lib.Models.CanvasItem? item);
     public signal void item_deleted (Lib.Models.CanvasItem item);
     public signal void item_locked (Lib.Models.CanvasItem item);
+    public signal void change_item_z_index (Lib.Models.CanvasItem item, int position);
 
     // Others.
     public signal void disconnect_typing_accel ();

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -58,6 +58,7 @@ public class Akira.Services.EventBus : Object {
     public signal void item_deleted (Lib.Models.CanvasItem item);
     public signal void item_locked (Lib.Models.CanvasItem item);
     public signal void change_item_z_index (Lib.Models.CanvasItem item, int position);
+    public signal void toggle_sidebar_indicator (bool show);
 
     // Others.
     public signal void disconnect_typing_accel ();


### PR DESCRIPTION
Goal of this PR is to bring the drag and drop capability back to the LayerPanel, in order to sync the LayerPanel list of items with the current z-index state of the canvas.

Another goal of this PR is to document the process behind the drag&drop which currently is not completely clear. 

For now, I'll focus on bringing back the basic functionality of the panel (such us layer z-index ordering). 
When we'll handle the grouping and artboard features, we'll extend the inner working to also cover those new piece of functionality. 
 
## Steps to Test
* Move the layers in the LayerPanel with D&D to change the z-index ordering of the items in the canvas
* Change z-index ordering with the actions on the HeaderBar to see the changes reflected in the LayersPanel

## Screenshots
![layer_z_ordering_d d](https://user-images.githubusercontent.com/11556031/74084766-a1d46580-4a72-11ea-8a76-1c10333b215c.gif)

## TODO List

- [x] Changes in the z-index of an item is reflected in the LayersPanel
- [x] Drag & Drop in the LayersPanel changes the z-index of the item in the canvas

## Known Issues

- When hovering over the `indicator` the cursor changes, as this widget is seen as a drop target. This could be caused by the fact the the `indicator` is over the `LayersPanel` iteself. We need to enable dropping only on the `LayerPanel`. This could cause problems when the user tries to drop and item on the orange line of the `indicator`, which could be frequent. 
- Trying to drop an item at the beginning of the list could be tricky since the drop area is limited to the `LayerPanel` and it is possible that the cursor is released onto the searchbar. Maybe we could handle this by extending the drop zone to the `RightPanel` instead of having it limited to the LayersPanel. 