### PR TITLE
Export dialog ui rebound

### DIFF
--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -15,7 +15,6 @@
 
 .sidebar-export {
     background-color: shade (@bg_color, 0.95);
-    padding: 10px 20px 20px;
     border-radius: 0 0 0 4px;
 }
 

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -109,6 +109,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     private void build_export_sidebar () {
         var grid = new Gtk.Grid ();
         grid.expand = true;
+        grid.margin = 12;
         grid.column_spacing = 10;
 
         // Folder location.
@@ -179,9 +180,14 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         grid.attach (separator, 0, 6, 2, 1);
 
         // Buttons.
+        var action_area = new Gtk.Grid ();
+        action_area.column_spacing = 6;
+        action_area.halign = Gtk.Align.END;
+        grid.attach (action_area, 0, 7, 2);
+
         var cancel_button = new Gtk.Button.with_label (_("Cancel"));
-        cancel_button.halign = Gtk.Align.START;
-        grid.attach (cancel_button, 0, 7, 1, 1);
+        cancel_button.halign = Gtk.Align.END;
+        action_area.add (cancel_button);
         cancel_button.clicked.connect (() => {
             close ();
         });
@@ -189,7 +195,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         var export_button = new Gtk.Button.with_label (_("Export"));
         export_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         export_button.halign = Gtk.Align.END;
-        grid.attach (export_button, 1, 7, 1, 1);
+        action_area.add (export_button);
 
         sidebar.add (grid);
     }

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -47,13 +47,12 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         var sidebar_header = new Gtk.Grid ();
         sidebar_header.vexpand = true;
         sidebar_header.get_style_context ().add_class ("sidebar-export-header");
-        sidebar_header.width_request = 300;
 
         var close_button = new Gtk.Button.from_icon_name (
             "window-close-symbolic",
             Gtk.IconSize.MENU
         );
-        close_button.margin = 5;
+        close_button.margin = 6;
         close_button.clicked.connect (() => {
             close ();
         });
@@ -82,7 +81,6 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
 
         sidebar = new Gtk.Grid ();
         sidebar.get_style_context ().add_class ("sidebar-export");
-        sidebar.width_request = 300;
         build_export_sidebar ();
 
         var main = new Gtk.Grid ();
@@ -108,12 +106,14 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
 
     private void build_export_sidebar () {
         var grid = new Gtk.Grid ();
+        grid.column_spacing = 12;
         grid.expand = true;
-        grid.margin = 12;
-        grid.column_spacing = 10;
+        grid.margin_start = grid.margin_end = grid.margin_bottom = 12;
+        grid.row_spacing = 6;
 
         // Folder location.
-        grid.attach (section_title (_("Select Destination Folder")), 0, 0, 2, 1);
+        var folder_title = section_title (_("Export to:"));
+        grid.attach (folder_title, 0, 0);
 
         folder_button = new Gtk.FileChooserButton (
             _("Select Folder"),
@@ -123,67 +123,62 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
             Environment.get_user_special_dir (UserDirectory.PICTURES)
         );
         folder_button.hexpand = true;
-        folder_button.margin_bottom = 20;
-        grid.attach (folder_button, 0, 1, 2, 1);
+        grid.attach (folder_button, 1, 0, 2);
 
         // Quality spinbutton.
-        grid.attach (section_title (_("Quality")), 0, 2, 2, 1);
+        grid.attach (section_title (_("Quality:")), 0, 1);
 
         quality_adj = new Gtk.Adjustment (100.0, 0, 100.0, 0, 0, 0);
         quality_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, quality_adj);
         quality_scale.hexpand = true;
         quality_scale.draw_value = false;
         quality_scale.round_digits = 1;
-        quality_scale.margin_bottom = 20;
-        grid.attach (quality_scale, 0, 3, 1, 1);
+        quality_scale.width_request = 128;
+        grid.attach (quality_scale, 1, 1);
 
         quality_entry = new Akira.Partials.InputField (
-            Akira.Partials.InputField.Unit.PERCENTAGE, 7, true, true);
-        quality_entry.entry.sensitive = true;
+            Akira.Partials.InputField.Unit.PERCENTAGE, 5, true, true);
         quality_entry.entry.hexpand = false;
