### PR TITLE
Handle multiple selection export

### DIFF
--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -22,6 +22,7 @@
 public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     public weak Akira.Window window { get; construct; }
     public weak Akira.Lib.Managers.ExportManager manager { get; construct; }
+    public weak Akira.Lib.Managers.ExportManager.Type export_type { get; construct; }
 
     public GLib.ListStore list_store;
 
@@ -42,10 +43,15 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     private Gtk.Overlay main_overlay;
     private Granite.Widgets.OverlayBar overlaybar;
 
-    public ExportDialog (Akira.Window window, Akira.Lib.Managers.ExportManager manager) {
+    public ExportDialog (
+        Akira.Window window,
+        Akira.Lib.Managers.ExportManager manager,
+        Akira.Lib.Managers.ExportManager.Type export_type
+    ) {
         Object (
             window: window,
             manager: manager,
+            export_type: export_type,
             border_width: 0,
             deletable: true,
             resizable: true,
@@ -167,7 +173,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         grid.attach (file_format, 1, 2, 1, 1);
         settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
         settings.changed["export-format"].connect (() => {
-            manager.init_generate_pixbuf.begin ();
+            manager.regenerate_pixbuf (export_type);
         });
 
         // Quality spinbutton.
@@ -206,7 +212,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         grid.attach (alpha_switch, 1, 5, 1, 1);
         settings.bind ("export-alpha", alpha_switch, "active", SettingsBindFlags.DEFAULT);
         settings.changed["export-alpha"].connect (() => {
-            manager.init_generate_pixbuf.begin ();
+            manager.regenerate_pixbuf (export_type);
         });
 
         // Resolution.
@@ -223,7 +229,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         settings.bind ("export-scale", scale_button, "selected", SettingsBindFlags.DEFAULT);
         grid.attach (scale_button, 1, 6, 1, 1);
         settings.changed["export-scale"].connect (() => {
-            manager.init_generate_pixbuf.begin ();
+            manager.regenerate_pixbuf (export_type);
         });
 
         // Buttons.

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -52,7 +52,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         MODE_PANNING,
     }
 
-    public Managers.ExportManager export_area_manager;
+    public Managers.ExportManager export_manager;
     public Managers.SelectedBoundManager selected_bound_manager;
     private Managers.ItemsManager items_manager;
     private Managers.NobManager nob_manager;
@@ -81,7 +81,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         events |= Gdk.EventMask.TOUCHPAD_GESTURE_MASK;
         events |= Gdk.EventMask.TOUCH_MASK;
 
-        export_area_manager = new Managers.ExportManager (this);
+        export_manager = new Managers.ExportManager (this);
         selected_bound_manager = new Managers.SelectedBoundManager (this);
         items_manager = new Managers.ItemsManager (this);
         nob_manager = new Managers.NobManager (this);
@@ -160,7 +160,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Gdk.Key.Escape:
                 edit_mode = Akira.Lib.Canvas.EditMode.MODE_SELECTION;
                 // Clear the selected export area to be sure to not leave anything behind.
-                export_area_manager.clear ();
+                export_manager.clear ();
                 break;
 
             case Gdk.Key.Delete:
@@ -273,7 +273,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
             case EditMode.MODE_EXPORT_AREA:
                 selected_bound_manager.reset_selection ();
-                export_area_manager.create_area (event);
+                export_manager.create_area (event);
                 break;
         }
 
@@ -297,7 +297,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 break;
 
             case EditMode.MODE_EXPORT_AREA:
-                export_area_manager.create_export_snapshot ();
+                export_manager.create_area_snapshot ();
                 edit_mode = EditMode.MODE_SELECTION;
                 break;
 
@@ -338,7 +338,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 break;
 
             case EditMode.MODE_EXPORT_AREA:
-                export_area_manager.resize_area (event.x, event.y);
+                export_manager.resize_area (event.x, event.y);
                 break;
         }
 
@@ -354,7 +354,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         ctrl_is_pressed = false;
         focus_canvas ();
         // Clear the selected export area to be sure to not leave anything behind.
-        export_area_manager.clear ();
+        export_manager.clear ();
     }
 
     public void focus_canvas () {

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -73,6 +73,8 @@ public class Akira.Lib.Managers.NobManager : Object {
 
         canvas.window.event_bus.selected_items_changed.connect (on_add_select_effect);
         canvas.window.event_bus.zoom.connect (on_canvas_zoom);
+        canvas.window.event_bus.hide_select_effect.connect (on_hide_select_effect);
+        canvas.window.event_bus.show_select_effect.connect (on_show_select_effect);
     }
 
     private void on_canvas_zoom () {
@@ -374,5 +376,19 @@ public class Akira.Lib.Managers.NobManager : Object {
         _height = height;
         x = left;
         y = top;
+    }
+
+    private async void on_hide_select_effect () {
+        for (int i = 0; i < 9; i++) {
+            nobs[i].set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+        }
+        select_effect.set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+    }
+
+    private async void on_show_select_effect () {
+        for (int i = 0; i < 9; i++) {
+            nobs[i].set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+        }
+        select_effect.set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
     }
 }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -124,9 +124,9 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
 
         var rgba_fill = Gdk.RGBA ();
         rgba_fill = color;
-        //  debug (fill_alpha.to_string ());
+        // debug (fill_alpha.to_string ());
         rgba_fill.alpha = ((double) fill_alpha) / 255 * opacity / 100;
-        //  debug (rgba_fill.alpha.to_string ());
+        // debug (rgba_fill.alpha.to_string ());
 
         uint fill_color_rgba = Utils.Color.rgba_to_uint (rgba_fill);
         set ("fill-color-rgba", fill_color_rgba);

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -208,6 +208,7 @@ public class Akira.Services.ActionManager : Object {
             return;
         }
         // TODO: Trigger selection pixbuf generation.
+        canvas.export_manager.create_selection_snapshot ();
     }
 
     private void action_export_artboards () {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -38,6 +38,8 @@ public class Akira.Services.EventBus : Object {
     public signal void update_nob_size ();
     public signal void zoom ();
     public signal void canvas_notification (string message);
+    public signal void hide_select_effect ();
+    public signal void show_select_effect ();
 
     // Options panel signals.
     public signal void align_items (string align_action);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
This PR extends the basic functionalities of the `ExportManager` to allow dynamic exporting and handling of selections and custom areas.
This PR creates a distinction between areas and selections, handling those separately, and implementing a dynamic hide/show of the selection effect.

### Screenshot
![export-selection](https://user-images.githubusercontent.com/2527103/76061399-4ba2f700-5f38-11ea-89ec-bea156060790.gif)

