### PR TITLE
Improve typing on GtkEntry widgets

### DIFF
--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+ * Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
  *
  * This file is part of Akira.
  *
@@ -10,11 +10,11 @@
 
  * Akira is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
 
  * You should have received a copy of the GNU General Public License
- * along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
  *
  * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
  */

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -10,11 +10,11 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -67,6 +67,8 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         entry.visible = false;
         entry.no_show_all = true;
         entry.set_text (layer_name);
+        entry.focus_in_event.connect (handle_focus_in);
+        entry.focus_out_event.connect (handle_focus_out);
 
         entry.activate.connect (update_on_enter);
         entry.focus_out_event.connect (update_on_leave);
@@ -441,5 +443,15 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
                 layers_count++;
             }
         });
+    }
+
+    private bool handle_focus_in (Gdk.EventFocus event) {
+        window.event_bus.disconnect_typing_accel ();
+        return false;
+    }
+
+    private bool handle_focus_out (Gdk.EventFocus event) {
+        window.event_bus.connect_typing_accel ();
+        return false;
     }
 }

--- a/src/Layouts/Partials/BorderItem.vala
+++ b/src/Layouts/Partials/BorderItem.vala
@@ -28,7 +28,7 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
     private Gtk.Image hidden_button_icon;
     private Gtk.MenuButton selected_color;
     public Akira.Partials.InputField tickness_container;
-    public Gtk.Entry color_container;
+    public Akira.Partials.ColorField color_container;
     private Gtk.Popover color_popover;
     private Gtk.Grid color_picker;
     private Gtk.ColorChooserWidget color_chooser_widget;
@@ -122,14 +122,8 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
         picker_container.get_style_context ().add_class ("bg-pattern");
         picker_container.add (selected_color);
 
-        color_container = new Gtk.Entry ();
-        color_container.margin_end = 10;
-        color_container.width_chars = 8;
-        color_container.max_length = 7;
-        color_container.hexpand = true;
+        color_container = new Akira.Partials.ColorField (window);
         color_container.text = Utils.Color.rgba_to_hex (color);
-        color_container.focus_in_event.connect (handle_focus_in);
-        color_container.focus_out_event.connect (handle_focus_out);
 
         color_container.bind_property (
             "text", model, "color",
@@ -156,41 +150,6 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
                 return true;
             }
         );
-
-        color_container.insert_text.connect ((_new_text, new_text_length) => {
-            string new_text = _new_text.strip ();
-
-            if (new_text.contains ("#")) {
-                new_text = new_text.substring (1, new_text.length - 1);
-            } else if (!color_container.text.contains ("#")) {
-                GLib.Signal.stop_emission_by_name (color_container, "insert-text");
-
-                var builder = new StringBuilder ();
-                builder.append (new_text);
-                builder.prepend ("#");
-                color_container.text = builder.str;
-            }
-
-            bool is_valid_hex = true;
-            bool char_is_numeric = true;
-            bool char_is_valid_alpha = true;
-
-            char keyval;
-
-            for (var i = 0; i < new_text.length; i++) {
-                keyval = new_text [i];
-
-                char_is_numeric = keyval >= Gdk.Key.@0 && keyval <= Gdk.Key.@9;
-                char_is_valid_alpha = keyval >= Gdk.Key.A && keyval <= Gdk.Key.F;
-
-                is_valid_hex &= keyval.isxdigit ();
-            }
-
-            if (!is_valid_hex) {
-                GLib.Signal.stop_emission_by_name (color_container, "insert-text");
-                return;
-            }
-        });
 
         tickness_container = new Akira.Partials.InputField (
             Akira.Partials.InputField.Unit.PIXEL, 7, true, true);
@@ -320,15 +279,5 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
         new_rgba.alpha = (double) alpha / 255;
 
         color_chooser_widget.set_rgba (new_rgba);
-    }
-
-    private bool handle_focus_in (Gdk.EventFocus event) {
-        window.event_bus.disconnect_typing_accel ();
-        return false;
-    }
-
-    private bool handle_focus_out (Gdk.EventFocus event) {
-        window.event_bus.connect_typing_accel ();
-        return false;
     }
 }

--- a/src/Layouts/Partials/BorderItem.vala
+++ b/src/Layouts/Partials/BorderItem.vala
@@ -157,29 +157,21 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
             }
         );
 
