### PR TITLE
Export dialog UI

### DIFF
--- a/data/css/headerbar.css
+++ b/data/css/headerbar.css
@@ -9,3 +9,7 @@
 .linked-flat button {
     background-color: shade (@bg_color, 1);
 }
+
+.export-titlebar {
+    padding: 0;
+}

--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -81,3 +81,9 @@
 .input-button.down {
     margin-top: -2pt;
 }
+
+paned > separator {
+    min-width: 1px;
+    margin-right: 0;
+    margin-left: 0;
+}

--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -8,6 +8,11 @@
     border-left: 1px solid shade (@bg_color, 0.9);
 }
 
+.sidebar-export {
+    background-color: shade (@bg_color, 0.95);
+    padding: 0 10px;
+}
+
 .color-picker {
   padding: 8px 5px;
 }

--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -8,9 +8,15 @@
     border-left: 1px solid shade (@bg_color, 0.9);
 }
 
+.sidebar-export-header {
+    background-color: shade (@bg_color, 0.95);
+    border-radius: 4px 0 0 0;
+}
+
 .sidebar-export {
     background-color: shade (@bg_color, 0.95);
     padding: 10px 20px 20px;
+    border-radius: 0 0 0 4px;
 }
 
 .color-picker {

--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -10,7 +10,7 @@
 
 .sidebar-export {
     background-color: shade (@bg_color, 0.95);
-    padding: 0 10px;
+    padding: 10px 20px 20px;
 }
 
 .color-picker {

--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -15,7 +15,6 @@
 
 .sidebar-export {
     background-color: shade (@bg_color, 0.95);
-    padding: 0 20px 20px;
     border-radius: 0 0 0 4px;
 }
 
@@ -59,8 +58,8 @@
 }
 
 .group-title {
-    font-size: 8pt;
-    font-weight: 700;
+    font-size: 9pt;
+    font-weight: 600;
     color: alpha (@fg_color, 0.9);
 }
 

--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -15,7 +15,7 @@
 
 .sidebar-export {
     background-color: shade (@bg_color, 0.95);
-    padding: 10px 20px 20px;
+    padding: 0 20px 20px;
     border-radius: 0 0 0 4px;
 }
 

--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -119,8 +119,8 @@
             <description>The format type for exporting images in the export dialog.</description>
         </key>
 
-        <key name="export-scale" type="s">
-            <default>'1'</default>
+        <key name="export-scale" type="i">
+            <default>0</default>
             <summary>The scaled resolution for exporting images.</summary>
             <description>The scaled resolution for exporting images in the export dialog.</description>
         </key>

--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -124,5 +124,11 @@
             <summary>The scaled resolution for exporting images.</summary>
             <description>The scaled resolution for exporting images in the export dialog.</description>
         </key>
+
+        <key name="export-alpha" type="b">
+            <default>true</default>
+            <summary>The alpha setting for exporting PNG images.</summary>
+            <description>The alpha setting for exporting PNG images in the export dialog.</description>
+        </key>
     </schema>
 </schemalist>

--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -103,8 +103,14 @@
 
         <key name="export-quality" type="i">
             <default>100</default>
-            <summary>The quality value for exporting images.</summary>
-            <description>The quality value for exporting images in the export dialog.</description>
+            <summary>The quality value for exporting JPG images.</summary>
+            <description>The quality value for exporting JPG images in the export dialog.</description>
+        </key>
+
+        <key name="export-compression" type="i">
+            <default>0</default>
+            <summary>The compression value for exporting PNG images.</summary>
+            <description>The compression value for exporting PNG images in the export dialog.</description>
         </key>
 
         <key name="export-format" type="s">

--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -97,8 +97,8 @@
 
         <key name="export-paned" type="i">
             <default>300</default>
-            <summary>The saved width of the export right panel.</summary>
-            <description>The saved width of the right panel in the export dialog.</description>
+            <summary>The saved position of the export left panel.</summary>
+            <description>The saved position of the left panel in the export dialog.</description>
         </key>
 
         <key name="export-quality" type="i">

--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -82,5 +82,41 @@
             <summary>Auto Reopen latest file</summary>
             <description>Automatically reopen the latest file on startup.</description>
         </key>
+
+        <key name="export-width" type="i">
+            <default>1000</default>
+            <summary>The saved width of the export dialog.</summary>
+            <description>The saved width of the export dialog.</description>
+        </key>
+
+        <key name="export-height" type="i">
+            <default>600</default>
+            <summary>The saved height of the export dialog.</summary>
+            <description>The saved height of the export dialog.</description>
+        </key>
+
+        <key name="export-paned" type="i">
+            <default>300</default>
+            <summary>The saved width of the export right panel.</summary>
+            <description>The saved width of the right panel in the export dialog.</description>
+        </key>
+
+        <key name="export-quality" type="i">
+            <default>100</default>
+            <summary>The quality value for exporting images.</summary>
+            <description>The quality value for exporting images in the export dialog.</description>
+        </key>
+
+        <key name="export-format" type="s">
+            <default>'png'</default>
+            <summary>The format type for exporting images.</summary>
+            <description>The format type for exporting images in the export dialog.</description>
+        </key>
+
+        <key name="export-scale" type="s">
+            <default>'1'</default>
+            <summary>The scaled resolution for exporting images.</summary>
+            <description>The scaled resolution for exporting images in the export dialog.</description>
+        </key>
     </schema>
 </schemalist>

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -30,8 +30,10 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     public Gtk.Adjustment compression_adj;
     public Gtk.Scale compression_scale;
     public Gtk.ComboBoxText file_format;
-    public Gtk.Label jpeg_title;
+    public Gtk.Label jpg_title;
     public Gtk.Label png_title;
+    public Gtk.Label alpha_title;
+    public Gtk.Switch alpha_switch;
 
     public ExportDialog (Akira.Window window) {
         Object (
@@ -128,13 +130,13 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         file_format = new Gtk.ComboBoxText ();
         file_format.append ("png", "PNG");
         file_format.append ("jpg", "JPG");
-        file_format.changed.connect (update_format_ui);
-        settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
+        //  file_format.changed.connect (update_format_ui);
         grid.attach (file_format, 1, 2, 1, 1);
+        settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
 
         // Quality spinbutton.
-        jpeg_title = section_title (_("Quality:"));
-        grid.attach (jpeg_title, 0, 3, 1, 1);
+        jpg_title = section_title (_("Quality:"));
+        grid.attach (jpg_title, 0, 3, 1, 1);
 
         quality_adj = new Gtk.Adjustment (100.0, 0, 100.0, 0, 0, 0);
         quality_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, quality_adj);
@@ -142,17 +144,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         quality_scale.draw_value = true;
         quality_scale.digits = 0;
         grid.attach (quality_scale, 1, 3, 1, 1);
-
-        //  quality_entry = new Akira.Partials.InputField (
-        //      Akira.Partials.InputField.Unit.PERCENTAGE, 7, true, true);
-        //  quality_entry.entry.sensitive = true;
-        //  quality_entry.entry.hexpand = false;
-        //  settings.bind ("export-quality", quality_entry.entry, "value", SettingsBindFlags.DEFAULT);
-
-        //  quality_entry.entry.bind_property (
-        //      "value", quality_adj, "value",
-        //      BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
-        //  grid.attach (quality_entry, 1, 4, 1, 1);
+        settings.bind ("export-quality", quality_adj, "value", SettingsBindFlags.DEFAULT);
 
         // Compression spinbutton.
         png_title = section_title (_("Compression:"));
@@ -167,12 +159,20 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
             compression_scale.add_mark (i, Gtk.PositionType.BOTTOM, null);
         }
         grid.attach (compression_scale, 1, 4, 1, 1);
+        settings.bind ("export-compression", compression_adj, "value", SettingsBindFlags.DEFAULT);
 
-        settings.bind ("export-compression", compression_scale, "value", SettingsBindFlags.DEFAULT);
+        alpha_title = section_title (_("Transparency:"));
+        grid.attach (alpha_title, 0, 5, 1, 1);
+
+        alpha_switch = new Gtk.Switch ();
+        alpha_switch.valign = Gtk.Align.CENTER;
+        alpha_switch.halign = Gtk.Align.START;
+        grid.attach (alpha_switch, 1, 5, 1, 1);
+        settings.bind ("export-alpha", alpha_switch, "active", SettingsBindFlags.DEFAULT);
 
         // Resolution.
         var size_title = section_title (_("Scale:"));
-        grid.attach (size_title, 0, 5, 1, 1);
+        grid.attach (size_title, 0, 6, 1, 1);
 
         var scale_button = new Granite.Widgets.ModeButton ();
         scale_button.halign = Gtk.Align.FILL;
@@ -181,7 +181,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         scale_button.append_text ("4×");
         scale_button.set_active (settings.export_scale);
         settings.bind ("export-scale", scale_button, "selected", SettingsBindFlags.DEFAULT);
-        grid.attach (scale_button, 1, 5, 1, 1);
+        grid.attach (scale_button, 1, 6, 1, 1);
 
         // Buttons.
         var action_area = new Gtk.Grid ();
@@ -189,7 +189,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         action_area.halign = Gtk.Align.END;
         action_area.valign = Gtk.Align.END;
         action_area.vexpand = true;
-        grid.attach (action_area, 0, 6, 2, 1);
+        grid.attach (action_area, 0, 7, 2, 1);
 
         var cancel_button = new Gtk.Button.with_label (_("Cancel"));
         cancel_button.halign = Gtk.Align.START;
@@ -207,12 +207,14 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     }
 
     private void update_format_ui () {
-        jpeg_title.visible = (file_format.active_id == "jpg");
+        jpg_title.visible = (file_format.active_id == "jpg");
         quality_scale.visible = (file_format.active_id == "jpg");
         quality_entry.visible = (file_format.active_id == "jpg");
 
         png_title.visible = (file_format.active_id == "png");
         compression_scale.visible = (file_format.active_id == "png");
+        alpha_title.visible = (file_format.active_id == "png");
+        alpha_switch.visible = (file_format.active_id == "png");
     }
 
     private Gtk.Label section_title (string title) {

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -22,6 +22,9 @@
 public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     public weak Akira.Window window { get; construct; }
 
+    private Gtk.Grid sidebar;
+    public Gtk.FileChooserButton folder_button;
+
     public ExportDialog (Akira.Window window) {
         Object (
             window: window,
@@ -41,13 +44,14 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         var sidebar_header = new Gtk.Grid ();
         sidebar_header.vexpand = true;
         sidebar_header.get_style_context ().add_class ("sidebar-l");
-        sidebar_header.width_request = 300;
+        sidebar_header.width_request = 280;
 
         var close_button =  new Gtk.Button.from_icon_name (
             "window-close-symbolic",
             Gtk.IconSize.MENU
         );
-        close_button.margin = 6;
+        close_button.margin_top = close_button.margin_bottom = 6;
+        close_button.margin_right = close_button.margin_left = 4;
         close_button.clicked.connect (() => {
             close ();
         });
@@ -74,16 +78,13 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         var button_area = button.get_parent ();
         button_area.destroy ();
 
-        var sidebar = new Gtk.Grid ();
-        sidebar.vexpand = true;
-        sidebar.get_style_context ().add_class ("sidebar-l");
-        sidebar.width_request = 300;
-        sidebar.add (new Gtk.Label ("Sidebar"));
+        sidebar = new Gtk.Grid ();
+        sidebar.get_style_context ().add_class ("sidebar-export");
+        sidebar.width_request = 280;
 
         var main = new Gtk.Grid ();
         main.vexpand = true;
         main.get_style_context ().add_class ("layers-panel");
-        main.add (new Gtk.Label ("Main"));
 
         var pane = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         pane.pack1 (sidebar, false, false);
@@ -93,10 +94,39 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         content_area.border_width = 0;
         content_area.add (pane);
 
-        pane.bind_property ("position", pane_header, "position", BindingFlags.SYNC_CREATE);
+        pane.bind_property ("position", pane_header, "position");
 
-        pane_header.notify.connect (() => {
+        pane_header.notify["position"].connect (() => {
             pane_header.position = pane.position;
         });
+
+        Idle.add (() => {
+            build_export_sidebar ();
+        });
+    }
+
+    private void build_export_sidebar () {
+        var folder_dir = Environment.get_user_special_dir (UserDirectory.PICTURES);
+
+        // Folder location
+        var folder_label = new Gtk.Label (_("Select Destination Folder"));
+        folder_label.get_style_context ().add_class ("h4");
+        folder_label.halign = Gtk.Align.START;
+        sidebar.attach (folder_label, 0, 0, 1, 1);
+
+        folder_button = new Gtk.FileChooserButton (_("Select Folder"), Gtk.FileChooserAction.SELECT_FOLDER);
+        folder_button.set_current_folder (folder_dir);
+        folder_button.hexpand = true;
+        sidebar.attach (folder_button, 0, 1, 1, 1);
+
+        // Quality spinbutton
+
+        // File format
+
+        // Scale
+
+        // Buttons
+
+        sidebar.show_all ();
     }
 }

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -27,6 +27,8 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     public Gtk.Adjustment quality_adj;
     public Gtk.Scale quality_scale;
     public Akira.Partials.InputField quality_entry;
+    public Gtk.Adjustment compression_adj;
+    public Gtk.Scale compression_scale;
 
     public ExportDialog (Akira.Window window) {
         Object (
@@ -48,17 +50,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         sidebar_header.vexpand = true;
         sidebar_header.get_style_context ().add_class ("sidebar-export-header");
         sidebar_header.width_request = 300;
-
-        var close_button = new Gtk.Button.from_icon_name (
-            "window-close-symbolic",
-            Gtk.IconSize.MENU
-        );
-        close_button.margin = 5;
-        close_button.clicked.connect (() => {
-            close ();
-        });
-
-        sidebar_header.add (close_button);
+        sidebar_header.height_request = 34;
 
         var main_header = new Gtk.Grid ();
         main_header.vexpand = true;
@@ -126,13 +118,13 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         grid.attach (folder_button, 0, 1, 2, 1);
 
         // Quality spinbutton.
-        grid.attach (section_title (_("Quality")), 0, 2, 2, 1);
+        grid.attach (section_title (_("JPEG Quality")), 0, 2, 2, 1);
 
         quality_adj = new Gtk.Adjustment (100.0, 0, 100.0, 0, 0, 0);
         quality_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, quality_adj);
         quality_scale.hexpand = true;
         quality_scale.draw_value = false;
-        quality_scale.round_digits = 1;
+        quality_scale.digits = 0;
         quality_scale.margin_bottom = 20;
         grid.attach (quality_scale, 0, 3, 1, 1);
 
@@ -148,22 +140,38 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
             BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
         grid.attach (quality_entry, 1, 3, 1, 1);
 
+        // Compression spinbutton.
+        grid.attach (section_title (_("PNG Compression")), 0, 4, 2, 1);
+
+        compression_adj = new Gtk.Adjustment (0.0, 0, 9.0, 1, 0, 0);
+        compression_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, compression_adj);
+        compression_scale.hexpand = true;
+        compression_scale.draw_value = true;
+        compression_scale.digits = 0;
+        compression_scale.margin_bottom = 20;
+        for (int i = 1; i <= 9; i++) {
+            compression_scale.add_mark (i, Gtk.PositionType.BOTTOM, null);
+        }
+        grid.attach (compression_scale, 0, 5, 2, 1);
+
+        settings.bind ("export-compression", compression_scale, "value", SettingsBindFlags.DEFAULT);
+
         // File format.
         var format_title = section_title (_("Format"));
         format_title.margin_bottom = 20;
-        grid.attach (format_title, 0, 4, 1, 1);
+        grid.attach (format_title, 0, 6, 1, 1);
 
         var file_format = new Gtk.ComboBoxText ();
         file_format.append ("png", "PNG");
         file_format.append ("jpg", "JPG");
         settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
         file_format.margin_bottom = 20;
-        grid.attach (file_format, 1, 4, 1, 1);
+        grid.attach (file_format, 1, 6, 1, 1);
 
         // Resolution.
         var size_title = section_title (_("Size"));
         size_title.margin_bottom = 20;
-        grid.attach (size_title, 0, 5, 1, 1);
+        grid.attach (size_title, 0, 7, 1, 1);
 
         var file_size = new Gtk.ComboBoxText ();
         file_size.append ("1", "1x");
@@ -171,17 +179,17 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         file_size.append ("4", "4x");
         settings.bind ("export-scale", file_size, "active_id", SettingsBindFlags.DEFAULT);
         file_size.margin_bottom = 20;
-        grid.attach (file_size, 1, 5, 1, 1);
+        grid.attach (file_size, 1, 7, 1, 1);
 
         // Push the buttons to the bottom.
         var separator = new Gtk.Grid ();
         separator.vexpand = true;
-        grid.attach (separator, 0, 6, 2, 1);
+        grid.attach (separator, 0, 8, 2, 1);
 
         // Buttons.
         var cancel_button = new Gtk.Button.with_label (_("Cancel"));
         cancel_button.halign = Gtk.Align.START;
-        grid.attach (cancel_button, 0, 7, 1, 1);
+        grid.attach (cancel_button, 0, 9, 1, 1);
         cancel_button.clicked.connect (() => {
             close ();
         });
@@ -189,7 +197,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         var export_button = new Gtk.Button.with_label (_("Export"));
         export_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         export_button.halign = Gtk.Align.END;
-        grid.attach (export_button, 1, 7, 1, 1);
+        grid.attach (export_button, 1, 9, 1, 1);
 
         sidebar.add (grid);
     }

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -49,7 +49,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         sidebar_header.get_style_context ().add_class ("sidebar-l");
         sidebar_header.width_request = 300;
 
-        var close_button =  new Gtk.Button.from_icon_name (
+        var close_button = new Gtk.Button.from_icon_name (
             "window-close-symbolic",
             Gtk.IconSize.MENU
         );
@@ -76,7 +76,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         set_titlebar (pane_header);
 
         // Another hack to remove the bottom action area.
-        var button = add_button("OK", 3);
+        var button = add_button ("OK", 3);
         var button_area = button.get_parent ();
         button_area.destroy ();
 

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -46,7 +46,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
 
         var sidebar_header = new Gtk.Grid ();
         sidebar_header.vexpand = true;
-        sidebar_header.get_style_context ().add_class ("sidebar-l");
+        sidebar_header.get_style_context ().add_class ("sidebar-export-header");
         sidebar_header.width_request = 300;
 
         var close_button = new Gtk.Button.from_icon_name (

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -1,0 +1,102 @@
+/*
+* Copyright (c) 2020 Alecaddd (https://alecaddd.com)
+*
+* This file is part of Akira.
+*
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
+*
+* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+*/
+
+public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
+    public weak Akira.Window window { get; construct; }
+
+    public ExportDialog (Akira.Window window) {
+        Object (
+            window: window,
+            border_width: 0,
+            deletable: true,
+            resizable: true,
+            modal: true
+        );
+    }
+
+    construct {
+        transient_for = window;
+        use_header_bar = 1;
+        default_width = 900;
+        default_height = 600;
+
+        var sidebar_header = new Gtk.Grid ();
+        sidebar_header.vexpand = true;
+        sidebar_header.get_style_context ().add_class ("sidebar-l");
+        sidebar_header.width_request = 300;
+
+        var close_button =  new Gtk.Button.from_icon_name (
+            "window-close-symbolic",
+            Gtk.IconSize.MENU
+        );
+        close_button.margin = 6;
+        close_button.clicked.connect (() => {
+            close ();
+        });
+
+        sidebar_header.add (close_button);
+
+        var main_header = new Gtk.Grid ();
+        main_header.vexpand = true;
+        main_header.get_style_context ().add_class ("layers-panel");
+
+        var pane_header = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        pane_header.pack1 (sidebar_header, false, false);
+        pane_header.pack2 (main_header, false, false);
+        pane_header.get_style_context ().add_class ("export-titlebar");
+
+        // Hack to remove the default header area and replace it with
+        // a custom widget.
+        var header_area = get_header_bar ();
+        header_area.destroy ();
+        set_titlebar (pane_header);
+
+        // Another hack to remove the bottom action area.
+        var button = add_button("OK", 3);
+        var button_area = button.get_parent ();
+        button_area.destroy ();
+
+        var sidebar = new Gtk.Grid ();
+        sidebar.vexpand = true;
+        sidebar.get_style_context ().add_class ("sidebar-l");
+        sidebar.width_request = 300;
+        sidebar.add (new Gtk.Label ("Sidebar"));
+
+        var main = new Gtk.Grid ();
+        main.vexpand = true;
+        main.get_style_context ().add_class ("layers-panel");
+        main.add (new Gtk.Label ("Main"));
+
+        var pane = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        pane.pack1 (sidebar, false, false);
+        pane.pack2 (main, true, false);
+
+        var content_area = get_content_area ();
+        content_area.border_width = 0;
+        content_area.add (pane);
+
+        pane.bind_property ("position", pane_header, "position", BindingFlags.SYNC_CREATE);
+
+        pane_header.notify.connect (() => {
+            pane_header.position = pane.position;
+        });
+    }
+}

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -99,8 +99,6 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         });
 
         settings.bind ("export-paned", pane, "position", SettingsBindFlags.DEFAULT);
-
-        update_format_ui ();
     }
 
     private void build_export_sidebar () {
@@ -206,7 +204,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         sidebar.add (grid);
     }
 
