### PR TITLE
Fix unwanted pressed CTRL on canvas when opening settings dialog

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -151,40 +151,42 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         switch (uppercase_keyval) {
             case Gdk.Key.Escape:
                 edit_mode = Akira.Lib.Canvas.EditMode.MODE_SELECTION;
-                return true;
+                break;
 
             case Gdk.Key.Delete:
                 selected_bound_manager.delete_selection ();
-                return true;
+                break;
 
             case Gdk.Key.space:
                 if (edit_mode != EditMode.MODE_PANNING) {
                     edit_mode = EditMode.MODE_PAN;
                 }
-                return true;
+                break;
 
             case Gdk.Key.Control_L:
             case Gdk.Key.Control_R:
                 ctrl_is_pressed = true;
-                return true;
+                break;
 
             case Gdk.Key.Up:
             case Gdk.Key.Down:
             case Gdk.Key.Right:
             case Gdk.Key.Left:
                 window.event_bus.move_item_from_canvas (event);
-                return true;
+                break;
 
             default:
                 // Send to ItemsManager to deal with custom user shape
                 // hotkey preferences from settings
                 if (items_manager.set_insert_type_from_key (uppercase_keyval)) {
                     edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
-                    return true;
+                    break;
                 }
 
-                return false;
+                break;
         }
+
+        return true;
     }
 
     public override bool key_release_event (Gdk.EventKey event) {
@@ -327,6 +329,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     public void on_set_focus_on_canvas () {
         edit_mode = EditMode.MODE_SELECTION;
+        ctrl_is_pressed = false;
         focus_canvas ();
     }
 

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -174,6 +174,9 @@ public class Akira.Services.ActionManager : Object {
         var settings_dialog = new Akira.Widgets.SettingsDialog (window);
         settings_dialog.show_all ();
         settings_dialog.present ();
+        settings_dialog.close.connect (() => {
+            window.event_bus.set_focus_on_canvas ();
+        });
     }
 
     private void action_export_selection () {


### PR DESCRIPTION
This fixes a tiny annoying bug with the lock size ratio.
We set `ctrl_is_pressed` to TRUE when the <kbd>CTRL</kbd> key is pressed to enable the lock resize on item creation, and then we set it back to FALSE once that key is released.

Since we're opening the Settings Panel with the keystroke combination <kbd>CTRL</kbd> + <kbd>.</kbd>, we were setting `ctrl_is_pressed` to TRUE but never back to FALSE since the focus moved away from the Canvas.

I fixed it by listening to the `close()` signal of the settings dialog to force the focus back to the canvas, and resetting that variable to FALSE when the canvas gets the focus back.