### PR TITLE
Initial Artboard Feature Implementation

### DIFF
--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -415,7 +415,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         move_top.sensitive = (selected_item != null);
         move_bottom.sensitive = (selected_item != null);
 
-        if (selected_item == null) {
+        if (selected_item == null || selected_item.get_canvas () == null) {
             return;
         }
 

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -60,7 +60,13 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         bind_model (list_model, item => {
             // TODO: Differentiate between layer and artboard
             // based upon item "type" of some sort
-            return new Akira.Layouts.Partials.Layer (window, (Akira.Models.LayerModel) item);
+            var layer_model = (Akira.Models.LayerModel) item;
+
+            if (layer_model.is_artboard) {
+              return new Akira.Layouts.Partials.Artboard (window, layer_model);
+            }
+
+            return new Akira.Layouts.Partials.Layer (window, layer_model);
         });
 
         build_drag_and_drop ();

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -218,6 +218,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 selected_bound_manager.reset_selection ();
 
                 var new_item = items_manager.insert_item (event);
+
                 selected_bound_manager.add_item_to_selection (new_item);
 
                 selected_bound_manager.set_initial_coordinates (event.x, event.y);

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -88,6 +88,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         window.event_bus.request_change_cursor.connect (on_request_change_cursor);
         window.event_bus.set_focus_on_canvas.connect (on_set_focus_on_canvas);
         window.event_bus.request_escape.connect (on_set_focus_on_canvas);
+        window.event_bus.insert_item.connect (on_insert_item);
     }
 
     public void insert_item_default (Akira.Lib.Models.CanvasItem item, bool select) {
@@ -315,6 +316,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
 
         return true;
+    }
+
+    public void on_insert_item () {
+        edit_mode = EditMode.MODE_INSERT;
     }
 
     public void on_set_focus_on_canvas () {

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -23,14 +23,8 @@
 public class Akira.Lib.Managers.ItemsManager : Object {
     public weak Akira.Lib.Canvas canvas { get; construct; }
 
-    public enum InsertType {
-        RECT,
-        ELLIPSE,
-        TEXT
-    }
-
     private List<Models.CanvasItem> items;
-    private InsertType? insert_type { get; set; }
+    private Models.CanvasItemType? insert_type { get; set; }
     private Goo.CanvasItem root;
     private int border_size;
     private Gdk.RGBA border_color;
@@ -54,48 +48,28 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         canvas.window.event_bus.change_item_z_index.connect (on_change_item_z_index);
     }
 
-    public bool set_insert_type_from_key (uint keyval) {
-        // TODO: take those values from preferences/settings and not from hardcoded values
-        if (keyval > Gdk.Key.Z || keyval < Gdk.Key.A) {
-            return false;
-        }
-
-        switch (keyval) {
-            case Gdk.Key.R:
-                set_item_to_insert ("rectangle");
-                break;
-
-            case Gdk.Key.E:
-                set_item_to_insert ("ellipse");
-                break;
-
-            case Gdk.Key.T:
-                set_item_to_insert ("text");
-                break;
-            default:
-                return false;
-        }
-
-        return true;
-    }
-
     public Models.CanvasItem? insert_item (Gdk.EventButton event) {
         udpate_default_values ();
 
         Models.CanvasItem? new_item;
 
         switch (insert_type) {
-            case InsertType.RECT:
+            case Models.CanvasItemType.RECT:
                 new_item = add_rect (event);
                 break;
 
-            case InsertType.ELLIPSE:
+            case Models.CanvasItemType.ELLIPSE:
                 new_item = add_ellipse (event);
                 break;
 
-            case InsertType.TEXT:
+            case Models.CanvasItemType.TEXT:
                 new_item = add_text (event);
                 break;
+
+            case Models.CanvasItemType.ARTBOARD:
+                new_item = add_artboard (event);
+                break;
+
             default:
                 new_item = null;
                 break;
@@ -117,6 +91,16 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     public void on_request_delete_item (Lib.Models.CanvasItem item) {
         item.delete ();
         canvas.window.event_bus.item_deleted (item);
+    }
+
+    public Models.CanvasItem add_artboard (Gdk.EventButton event) {
+        var artboard = new Models.CanvasArtboard (
+            Utils.AffineTransform.fix_size (event.x),
+            Utils.AffineTransform.fix_size (event.y),
+            root
+        );
+
+        return artboard as Models.CanvasItem;
     }
 
     public Models.CanvasItem add_rect (Gdk.EventButton event) {
@@ -168,15 +152,19 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     private void set_item_to_insert (string type) {
         switch (type) {
             case "rectangle":
-                insert_type = InsertType.RECT;
+                insert_type = Models.CanvasItemType.RECT;
                 break;
 
             case "ellipse":
-                insert_type = InsertType.ELLIPSE;
+                insert_type = Models.CanvasItemType.ELLIPSE;
                 break;
 
             case "text":
-                insert_type = InsertType.TEXT;
+                insert_type = Models.CanvasItemType.TEXT;
+                break;
+
+            case "artboard":
+                insert_type = Models.CanvasItemType.ARTBOARD;
                 break;
         }
     }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -58,6 +58,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     public bool selected { get; set; }
     public bool locked { get; set; }
     public string layer_icon { get; set; default = "shape-rectangle-symbolic"; }
+    public int z_index { get; set; }
 
     // Shape's unique identifiers.
     public bool is_radius_uniform { get; set; }
@@ -68,14 +69,20 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     public double y { get; set; }
     public double width { get; set; }
     public double height { get; set; }
+    public Goo.CanvasItem parent { get; set; }
 
     private double label_height;
 
     public CanvasArtboard (
         double _x = 0,
         double _y = 0,
-        Goo.CanvasItem? parent = null
+        Goo.CanvasItem? _parent = null
     ) {
+        parent = _parent;
+
+        canvas = parent.get_canvas ();
+        parent.add_child (this, -1);
+
         item_type = Models.CanvasItemType.ARTBOARD;
         id = Models.CanvasItem.create_item_id (this);
         Models.CanvasItem.init_item (this);
@@ -84,9 +91,6 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         height = 1;
         x = 0;
         y = 0;
-
-        canvas = parent.get_canvas ();
-        parent.add_child (this, -1);
 
         show_border_radius_panel = false;
         show_fill_panel = false;

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -1,0 +1,136 @@
+/*
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
+*
+* This file is part of Akira.
+*
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
+*
+* Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
+*/
+
+public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Models.CanvasItem {
+    // Identifiers.
+    public Models.CanvasItemType item_type { get; set; }
+    public string id { get; set; }
+    public string name { get; set; }
+
+    // Transform Panel attributes.
+    public double opacity { get; set; }
+    public double rotation { get; set; }
+
+    // Fill Panel attributes.
+    public bool has_fill { get; set; default = true; }
+    public int fill_alpha { get; set; }
+    public Gdk.RGBA color { get; set; }
+    public bool hidden_fill { get; set; }
+
+    // Border Panel attributes.
+    public bool has_border { get; set; default = true; }
+    public int border_size { get; set; }
+    public Gdk.RGBA border_color { get; set; }
+    public int stroke_alpha { get; set; }
+    public bool hidden_border { get; set; }
+
+    // Style Panel attributes.
+    public bool size_locked { get; set; }
+    public double size_ratio { get; set; }
+    public bool flipped_h { get; set; }
+    public bool flipped_v { get; set; }
+    public bool show_border_radius_panel { get; set; }
+    public bool show_fill_panel { get; set; }
+    public bool show_border_panel { get; set; }
+
+    // Layers panel attributes.
+    public bool selected { get; set; }
+    public bool locked { get; set; }
+    public string layer_icon { get; set; default = "shape-rectangle-symbolic"; }
+
+    // Shape's unique identifiers.
+    public bool is_radius_uniform { get; set; }
+    public bool is_radius_autoscale { get; set; }
+
+    // CanvasItemSimple basic properties
+    public double x { get; set; }
+    public double y { get; set; }
+    public double width { get; set; }
+    public double height { get; set; }
+
+    public CanvasArtboard (
+        double _x = 0,
+        double _y = 0,
+        Goo.CanvasItem? parent = null
+    ) {
+        item_type = Models.CanvasItemType.ARTBOARD;
+        id = Models.CanvasItem.create_item_id (this);
+        Models.CanvasItem.init_item (this);
+
+        width = 1;
+        height = 1;
+        x = 0;
+        y = 0;
+
+        this.notify["width"].connect((w) => {
+            debug (@"New width: $(width)");
+        });
+
+        canvas = parent.get_canvas ();
+
+        show_border_radius_panel = false;
+        show_fill_panel = false;
+        show_border_panel = false;
+        is_radius_uniform = true;
+        is_radius_autoscale = false;
+
+        set_transform (Cairo.Matrix.identity ());
+
+        // Keep the item always in the origin
+        // move the entire coordinate system every time
+        translate (_x, _y);
+
+        // Get colors from settings
+    }
+
+    public override void simple_update (Cairo.Context cr) {
+        //(this as Goo.CanvasItemSimple).simple_update (cr);
+
+        this.bounds.x1 = x;
+        this.bounds.y1 = y;
+        this.bounds.x2 = x + width;
+        this.bounds.y2 = y + height;
+    }
+
+    public override void simple_paint (Cairo.Context cr, Goo.CanvasBounds bounds) {
+        //(this as Goo.CanvasItemSimple).simple_paint (cr, bounds);
+
+        cr.set_source_rgba (1, 0, 0, 1);
+        cr.set_line_width (2);
+
+        cr.move_to (x, y);
+        cr.line_to (x, y + height);
+        cr.line_to (x + width, y + height);
+        cr.line_to (x + width, y);
+
+        cr.stroke ();
+
+    }
+
+    public override bool simple_is_item_at (double x, double y, Cairo.Context cr, bool is_pointer_event) {
+        return true;
+    }
+
+    /*
+    public void create_path (Cairo.Context cr) {
+    }
+    */
+}

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -19,7 +19,10 @@
 * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
 */
 
-public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Models.CanvasItem {
+public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasItem, Models.CanvasItem {
+    private const double LABEL_FONT_SIZE = 14.0;
+    private const double LABEL_BOTTOM_PADDING = 8.0;
+
     // Identifiers.
     public Models.CanvasItemType item_type { get; set; }
     public string id { get; set; }
@@ -66,6 +69,8 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Models.Canv
     public double width { get; set; }
     public double height { get; set; }
 
+    private double label_height;
+
     public CanvasArtboard (
         double _x = 0,
         double _y = 0,
@@ -80,11 +85,8 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Models.Canv
         x = 0;
         y = 0;
 
-        this.notify["width"].connect((w) => {
-            debug (@"New width: $(width)");
-        });
-
         canvas = parent.get_canvas ();
+        parent.add_child (this, -1);
 
         show_border_radius_panel = false;
         show_fill_panel = false;
@@ -99,38 +101,61 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Models.Canv
         translate (_x, _y);
 
         // Get colors from settings
+        // TODO
+
+        // Get artboard name pixel extent
+        get_label_extent ();
+    }
+
+    private void get_label_extent () {
+        Cairo.ImageSurface surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, 290, 256);
+        Cairo.Context cr = new Cairo.Context (surface);
+
+        Cairo.TextExtents extents;
+        cr.select_font_face (
+            "Sans",
+            Cairo.FontSlant.NORMAL,
+            Cairo.FontWeight.NORMAL
+        );
+        cr.set_font_size (LABEL_FONT_SIZE);
+
+        cr.text_extents (id, out extents);
+
+        label_height = extents.height;
     }
 
     public override void simple_update (Cairo.Context cr) {
-        //(this as Goo.CanvasItemSimple).simple_update (cr);
-
         this.bounds.x1 = x;
-        this.bounds.y1 = y;
+        this.bounds.y1 = y - label_height - LABEL_BOTTOM_PADDING;
         this.bounds.x2 = x + width;
         this.bounds.y2 = y + height;
     }
 
     public override void simple_paint (Cairo.Context cr, Goo.CanvasBounds bounds) {
-        //(this as Goo.CanvasItemSimple).simple_paint (cr, bounds);
+        cr.set_source_rgba (0.3, 0.3, 0.3, 1);
 
-        cr.set_source_rgba (1, 0, 0, 1);
-        cr.set_line_width (2);
+        cr.select_font_face (
+            "Sans",
+            Cairo.FontSlant.NORMAL,
+            Cairo.FontWeight.NORMAL
+        );
+        cr.set_font_size (LABEL_FONT_SIZE);
 
+        cr.move_to (x, y - LABEL_BOTTOM_PADDING);
+        cr.show_text (id);
         cr.move_to (x, y);
         cr.line_to (x, y + height);
         cr.line_to (x + width, y + height);
         cr.line_to (x + width, y);
+        cr.line_to (x, y);
 
-        cr.stroke ();
-
+        cr.set_source_rgba (1, 1, 1, 1);
+        cr.fill ();
     }
 
     public override bool simple_is_item_at (double x, double y, Cairo.Context cr, bool is_pointer_event) {
-        return true;
-    }
+        var is_on_handle = y < 0;
 
-    /*
-    public void create_path (Cairo.Context cr) {
+        return is_on_handle;
     }
-    */
 }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -26,7 +26,16 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     // Identifiers.
     public Models.CanvasItemType item_type { get; set; }
     public string id { get; set; }
-    public string name { get; set; }
+    private string _name;
+    public string name {
+      get {
+        return _name;
+      }
+      set {
+        _name = value;
+        changed (false);
+      }
+    }
 
     // Transform Panel attributes.
     public double opacity { get; set; }
@@ -146,14 +155,18 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         cr.set_font_size (LABEL_FONT_SIZE);
 
         cr.move_to (x, y - LABEL_BOTTOM_PADDING);
-        cr.show_text (id);
-        cr.move_to (x, y);
-        cr.line_to (x, y + height);
-        cr.line_to (x + width, y + height);
-        cr.line_to (x + width, y);
-        cr.line_to (x, y);
+        cr.show_text (name != null ? name : id);
+
+        // Add a bit of "emulated" shadow around the Artboard
+        cr.set_source_rgba (0.90, 0.90, 0.90, 1);
+        cr.save ();
+        cr.translate (2, 2);
+        cr.rectangle (x, y, width, height);
+        cr.restore ();
+        cr.fill ();
 
         cr.set_source_rgba (1, 1, 1, 1);
+        cr.rectangle (x, y, width, height);
         cr.fill ();
     }
 

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -24,7 +24,8 @@ public enum Akira.Lib.Models.CanvasItemType {
     RECT,
     ELLIPSE,
     TEXT,
-    IMAGE
+    IMAGE,
+    ARTBOARD
 }
 
 public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasItem {

--- a/src/Models/LayerModel.vala
+++ b/src/Models/LayerModel.vala
@@ -68,6 +68,12 @@ public class Akira.Models.LayerModel : Models.ItemModel {
         }
     }
 
+    public bool is_artboard {
+        get {
+            return item is Akira.Lib.Models.CanvasArtboard;
+        }
+    }
+
     public LayerModel (
         Lib.Models.CanvasItem item,
         Akira.Models.ListModel list_model

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -258,8 +258,8 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_artboard_tool () {
-        //  window.event_bus.insert_item ("artboard");
-        //  window.event_bus.close_popover ("insert");
+        window.event_bus.insert_item ("artboard");
+        window.event_bus.close_popover ("insert");
     }
 
     private void action_rect_tool () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -258,13 +258,11 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_artboard_tool () {
-        //  window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
         //  window.event_bus.insert_item ("artboard");
         //  window.event_bus.close_popover ("insert");
     }
 
     private void action_rect_tool () {
-        window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
         window.event_bus.insert_item ("rectangle");
         window.event_bus.close_popover ("insert");
     }
@@ -280,13 +278,11 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_ellipse_tool () {
-        window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
         window.event_bus.insert_item ("ellipse");
         window.event_bus.close_popover ("insert");
     }
 
     private void action_text_tool () {
-        window.main_window.main_canvas.canvas.edit_mode = Akira.Lib.Canvas.EditMode.MODE_INSERT;
         window.event_bus.insert_item ("text");
         window.event_bus.close_popover ("insert");
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -84,6 +84,7 @@ sources = files(
     'Lib/Models/CanvasEllipse.vala',
     'Lib/Models/CanvasText.vala',
     'Lib/Models/CanvasImage.vala',
+    'Lib/Models/CanvasArtboard.vala',
 
     'Lib/Selection/Nob.vala',
 )


### PR DESCRIPTION
## Summary
This PR provides an initials implementation of the Artboard feature, with basic functionality such as canvas drag & resize using the handle and LayersPanel integration.

## Steps to Test
Create an Artboard on the Canvas by pressing _I_ on the keyboard or by clicking on the Add menu and choosing "Artboard".
Then simply click & drag to size the Artboard on the Canvas.

## Screenshots
![first_akira_artboard](https://user-images.githubusercontent.com/11556031/75605094-fd2ccd00-5adf-11ea-871e-5a0f27845627.gif)

## Known Issues / Things To Do

- [x] Correctly implement the `Goo.CanvasItemSimple` interface
- [x] Add Artboard's name at top left corner and use it as a handle for Artboard movement
- [x] Add ArtboardLayer in LayersPanel at creation
- [x] Sync Artboard name in the Canvas with displayed name in ArtboardLayer widget

## This PR implements the following **features**:

- Create Artboard using `a` on the keyboard or the fle menu 
- Size Artboard using either the nobs or the property panel
- Select the Artboard using either by cliking on the Artboard label or by selecting the Artbord in the LayersPanel
- Delete the artboard with delete key on either the LayersPanel or the canvas itself
- Add a tiny box shadow to the Artboard to better distinguish it from the canvas
- Add the correct LayersPanel widget for Artboards when insering one on the canvas

## What's missing: 

- User cannot rotate an Artboard (hide nob & hide control in Transform Panel)
- User cannot modifiy or add borders to Artboards
- User should be able to lock or hide an Artboard