-        quality_entry.margin_bottom = 20;
+        quality_entry.entry.sensitive = true;
+        quality_entry.halign = Gtk.Align.END;
         settings.bind ("export-quality", quality_entry.entry, "value", SettingsBindFlags.DEFAULT);
 
         quality_entry.entry.bind_property (
             "value", quality_adj, "value",
             BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
-        grid.attach (quality_entry, 1, 3, 1, 1);
+        grid.attach (quality_entry, 2, 1);
 
         // File format.
-        var format_title = section_title (_("Format"));
-        format_title.margin_bottom = 20;
-        grid.attach (format_title, 0, 4, 1, 1);
+        var format_title = section_title (_("Format:"));
+        grid.attach (format_title, 0, 2);
 
-        var file_format = new Gtk.ComboBoxText ();
-        file_format.append ("png", "PNG");
-        file_format.append ("jpg", "JPG");
-        settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
-        file_format.margin_bottom = 20;
-        grid.attach (file_format, 1, 4, 1, 1);
+        var format_button = new Granite.Widgets.ModeButton ();
+        format_button.halign = Gtk.Align.START;
+        format_button.append_text ("PNG");
+        format_button.append_text ("JPG");
+        format_button.set_active (0);
+        grid.attach (format_button, 1, 2, 2);
 
         // Resolution.
-        var size_title = section_title (_("Size"));
-        size_title.margin_bottom = 20;
-        grid.attach (size_title, 0, 5, 1, 1);
+        var scale_title = section_title (_("Scale:"));
+        grid.attach (scale_title, 0, 3);
 
-        var file_size = new Gtk.ComboBoxText ();
-        file_size.append ("1", "1x");
-        file_size.append ("2", "2x");
-        file_size.append ("4", "4x");
-        settings.bind ("export-scale", file_size, "active_id", SettingsBindFlags.DEFAULT);
-        file_size.margin_bottom = 20;
-        grid.attach (file_size, 1, 5, 1, 1);
-
-        // Push the buttons to the bottom.
-        var separator = new Gtk.Grid ();
-        separator.vexpand = true;
-        grid.attach (separator, 0, 6, 2, 1);
+        var scale_button = new Granite.Widgets.ModeButton ();
+        scale_button.halign = Gtk.Align.START;
+        scale_button.append_text ("1×");
+        scale_button.append_text ("2×");
+        scale_button.append_text ("4×");
+        scale_button.set_active (0);
+        settings.bind ("export-scale", scale_button, "selected", SettingsBindFlags.DEFAULT);
+        grid.attach (scale_button, 1, 3, 2);
 
         // Buttons.
         var action_area = new Gtk.Grid ();
         action_area.column_spacing = 6;
         action_area.halign = Gtk.Align.END;
-        grid.attach (action_area, 0, 7, 2);
+        action_area.valign = Gtk.Align.END;
+        action_area.vexpand = true;
+        grid.attach (action_area, 0, 4, 3);
 
         var cancel_button = new Gtk.Button.with_label (_("Cancel"));
         cancel_button.halign = Gtk.Align.END;
@@ -202,11 +197,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
 
     private Gtk.Label section_title (string title) {
         var title_label = new Gtk.Label (title);
-        title_label.get_style_context ().add_class ("group-title");
-        title_label.halign = Gtk.Align.START;
-        title_label.valign = Gtk.Align.CENTER;
-        title_label.hexpand = true;
-        title_label.margin_bottom = 5;
+        title_label.halign = Gtk.Align.END;
 
         return title_label;
     }


### PR DESCRIPTION
This is a rebound on the export dialog. My main goal was to follow elementary HIG while keeping all functionality. In summary:

- Gets rid of hardcoded sidebar and header width request and lets the contents determine the width
- Gets rid of separator grid in favor of valign on an action area grid
- Right-aligns the action buttons like elementary dialogs
- Uses margins instead of CSS padding
- Uses elementary HIG styled right-aligned labels
- Simplifies some of the copy
- Reduces the number of clicks by using ModeButtons instead of comboboxes

## Screenshots 
![image](https://user-images.githubusercontent.com/611168/73696786-42eda580-469a-11ea-867d-317834d9c68a.png)