-        color_container.delete_text.connect ((start_pos, end_pos) => {
-            if (end_pos == -1) {
-                // We are replacing the string from the internal
-                // Not by manually selecting the text, so we don't need to check anything
-                return;
-            }
-
-            string new_text = color_container.text.splice (start_pos, end_pos);
-
-            if (!new_text.contains ("#")) {
-                GLib.Signal.stop_emission_by_name (color_container, "delete-text");
-            }
-        });
-
         color_container.insert_text.connect ((_new_text, new_text_length) => {
             string new_text = _new_text.strip ();
 
             if (new_text.contains ("#")) {
                 new_text = new_text.substring (1, new_text.length - 1);
+            } else if (!color_container.text.contains ("#")) {
+                GLib.Signal.stop_emission_by_name (color_container, "insert-text");
+
+                var builder = new StringBuilder ();
+                builder.append (new_text);
+                builder.prepend ("#");
+                color_container.text = builder.str;
             }
 
             bool is_valid_hex = true;
-
             bool char_is_numeric = true;
             bool char_is_valid_alpha = true;
 

--- a/src/Layouts/Partials/BorderItem.vala
+++ b/src/Layouts/Partials/BorderItem.vala
@@ -128,6 +128,8 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
         color_container.max_length = 7;
         color_container.hexpand = true;
         color_container.text = Utils.Color.rgba_to_hex (color);
+        color_container.focus_in_event.connect (handle_focus_in);
+        color_container.focus_out_event.connect (handle_focus_out);
 
         color_container.bind_property (
             "text", model, "color",
@@ -326,5 +328,15 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
         new_rgba.alpha = (double) alpha / 255;
 
         color_chooser_widget.set_rgba (new_rgba);
+    }
+
+    private bool handle_focus_in (Gdk.EventFocus event) {
+        window.event_bus.disconnect_typing_accel ();
+        return false;
+    }
+
+    private bool handle_focus_out (Gdk.EventFocus event) {
+        window.event_bus.connect_typing_accel ();
+        return false;
     }
 }

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -150,29 +150,21 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
             }
         );
 
-        color_container.delete_text.connect ((start_pos, end_pos) => {
-            if (end_pos == -1) {
-                // We are replacing the string from the internal
-                // Not by manually selecting the text, so we don't need to check anything
-                return;
-            }
-
-            string new_text = color_container.text.splice (start_pos, end_pos);
-
-            if (!new_text.contains ("#")) {
-                GLib.Signal.stop_emission_by_name (color_container, "delete-text");
-            }
-        });
-
         color_container.insert_text.connect ((_new_text, new_text_length) => {
             string new_text = _new_text.strip ();
 
             if (new_text.contains ("#")) {
                 new_text = new_text.substring (1, new_text.length - 1);
+            } else if (!color_container.text.contains ("#")) {
+                GLib.Signal.stop_emission_by_name (color_container, "insert-text");
+
+                var builder = new StringBuilder ();
+                builder.append (new_text);
+                builder.prepend ("#");
+                color_container.text = builder.str;
             }
 
             bool is_valid_hex = true;
-
             bool char_is_numeric = true;
             bool char_is_valid_alpha = true;
 

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -29,7 +29,7 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
     private Gtk.Image hidden_button_icon;
     private Gtk.MenuButton selected_color;
     public Akira.Partials.InputField opacity_container;
-    public Gtk.Entry color_container;
+    public Akira.Partials.ColorField color_container;
     private Gtk.Popover color_popover;
     private Gtk.Grid color_picker;
     private Gtk.ColorChooserWidget color_chooser_widget;
@@ -115,14 +115,8 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         picker_container.get_style_context ().add_class ("bg-pattern");
         picker_container.add (selected_color);
 
-        color_container = new Gtk.Entry ();
-        color_container.margin_end = 10;
-        color_container.width_chars = 8;
-        color_container.max_length = 7;
-        color_container.hexpand = true;
+        color_container = new Akira.Partials.ColorField (window);
         color_container.text = Utils.Color.rgba_to_hex (color);
-        color_container.focus_in_event.connect (handle_focus_in);
-        color_container.focus_out_event.connect (handle_focus_out);
 
         color_container.bind_property (
             "text", model, "color",
@@ -149,41 +143,6 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
                 return true;
             }
         );
-
-        color_container.insert_text.connect ((_new_text, new_text_length) => {
-            string new_text = _new_text.strip ();
-
-            if (new_text.contains ("#")) {
-                new_text = new_text.substring (1, new_text.length - 1);
-            } else if (!color_container.text.contains ("#")) {
-                GLib.Signal.stop_emission_by_name (color_container, "insert-text");
-
-                var builder = new StringBuilder ();
-                builder.append (new_text);
-                builder.prepend ("#");
-                color_container.text = builder.str;
-            }
-
-            bool is_valid_hex = true;
-            bool char_is_numeric = true;
-            bool char_is_valid_alpha = true;
-
-            char keyval;
-
-            for (var i = 0; i < new_text.length; i++) {
-                keyval = new_text [i];
-
-                char_is_numeric = keyval >= Gdk.Key.@0 && keyval <= Gdk.Key.@9;
-                char_is_valid_alpha = keyval >= Gdk.Key.A && keyval <= Gdk.Key.F;
-
-                is_valid_hex &= keyval.isxdigit ();
-            }
-
-            if (!is_valid_hex) {
-                GLib.Signal.stop_emission_by_name (color_container, "insert-text");
-                return;
-            }
-        });
 
         opacity_container = new Akira.Partials.InputField (
             Akira.Partials.InputField.Unit.PERCENTAGE, 7, true, true);
@@ -322,15 +281,5 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         new_rgba.alpha = (double) alpha / 255;
 
         color_chooser_widget.set_rgba (new_rgba);
-    }
-
-    private bool handle_focus_in (Gdk.EventFocus event) {
-        window.event_bus.disconnect_typing_accel ();
-        return false;
-    }
-
-    private bool handle_focus_out (Gdk.EventFocus event) {
-        window.event_bus.connect_typing_accel ();
-        return false;
     }
 }

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -121,6 +121,8 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         color_container.max_length = 7;
         color_container.hexpand = true;
         color_container.text = Utils.Color.rgba_to_hex (color);