-    private void update_format_ui () {
+    public void update_format_ui () {
         jpg_title.visible = (file_format.active_id == "jpg");
         quality_scale.visible = (file_format.active_id == "jpg");
         quality_entry.visible = (file_format.active_id == "jpg");

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -130,7 +130,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         file_format = new Gtk.ComboBoxText ();
         file_format.append ("png", "PNG");
         file_format.append ("jpg", "JPG");
-        //  file_format.changed.connect (update_format_ui);
+        file_format.changed.connect (update_format_ui);
         grid.attach (file_format, 1, 2, 1, 1);
         settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
 

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -10,11 +10,11 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -38,7 +38,7 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         Object (
             window: _window,
             border_width: 5,
-            deletable: false,
+            deletable: true,
             resizable: false,
             modal: true,
             title: _("Preferences")
@@ -65,14 +65,6 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         grid.attach (stack, 1, 2, 1, 1);
 
         get_content_area ().add (grid);
-
-        var close_button = (Gtk.Button) add_button (_("Close"), 0);
-        close_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-
-        close_button.clicked.connect (() => {
-            destroy ();
-            window.event_bus.set_focus_on_canvas ();
-        });
     }
 
     private Gtk.Widget get_general_box () {

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -19,7 +19,7 @@
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
-public class Akira.Widgets.SettingsDialog : Gtk.Dialog {
+public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
     public weak Akira.Window window { get; construct; }
     private Gtk.Stack stack;
     private Gtk.Switch dark_theme_switch;

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -362,7 +362,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     }
 
     private Gtk.Label group_title (string title) {
-        var title_label = new Gtk.Label ("%s".printf (title));
+        var title_label = new Gtk.Label (title);
         title_label.get_style_context ().add_class ("group-title");
         title_label.halign = Gtk.Align.START;
         title_label.hexpand = true;

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -147,7 +147,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         scale.hexpand = true;
         scale.sensitive = false;
         scale.draw_value = false;
-        scale.round_digits = 1;
+        scale.digits = 0;
         scale.margin_end = 20;
         opacity_entry = new Akira.Partials.InputField (
             Akira.Partials.InputField.Unit.PERCENTAGE, 7, true, true);

--- a/src/Partials/InputField.vala
+++ b/src/Partials/InputField.vala
@@ -27,7 +27,7 @@ public class Akira.Partials.InputField : Gtk.EventBox {
     public bool rtl { get; construct set; }
     public bool icon_right { get; construct set; }
     public Unit unit { get; construct set; }
-    public string icon { get; set; }
+    public string? icon { get; set; }
 
     public double step { get; set; default = 1; }
 
@@ -35,7 +35,8 @@ public class Akira.Partials.InputField : Gtk.EventBox {
         PIXEL,
         HASH,
         PERCENTAGE,
-        DEGREES
+        DEGREES,
+        NONE
     }
 
     public InputField (
@@ -68,28 +69,33 @@ public class Akira.Partials.InputField : Gtk.EventBox {
         switch (unit) {
             case Unit.HASH:
                 icon = "input-hash-symbolic";
-            break;
+                break;
             case Unit.PERCENTAGE:
                 icon = "input-percentage-symbolic";
-            break;
+                break;
             case Unit.PIXEL:
                 icon = "input-pixel-symbolic";
-            break;
+                break;
             case Unit.DEGREES:
                 icon = "input-degrees-symbolic";
-            break;
+                break;
+            default:
+                icon = null;
+                break;
         }
 
-        if (icon_right) {
-            entry.get_style_context ().add_class ("input-icon-right");
-            entry.secondary_icon_name = icon;
-            entry.secondary_icon_sensitive = false;
-            entry.secondary_icon_activatable = false;
-        } else {
-            entry.get_style_context ().add_class ("input-icon-left");
-            entry.primary_icon_name = icon;
-            entry.primary_icon_sensitive = false;
-            entry.primary_icon_activatable = false;
+        if (icon != null) {
+            if (icon_right) {
+                entry.get_style_context ().add_class ("input-icon-right");
+                entry.secondary_icon_name = icon;
+                entry.secondary_icon_sensitive = false;
+                entry.secondary_icon_activatable = false;
+            } else {
+                entry.get_style_context ().add_class ("input-icon-left");
+                entry.primary_icon_name = icon;
+                entry.primary_icon_sensitive = false;
+                entry.primary_icon_activatable = false;
+            }
         }
 
         if (rtl) {

--- a/src/Partials/InputField.vala
+++ b/src/Partials/InputField.vala
@@ -129,6 +129,9 @@ public class Akira.Partials.InputField : Gtk.EventBox {
 
     private bool handle_focus_in (Gdk.EventFocus event) {
         Akira.Window window = get_toplevel () as Akira.Window;
+        if (!(window is Akira.Window)) {
+            return true;
+        }
         window.event_bus.disconnect_typing_accel ();
 
         return false;
@@ -136,6 +139,9 @@ public class Akira.Partials.InputField : Gtk.EventBox {
 
     private bool handle_focus_out (Gdk.EventFocus event) {
         Akira.Window window = get_toplevel () as Akira.Window;
+        if (!(window is Akira.Window)) {
+            return true;
+        }
         window.event_bus.connect_typing_accel ();
 
         return false;

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -214,6 +214,9 @@ public class Akira.Services.ActionManager : Object {
         var export_dialog = new Akira.Dialogs.ExportDialog (window);
         export_dialog.show_all ();
         export_dialog.present ();
+
+        export_dialog.update_format_ui ();
+
         export_dialog.close.connect (() => {
             int width, height;
 

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -192,7 +192,7 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_preferences () {
-        var settings_dialog = new Akira.Widgets.SettingsDialog (window);
+        var settings_dialog = new Akira.Dialogs.SettingsDialog (window);
         settings_dialog.show_all ();
         settings_dialog.present ();
         settings_dialog.close.connect (() => {
@@ -209,7 +209,12 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_export_grab () {
-        warning ("export");
+        var export_dialog = new Akira.Dialogs.ExportDialog (window);
+        export_dialog.show_all ();
+        export_dialog.present ();
+        export_dialog.close.connect (() => {
+            window.event_bus.set_focus_on_canvas ();
+        });
     }
 
     private void action_zoom_in () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -209,10 +209,13 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_export_grab () {
+        disable_typing_accels ();
+
         var export_dialog = new Akira.Dialogs.ExportDialog (window);
         export_dialog.show_all ();
         export_dialog.present ();
         export_dialog.close.connect (() => {
+            enable_typing_accels ();
             window.event_bus.set_focus_on_canvas ();
         });
     }

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -215,6 +215,12 @@ public class Akira.Services.ActionManager : Object {
         export_dialog.show_all ();
         export_dialog.present ();
         export_dialog.close.connect (() => {
+            int width, height;
+
+            export_dialog.get_size (out width, out height);
+            settings.export_width = width;
+            settings.export_height = height;
+
             enable_typing_accels ();
             window.event_bus.set_focus_on_canvas ();
         });

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -102,6 +102,10 @@ public class Akira.Services.Settings : GLib.Settings {
         get { return get_int ("export-quality"); }
         set { set_int ("export-quality", value); }
     }
+    public int export_compression {
+        get { return get_int ("export-compression"); }
+        set { set_int ("export-compression", value); }
+    }
     public string export_format {
         owned get { return get_string ("export-format"); }
         set { set_string ("export-format", value); }

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -114,6 +114,10 @@ public class Akira.Services.Settings : GLib.Settings {
         get { return get_int ("export-scale"); }
         set { set_int ("export-scale", value); }
     }
+    public bool export_alpha {
+        get { return get_boolean ("export-alpha"); }
+        set { set_boolean ("export-alpha", value); }
+    }
 
     public Settings () {
         Object (schema_id: Constants.APP_ID);

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -110,9 +110,9 @@ public class Akira.Services.Settings : GLib.Settings {
         owned get { return get_string ("export-format"); }
         set { set_string ("export-format", value); }
     }
-    public string export_scale {
-        owned get { return get_string ("export-scale"); }
-        set { set_string ("export-scale", value); }
+    public int export_scale {
+        get { return get_int ("export-scale"); }
+        set { set_int ("export-scale", value); }
     }
 
     public Settings () {

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -21,6 +21,7 @@
 */
 
 public class Akira.Services.Settings : GLib.Settings {
+    // Main window settings.
     public int pos_x {
         get { return get_int ("pos-x"); }
         set { set_int ("pos-x", value); }
@@ -45,6 +46,8 @@ public class Akira.Services.Settings : GLib.Settings {
         get { return get_int ("left-paned"); }
         set { set_int ("left-paned", value); }
     }
+
+    // Theme settings.
     public bool dark_theme {
         get { return get_boolean ("dark-theme"); }
         set { set_boolean ("dark-theme", value); }
@@ -61,6 +64,8 @@ public class Akira.Services.Settings : GLib.Settings {
         owned get { return get_string ("fill-color"); }
         set { set_string ("fill-color", value); }
     }
+
+    // Default shape settings.
     public bool set_border {
         get { return get_boolean ("set-border"); }
         set { set_boolean ("set-border", value); }
@@ -73,9 +78,37 @@ public class Akira.Services.Settings : GLib.Settings {
         owned get { return get_string ("border-color"); }
         set { set_string ("border-color", value); }
     }
+
+    // File settings.
     public bool open_quick {
         get { return get_boolean ("open-quick"); }
         set { set_boolean ("open-quick", value); }
+    }
+
+    // Export Settings.
+    public int export_width {
+        get { return get_int ("export-width"); }
+        set { set_int ("export-width", value); }
+    }
+    public int export_height {
+        get { return get_int ("export-height"); }
+        set { set_int ("export-height", value); }
+    }
+    public int export_paned {
+        get { return get_int ("export-paned"); }
+        set { set_int ("export-paned", value); }
+    }
+    public int export_quality {
+        get { return get_int ("export-quality"); }
+        set { set_int ("export-quality", value); }
+    }
+    public string export_format {
+        owned get { return get_string ("export-format"); }
+        set { set_string ("export-format", value); }
+    }
+    public string export_scale {
+        owned get { return get_string ("export-scale"); }
+        set { set_string ("export-scale", value); }
     }
 
     public Settings () {

--- a/src/meson.build
+++ b/src/meson.build
@@ -69,7 +69,8 @@ sources = files(
     'Models/ItemModel.vala',
     'Models/ListModel.vala',
 
-    'Widgets/SettingsDialog.vala',
+    'Dialogs/SettingsDialog.vala',
+    'Dialogs/ExportDialog.vala',
 
     'Lib/Canvas.vala',
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
This PR implements **only** the UI of the Export Dialog and the GSettings options to properly remember user's settings.
No actual export logic or image manipulation is implemented here.

## Steps to Test
- Click on the `Export` toolbar button and select the last option "Export Area to Grab"
- Or use the keyboard shortcut <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>G</kbd>

## Screenshots 
![Screenshot from 2020-02-01 16-37-28](https://user-images.githubusercontent.com/2527103/73601194-b4e6b300-4511-11ea-9443-0b601981a0c1.png)

## Known Issues / Things To Do
There's a problem I can't seem to solve.
Whenever I use a `Gtk.ComboBox` inside a `Gtk.Dialog`, I get this warning in the terminal:
```
Gtk-CRITICAL: _gtk_widget_get_preferred_size_for_size: assertion 'size >= -1' failed
```

- Fixes #275