+        color_container.focus_in_event.connect (handle_focus_in);
+        color_container.focus_out_event.connect (handle_focus_out);
 
         color_container.bind_property (
             "text", model, "color",
@@ -328,5 +330,15 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         new_rgba.alpha = (double) alpha / 255;
 
         color_chooser_widget.set_rgba (new_rgba);
+    }
+
+    private bool handle_focus_in (Gdk.EventFocus event) {
+        window.event_bus.disconnect_typing_accel ();
+        return false;
+    }
+
+    private bool handle_focus_out (Gdk.EventFocus event) {
+        window.event_bus.connect_typing_accel ();
+        return false;
     }
 }

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019-2020 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -10,11 +10,11 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -117,6 +117,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         entry.activate.connect (update_on_enter);
         entry.focus_out_event.connect (update_on_leave);
         entry.key_release_event.connect (update_on_escape);
+        entry.focus_in_event.connect (handle_focus_in);
+        entry.focus_out_event.connect (handle_focus_out);
 
         icon = new Gtk.Image.from_icon_name (model.icon, Gtk.IconSize.MENU);
         icon.margin_start = icon_name != "folder-symbolic" ? 16 : 0;
@@ -693,5 +695,15 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         }
 
         return should_scroll;
+    }
+
+    private bool handle_focus_in (Gdk.EventFocus event) {
+        window.event_bus.disconnect_typing_accel ();
+        return false;
+    }
+
+    private bool handle_focus_out (Gdk.EventFocus event) {
+        window.event_bus.connect_typing_accel ();
+        return false;
     }
 }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -1,25 +1,26 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
-*
-* This file is part of Akira.
-*
-* Akira is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+ * Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
 
-* Akira is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
 
-* You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
-*
-* Authored by: Felipe Escoto <felescoto95@hotmail.com>
-* Authored by: Alberto Fanjul <albertofanjul@gmail.com>
-* Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
-*/
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Felipe Escoto <felescoto95@hotmail.com>
+ * Authored by: Alberto Fanjul <albertofanjul@gmail.com>
+ * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+ */
 
 public class Akira.Lib.Canvas : Goo.Canvas {
     public weak Akira.Window window { get; construct; }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -174,16 +174,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Gdk.Key.Left:
                 window.event_bus.move_item_from_canvas (event);
                 break;
-
-            default:
-                // Send to ItemsManager to deal with custom user shape
-                // hotkey preferences from settings
-                if (items_manager.set_insert_type_from_key (uppercase_keyval)) {
-                    edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
-                    break;
-                }
-
-                break;
         }
 
         return true;
@@ -195,16 +185,15 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         switch (uppercase_keyval) {
             case Gdk.Key.space:
                 edit_mode = EditMode.MODE_SELECTION;
-                return true;
+                break;
 
             case Gdk.Key.Control_L:
             case Gdk.Key.Control_R:
                 ctrl_is_pressed = false;
-                return true;
-
-            default:
-                return false;
+                break;
         }
+
+        return false;
     }
 
     public override bool button_press_event (Gdk.EventButton event) {

--- a/src/Partials/ColorField.vala
+++ b/src/Partials/ColorField.vala
@@ -1,0 +1,85 @@
+/*
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
+*
+* This file is part of Akira.
+*
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
+*
+* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+*/
+
+public class Akira.Partials.ColorField : Gtk.Entry {
+    public weak Akira.Window window { get; construct; }
+
+    public ColorField (Akira.Window window) {
+        Object (
+            window: window
+        );
+    }
+
+    construct {
+        margin_end = 10;
+        width_chars = 8;
+        max_length = 7;
+        hexpand = true;
+
+        focus_in_event.connect (handle_focus_in);
+        focus_out_event.connect (handle_focus_out);
+
+        insert_text.connect ((_new_text, new_text_length) => {
+            string new_text = _new_text.strip ();
+
+            if (new_text.contains ("#")) {
+                new_text = new_text.substring (1, new_text.length - 1);
+            } else if (!this.text.contains ("#")) {
+                GLib.Signal.stop_emission_by_name (this, "insert-text");
+
+                var builder = new StringBuilder ();
+                builder.append (new_text);
+                builder.prepend ("#");
+                this.text = builder.str;
+            }
+
+            bool is_valid_hex = true;
+            bool char_is_numeric = true;
+            bool char_is_valid_alpha = true;
+
+            char keyval;
+
+            for (var i = 0; i < new_text.length; i++) {
+                keyval = new_text [i];
+
+                char_is_numeric = keyval >= Gdk.Key.@0 && keyval <= Gdk.Key.@9;
+                char_is_valid_alpha = keyval >= Gdk.Key.A && keyval <= Gdk.Key.F;
+
+                is_valid_hex &= keyval.isxdigit ();
+            }
+
+            if (!is_valid_hex) {
+                GLib.Signal.stop_emission_by_name (this, "insert-text");
+                return;
+            }
+        });
+    }
+
+    private bool handle_focus_in (Gdk.EventFocus event) {
+        window.event_bus.disconnect_typing_accel ();
+        return false;
+    }
+
+    private bool handle_focus_out (Gdk.EventFocus event) {
+        window.event_bus.connect_typing_accel ();
+        return false;
+    }
+}

--- a/src/Partials/InputField.vala
+++ b/src/Partials/InputField.vala
@@ -20,6 +20,7 @@
 */
 
 public class Akira.Partials.InputField : Gtk.EventBox {
+    //  private Akira.Window window;
     public Gtk.SpinButton entry { get; construct set; }
 
     public int chars { get; construct set; }
@@ -51,6 +52,7 @@ public class Akira.Partials.InputField : Gtk.EventBox {
     }
 
     construct {
+        //  window = get_toplevel () as Akira.Window;
         valign = Gtk.Align.CENTER;
 
         entry = new Gtk.SpinButton.with_range (0, 100, step);
@@ -60,6 +62,8 @@ public class Akira.Partials.InputField : Gtk.EventBox {
 
         entry.key_press_event.connect (handle_key_press);
         entry.scroll_event.connect (handle_scroll_event);
+        entry.focus_in_event.connect (handle_focus_in);
+        entry.focus_out_event.connect (handle_focus_out);
 
         switch (unit) {
             case Unit.HASH:
@@ -120,6 +124,20 @@ public class Akira.Partials.InputField : Gtk.EventBox {
         if (!entry.has_focus) {
             return true;
         }
+        return false;
+    }
+
+    private bool handle_focus_in (Gdk.EventFocus event) {
+        Akira.Window window = get_toplevel () as Akira.Window;
+        window.event_bus.disconnect_typing_accel ();
+
+        return false;
+    }
+
+    private bool handle_focus_out (Gdk.EventFocus event) {
+        Akira.Window window = get_toplevel () as Akira.Window;
+        window.event_bus.connect_typing_accel ();
+
         return false;
     }
 }

--- a/src/Partials/LinkedInput.vala
+++ b/src/Partials/LinkedInput.vala
@@ -1,23 +1,23 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
 *
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 2 of the License, or (at your option) any later version.
+* This file is part of Akira.
 *
-* This program is distributed in the hope that it will be useful,
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Ana Gelez <ana@gelez.xyz>
-*              Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
 /**

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -56,6 +56,7 @@ public class Akira.Services.ActionManager : Object {
     public const string ACTION_ESCAPE = "action_escape";
 
     public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
+    public static Gee.MultiMap<string, string> typing_accelerators = new Gee.HashMultiMap<string, string> ();
 
     private const ActionEntry[] ACTION_ENTRIES = {
         { ACTION_NEW_WINDOW, action_new_window },
@@ -116,14 +117,15 @@ public class Akira.Services.ActionManager : Object {
         action_accelerators.set (ACTION_MOVE_DOWN, "<Control>Down");
         action_accelerators.set (ACTION_MOVE_TOP, "<Control><Shift>Up");
         action_accelerators.set (ACTION_MOVE_BOTTOM, "<Control><Shift>Down");
-        action_accelerators.set (ACTION_ARTBOARD_TOOL, "a");
-        action_accelerators.set (ACTION_RECT_TOOL, "r");
-        action_accelerators.set (ACTION_ELLIPSE_TOOL, "e");
-        action_accelerators.set (ACTION_TEXT_TOOL, "t");
-        action_accelerators.set (ACTION_IMAGE_TOOL, "i");
         action_accelerators.set (ACTION_FLIP_H, "<Control>bracketleft");
         action_accelerators.set (ACTION_FLIP_V, "<Control>bracketright");
         action_accelerators.set (ACTION_ESCAPE, "Escape");
+
+        typing_accelerators.set (ACTION_ARTBOARD_TOOL, "a");
+        typing_accelerators.set (ACTION_RECT_TOOL, "r");
+        typing_accelerators.set (ACTION_ELLIPSE_TOOL, "e");
+        typing_accelerators.set (ACTION_TEXT_TOOL, "t");
+        typing_accelerators.set (ACTION_IMAGE_TOOL, "i");
     }
 
     construct {
@@ -133,6 +135,25 @@ public class Akira.Services.ActionManager : Object {
 
         foreach (var action in action_accelerators.get_keys ()) {
             app.set_accels_for_action (ACTION_PREFIX + action, action_accelerators[action].to_array ());
+        }
+
+        enable_typing_accels ();
+
+        window.event_bus.disconnect_typing_accel.connect (disable_typing_accels);
+        window.event_bus.connect_typing_accel.connect (enable_typing_accels);
+    }
+
+    // Temporarily disable all the accelerators that might interfere with input fields.
+    private void disable_typing_accels () {
+        foreach (var action in typing_accelerators.get_keys ()) {
+            app.set_accels_for_action (ACTION_PREFIX + action, {});
+        }
+    }
+
+    // Enable all the accelerators that might interfere with input fields.
+    private void enable_typing_accels () {
+        foreach (var action in typing_accelerators.get_keys ()) {
+            app.set_accels_for_action (ACTION_PREFIX + action, typing_accelerators[action].to_array ());
         }
     }
 

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -58,6 +58,10 @@ public class Akira.Services.EventBus : Object {
     public signal void item_deleted (Lib.Models.CanvasItem item);
     public signal void item_locked (Lib.Models.CanvasItem item);
 
+    // Others.
+    public signal void disconnect_typing_accel ();
+    public signal void connect_typing_accel ();
+
     public void test (string caller_id) {
         debug (@"Test from EventBus called by $(caller_id)");
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -59,6 +59,7 @@ sources = files(
     'Partials/ButtonImage.vala',
     'Partials/AlignBoxButton.vala',
     'Partials/InputField.vala',
+    'Partials/ColorField.vala',
     'Partials/LinkedInput.vala',
     'Partials/PanelSeparator.vala',
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
I'm tackling two problems with this PR.
First, due to our global accelerators to create shapes, some letters weren't appearing when typing inside a `Gtk.Entry`.
Second, pasteing a color value with the `#` included wasn't possible and the color entry was ignoring the pasted text entirely.

## Steps to Test
### Accelerators fix
- Press `R` to create a shape.
- Double click on the layer name to make it editable.
- Type all the accel letters (`e`, `r`, `a`, `t`, `i`)
- Be sure the text is actually typed and those accels are not triggered.

### Color fields fix
- Create a shape and copy a color value that includes the `#` symbol. `#f9c440`
- Paste the entire value in the color field.
- Try selecting the entire text and pasting the color value without `#` symbol. `f9c440`
- Try other combinations and be sure the color updates properly.

---
- Fixes #287 
