### PR TITLE
WIP: Artboard as Containers

### DIFF
--- a/data/css/artboard.css
+++ b/data/css/artboard.css
@@ -24,7 +24,7 @@
     color: @fg_color;
 }
 
-artboard:selected {
+.artboard:selected {
     box-shadow: inset 4px 0 0 @primary;
 }
 

--- a/data/css/artboard.css
+++ b/data/css/artboard.css
@@ -8,7 +8,14 @@
     font-weight: bold;
     padding: 6px 10px;
     text-shadow: 0 1px 0 @bg_color;
-    border-bottom: 1px solid shade (@bg_color, 0.8);
+}
+
+.artboard .artboard-handle {
+  border-bottom: 1px solid shade (@bg_color, 0.8);
+}
+
+.artboard.hover .layer-action {
+  opacity: 0.5;
 }
 
 .artboard:hover,
@@ -17,7 +24,7 @@
     color: @fg_color;
 }
 
-.artboard:selected {
+artboard:selected {
     box-shadow: inset 4px 0 0 @primary;
 }
 

--- a/data/css/layer.css
+++ b/data/css/layer.css
@@ -78,7 +78,6 @@
     border: none;
     box-shadow: none;
     background: transparent;
-    border-bottom: 1px solid shade (@bg_color, 0.8);
 }
 
 .revealer-button image {

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -34,6 +34,12 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
     public Gtk.Label label;
     public Gtk.Entry entry;
     public Gtk.EventBox handle;
+    public Gtk.Image icon_locked;
+    public Gtk.Image icon_unlocked;
+    public Gtk.Image icon_hidden;
+    public Gtk.Image icon_visible;
+    public Gtk.ToggleButton button_locked;
+    public Gtk.ToggleButton button_hidden;
     public Gtk.ToggleButton button;
     public Gtk.Image button_icon;
     public Gtk.Revealer revealer;
@@ -98,6 +104,41 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         handle.add (label_grid);
         handle.event.connect (on_click_event);
 
+        button_locked = new Gtk.ToggleButton ();
+        button_locked.tooltip_text = _("Lock Layer");
+        button_locked.get_style_context ().remove_class ("button");
+        button_locked.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        button_locked.get_style_context ().add_class ("layer-action");
+        button_locked.valign = Gtk.Align.CENTER;
+        icon_locked = new Gtk.Image.from_icon_name ("changes-allow-symbolic", Gtk.IconSize.MENU);
+        icon_unlocked = new Gtk.Image.from_icon_name ("changes-prevent-symbolic", Gtk.IconSize.MENU);
+        icon_unlocked.visible = false;
+        icon_unlocked.no_show_all = true;
+
+        button_hidden = new Gtk.ToggleButton ();
+        button_hidden.tooltip_text = _("Hide Layer");
+        button_hidden.get_style_context ().remove_class ("button");
+        button_hidden.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        button_hidden.get_style_context ().add_class ("layer-action");
+        button_hidden.valign = Gtk.Align.CENTER;
+        icon_hidden = new Gtk.Image.from_icon_name ("layer-visible-symbolic", Gtk.IconSize.MENU);
+        icon_visible = new Gtk.Image.from_icon_name ("layer-hidden-symbolic", Gtk.IconSize.MENU);
+        icon_visible.visible = false;
+        icon_visible.no_show_all = true;
+
+        var button_locked_grid = new Gtk.Grid ();
+        button_locked_grid.margin_end = 6;
+        button_locked_grid.attach (icon_locked, 0, 0, 1, 1);
+        button_locked_grid.attach (icon_unlocked, 1, 0, 1, 1);
+
+        var button_hidden_grid = new Gtk.Grid ();
+        button_hidden_grid.margin_end = 14;
+        button_hidden_grid.attach (icon_hidden, 0, 0, 1, 1);
+        button_hidden_grid.attach (icon_visible, 1, 0, 1, 1);
+
+        button_hidden.add (button_hidden_grid);
+        button_locked.add (button_locked_grid);
+
         button = new Gtk.ToggleButton ();
         button.active = true;
         button.get_style_context ().remove_class ("button");
@@ -106,10 +147,16 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         button_icon = new Gtk.Image.from_icon_name ("pan-down-symbolic", Gtk.IconSize.MENU);
         button.add (button_icon);
 
+        var artboard_handle = new Gtk.Grid ();
+        artboard_handle.get_style_context ().add_class ("artboard-handle");
+        artboard_handle.attach (handle, 0, 0, 1, 1);
+        artboard_handle.attach (button_locked, 1, 0, 1, 1);
+        artboard_handle.attach (button_hidden, 2, 0, 1, 1);
+        artboard_handle.attach (button, 3, 0, 1, 1);
+
         var grid = new Gtk.Grid ();
-        grid.attach (handle, 0, 0, 1, 1);
-        grid.attach (button, 1, 0, 1, 1);
-        grid.attach (revealer, 0, 1, 2, 1);
+        grid.attach (artboard_handle, 0, 0, 1, 1);
+        grid.attach (revealer, 0, 1, 1, 1);
 
         add (grid);
 
@@ -136,6 +183,16 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
             }
 
             (parent as Gtk.ListBox).unselect_row (this);
+        });
+
+        handle.enter_notify_event.connect (event => {
+            get_style_context ().add_class ("hover");
+            return false;
+        });
+
+        handle.leave_notify_event.connect (event => {
+            get_style_context ().remove_class ("hover");
+            return false;
         });
     }
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -259,6 +259,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                     if ((clicked_item as Models.CanvasItem).locked) {
                         return true;
                     }
+
                     // Item has been selected
                     selected_bound_manager.add_item_to_selection (clicked_item as Models.CanvasItem);
                 }

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -114,8 +114,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
             null
         );
 
-        var transform = Cairo.Matrix.identity ();
-        item.get_transform (out transform);
+        var transform = item.get_real_transform ();
         hover_effect.set_transform (transform);
 
         hover_effect.set ("parent", canvas.get_root_item ());

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -55,19 +55,17 @@ public class Akira.Lib.Managers.ItemsManager : Object {
       udpate_default_values ();
 
       Models.CanvasItem? new_item;
-      Goo.CanvasItem parent = root;
+      Models.CanvasArtboard? artboard = null;
 
-      foreach (var artboard in artboards) {
-        if (artboard.is_inside (event.x, event.y)) {
-          parent = artboard as Goo.CanvasItem;
+      foreach (var _artboard in artboards) {
+        if (_artboard.is_inside (event.x, event.y)) {
+          artboard = _artboard;
         }
       }
 
-      debug (@"Event.x $(event.x) Event.y $(event.y)");
-
       switch (insert_type) {
         case Models.CanvasItemType.RECT:
-          new_item = add_rect (event, root);
+          new_item = add_rect (event, root, artboard);
           break;
 
         case Models.CanvasItemType.ELLIPSE:
@@ -93,10 +91,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         } else {
           items.append (new_item);
 
-          if (parent != root) {
-            var artboard = parent as Models.CanvasArtboard;
-
-            debug (@"Adding $(new_item.id) to $(artboard.id)");
+          if (artboard != null) {
             artboard.add_child (new_item, -1);
           }
         }
@@ -126,8 +121,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         return artboard as Models.CanvasItem;
     }
 
-    public Models.CanvasItem add_rect (Gdk.EventButton event, Goo.CanvasItem parent) {
-        debug (@"Add rect parent is null: $(parent == null)");
+    public Models.CanvasItem add_rect (Gdk.EventButton event, Goo.CanvasItem parent, Models.CanvasArtboard? artboard) {
         var rect = new Models.CanvasRect (
             Utils.AffineTransform.fix_size (event.x),
             Utils.AffineTransform.fix_size (event.y),
@@ -136,9 +130,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             border_size,
             border_color,
             fill_color,
-            parent
+            parent,
+            artboard
         );
-
 
         return rect;
     }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -69,11 +69,11 @@ public class Akira.Lib.Managers.ItemsManager : Object {
           break;
 
         case Models.CanvasItemType.ELLIPSE:
-          new_item = add_ellipse (event, root);
+          new_item = add_ellipse (event, root, artboard);
           break;
 
         case Models.CanvasItemType.TEXT:
-          new_item = add_text (event, root);
+          new_item = add_text (event, root, artboard);
           break;
 
         case Models.CanvasItemType.ARTBOARD:
@@ -103,6 +103,12 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     }
 
     public void on_request_delete_item (Lib.Models.CanvasItem item) {
+        if (item is Models.CanvasArtboard) {
+          artboards.remove (item as Models.CanvasArtboard);
+        } else {
+          items.remove (item);
+        }
+
         item.delete ();
         canvas.window.event_bus.item_deleted (item);
     }
@@ -133,7 +139,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         return rect;
     }
 
-    public Models.CanvasEllipse add_ellipse (Gdk.EventButton event, Goo.CanvasItem parent) {
+    public Models.CanvasEllipse add_ellipse (Gdk.EventButton event, Goo.CanvasItem parent, Models.CanvasArtboard? artboard) {
         var ellipse = new Models.CanvasEllipse (
             Utils.AffineTransform.fix_size (event.x),
             Utils.AffineTransform.fix_size (event.y),
@@ -142,13 +148,14 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             border_size,
             border_color,
             fill_color,
-            parent
+            parent,
+            artboard
         );
 
         return ellipse;
     }
 
-    public Models.CanvasText add_text (Gdk.EventButton event, Goo.CanvasItem parent) {
+    public Models.CanvasText add_text (Gdk.EventButton event, Goo.CanvasItem parent, Models.CanvasArtboard? artboard) {
         var text = new Models.CanvasText (
             "Add text here",
             Utils.AffineTransform.fix_size (event.x),
@@ -157,7 +164,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             25f,
             Goo.CanvasAnchorType.NW,
             "Open Sans 18",
-            parent
+            parent,
+            artboard
         );
 
         return text;

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -90,10 +90,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
           artboards.append ((Models.CanvasArtboard) new_item);
         } else {
           items.append (new_item);
-
-          if (artboard != null) {
-            artboard.add_child (new_item, -1);
-          }
         }
 
         canvas.window.event_bus.item_inserted (new_item);

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -33,7 +33,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     public ItemsManager (Akira.Lib.Canvas canvas) {
         Object (
             canvas: canvas
-            );
+        );
     }
 
     construct {

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -19,7 +19,6 @@
  * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>
  */
 
-
 public class Akira.Lib.Managers.ItemsManager : Object {
     public weak Akira.Lib.Canvas canvas { get; construct; }
 
@@ -34,7 +33,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     public ItemsManager (Akira.Lib.Canvas canvas) {
         Object (
             canvas: canvas
-        );
+            );
     }
 
     construct {
@@ -52,50 +51,50 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     }
 
     public Models.CanvasItem? insert_item (Gdk.EventButton event) {
-      udpate_default_values ();
+        udpate_default_values ();
 
-      Models.CanvasItem? new_item;
-      Models.CanvasArtboard? artboard = null;
+        Models.CanvasItem? new_item;
+        Models.CanvasArtboard? artboard = null;
 
-      foreach (var _artboard in artboards) {
-        if (_artboard.is_inside (event.x, event.y)) {
-          artboard = _artboard;
-        }
-      }
-
-      switch (insert_type) {
-        case Models.CanvasItemType.RECT:
-          new_item = add_rect (event, root, artboard);
-          break;
-
-        case Models.CanvasItemType.ELLIPSE:
-          new_item = add_ellipse (event, root, artboard);
-          break;
-
-        case Models.CanvasItemType.TEXT:
-          new_item = add_text (event, root, artboard);
-          break;
-
-        case Models.CanvasItemType.ARTBOARD:
-          new_item = add_artboard (event);
-          break;
-
-        default:
-          new_item = null;
-          break;
-      }
-
-      if (new_item != null) {
-        if (new_item is Akira.Lib.Models.CanvasArtboard) {
-          artboards.append ((Models.CanvasArtboard) new_item);
-        } else {
-          items.append (new_item);
+        foreach (var _artboard in artboards) {
+            if (_artboard.is_inside (event.x, event.y)) {
+                artboard = _artboard;
+            }
         }
 
-        canvas.window.event_bus.item_inserted (new_item);
-      }
+        switch (insert_type) {
+            case Models.CanvasItemType.RECT:
+                new_item = add_rect (event, root, artboard);
+                break;
 
-      return new_item;
+            case Models.CanvasItemType.ELLIPSE:
+                new_item = add_ellipse (event, root, artboard);
+                break;
+
+            case Models.CanvasItemType.TEXT:
+                new_item = add_text (event, root, artboard);
+                break;
+
+            case Models.CanvasItemType.ARTBOARD:
+                new_item = add_artboard (event);
+                break;
+
+            default:
+                new_item = null;
+                break;
+        }
+
+        if (new_item != null) {
+            if (new_item is Akira.Lib.Models.CanvasArtboard) {
+                artboards.append ((Models.CanvasArtboard) new_item);
+            } else {
+                items.append (new_item);
+            }
+
+            canvas.window.event_bus.item_inserted (new_item);
+        }
+
+        return new_item;
     }
 
     public void add_item (Akira.Lib.Models.CanvasItem item) {
@@ -104,9 +103,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
 
     public void on_request_delete_item (Lib.Models.CanvasItem item) {
         if (item is Models.CanvasArtboard) {
-          artboards.remove (item as Models.CanvasArtboard);
+            artboards.remove (item as Models.CanvasArtboard);
         } else {
-          items.remove (item);
+            items.remove (item);
         }
 
         item.delete ();
@@ -118,7 +117,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             Utils.AffineTransform.fix_size (event.x),
             Utils.AffineTransform.fix_size (event.y),
             root
-        );
+            );
 
         return artboard as Models.CanvasItem;
     }
@@ -134,7 +133,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             fill_color,
             parent,
             artboard
-        );
+            );
 
         return rect;
     }
@@ -150,7 +149,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             fill_color,
             parent,
             artboard
-        );
+            );
 
         return ellipse;
     }
@@ -166,7 +165,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             "Open Sans 18",
             parent,
             artboard
-        );
+            );
 
         return text;
     }

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -350,12 +350,7 @@ public class Akira.Lib.Managers.NobManager : Object {
         if (selected_items.length () == 1) {
             var item = selected_items.nth_data (0);
 
-            if (item.artboard == null) {
-                item.get_transform (out transform);
-            } else {
-                item.artboard.get_transform (out transform);
-                transform.translate (item.relative_x, item.relative_y);
-            }
+            transform = item.get_real_transform ();
 
             item.get ("line_width", out line_width);
             item.get ("width", out _width);

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -350,7 +350,14 @@ public class Akira.Lib.Managers.NobManager : Object {
         if (selected_items.length () == 1) {
             var item = selected_items.nth_data (0);
 
-            item.get_transform (out transform);
+            if (item.artboard == null) {
+                item.get_transform (out transform);
+            } else {
+                item.artboard.get_transform (out transform);
+                transform.translate (item.relative_x, item.relative_y);
+            }
+
+            item.get ("line_width", out line_width);
             item.get ("width", out _width);
             item.get ("height", out _height);
             item.get ("x", out x);

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -352,7 +352,7 @@ public class Akira.Lib.Managers.NobManager : Object {
 
             transform = item.get_real_transform ();
 
-            item.get ("line_width", out line_width);
+            // item.get ("line_width", out line_width);
             item.get ("width", out _width);
             item.get ("height", out _height);
             item.get ("x", out x);

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -62,6 +62,8 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         if (selected_items.length () == 1) {
             var selected_item = selected_items.nth_data (0);
 
+            selected_item.store_relative_position ();
+
             initial_event_x = event_x;
             initial_event_y = event_y;
 

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -37,6 +37,8 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     private Goo.CanvasBounds select_bb;
     private double initial_event_x;
     private double initial_event_y;
+    private double delta_x_accumulator;
+    private double delta_y_accumulator;
     private double initial_width;
     private double initial_height;
 
@@ -64,10 +66,13 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
             selected_item.store_relative_position ();
 
+            delta_x_accumulator = 0.0;
+            delta_y_accumulator = 0.0;
+
             initial_event_x = event_x;
             initial_event_y = event_y;
 
-            canvas.convert_to_item_space (selected_item, ref initial_event_x, ref initial_event_y);
+            // canvas.convert_to_item_space (selected_item, ref initial_event_x, ref initial_event_y);
 
             initial_width = selected_item.get_coords ("width");
             initial_height = selected_item.get_coords ("height");
@@ -93,7 +98,8 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
             case Managers.NobManager.Nob.NONE:
                 Utils.AffineTransform.move_from_event (
                     event_x, event_y,
-                    initial_event_x, initial_event_y,
+                    ref initial_event_x, ref initial_event_y,
+                    ref delta_x_accumulator, ref delta_y_accumulator,
                     selected_item
                 );
                 update_selected_items ();
@@ -111,6 +117,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
                 Utils.AffineTransform.scale_from_event (
                     event_x, event_y,
                     ref initial_event_x, ref initial_event_y,
+                    ref delta_x_accumulator, ref delta_y_accumulator,
                     initial_width, initial_height,
                     selected_nob,
                     selected_item

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -241,13 +241,10 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
 
     public override bool simple_is_item_at (double x, double y, Cairo.Context cr, bool is_pointer_event) {
         // To select an Artboard you should put the arrow
-        // ontop of the Artboard label
-        var is_on_handle =
-            y < 0
+        // over the Artboard label
+        return y < 0
             && y > - (label_extents.height + LABEL_BOTTOM_PADDING)
             && x < (label_extents.width);
-
-        return is_on_handle;
     }
 
     public double get_label_height () {
@@ -259,10 +256,8 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         var artboard_y = y;
 
         canvas.convert_to_item_space (this, ref artboard_x, ref artboard_y);
-        if (simple_is_item_at (
-                artboard_x, artboard_y,
-                cr, is_pointer_event)
-           ) {
+
+        if (simple_is_item_at (artboard_x, artboard_y, cr, is_pointer_event)) {
             found_items.append (this);
         }
 

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -84,7 +84,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     private double label_height;
     private List<Models.CanvasItem> items;
     public new Akira.Lib.Canvas canvas { get; set; }
-    public Models.CanvasArtboard artboard { get; set; }
+    public Models.CanvasArtboard? artboard { get; set; }
 
     public CanvasArtboard (
         double _x = 0,

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -149,6 +149,19 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
       items.remove (item);
     }
 
+    public void remove_all_items () {
+      Models.CanvasItem item;
+
+      while (items != null) {
+        // Get the new head of the list
+        item = items.nth_data (0);
+
+        canvas.window.event_bus.request_delete_item (item);
+      }
+
+      items = new List<Models.CanvasItem> ();
+    }
+
     public bool is_inside (double x, double y) {
         return x <= this.bounds.x2
             && x >= this.bounds.x1

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -95,7 +95,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         double _x = 0,
         double _y = 0,
         Goo.CanvasItem? _parent = null
-    ) {
+        ) {
         parent_item = _parent;
 
         canvas = parent_item.get_canvas () as Akira.Lib.Canvas;
@@ -146,20 +146,20 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public void remove_item (Models.CanvasItem item) {
-      items.remove (item);
+        items.remove (item);
     }
 
     public void remove_all_items () {
-      Models.CanvasItem item;
+        Models.CanvasItem item;
 
-      while (items != null) {
-        // Get the new head of the list
-        item = items.nth_data (0);
+        while (items != null) {
+            // Get the new head of the list
+            item = items.nth_data (0);
 
-        canvas.window.event_bus.request_delete_item (item);
-      }
+            canvas.window.event_bus.request_delete_item (item);
+        }
 
-      items = new List<Models.CanvasItem> ();
+        items = new List<Models.CanvasItem> ();
     }
 
     public bool is_inside (double x, double y) {
@@ -190,7 +190,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
             "Sans",
             Cairo.FontSlant.NORMAL,
             Cairo.FontWeight.NORMAL
-        );
+            );
 
         cr.set_font_size (LABEL_FONT_SIZE);
 
@@ -211,7 +211,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
             "Sans",
             Cairo.FontSlant.NORMAL,
             Cairo.FontWeight.NORMAL
-        );
+            );
 
         cr.set_font_size (LABEL_FONT_SIZE);
 
@@ -237,7 +237,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
                 cr.transform (item.compute_transform (Cairo.Matrix.identity ()));
 
                 if (item is Goo.CanvasItemSimple) {
-                  (item as Goo.CanvasItemSimple).simple_paint (cr, bounds);
+                    (item as Goo.CanvasItemSimple).simple_paint (cr, bounds);
                 }
 
                 cr.restore ();
@@ -249,9 +249,9 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         // To select an Artboard you should put the arrow
         // ontop of the Artboard label
         var is_on_handle =
-          y < 0
-          && y > - (label_extents.height + LABEL_BOTTOM_PADDING)
-          && x < (label_extents.width);
+            y < 0
+            && y > - (label_extents.height + LABEL_BOTTOM_PADDING)
+            && x < (label_extents.width);
 
         return is_on_handle;
     }
@@ -260,37 +260,34 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         return label_extents.height + LABEL_BOTTOM_PADDING;
     }
 
-    public unowned GLib.List<Goo.CanvasItem> get_items_at (
-      double x, double y,
-      Cairo.Context cr, bool is_pointer_event,
-      bool parent_is_visible, GLib.List<Goo.CanvasItem> found_items) {
-      var artboard_x = x;
-      var artboard_y = y;
+    public unowned GLib.List<Goo.CanvasItem> get_items_at (double x, double y, Cairo.Context cr, bool is_pointer_event, bool parent_is_visible, GLib.List<Goo.CanvasItem> found_items) {
+        var artboard_x = x;
+        var artboard_y = y;
 
-      canvas.convert_to_item_space (this, ref artboard_x, ref artboard_y);
-      if (simple_is_item_at (
-          artboard_x, artboard_y,
-          cr, is_pointer_event)
-      ) {
-        found_items.append (this);
-      }
-
-      foreach (var item in items) {
-        var item_x = x;
-        var item_y = y;
-
-        canvas.convert_to_item_space (item, ref item_x, ref item_y);
-
-        var item_is_inside = item.simple_is_item_at (
-          x, y,
-          cr, is_pointer_event
-        );
-
-        if (item_is_inside) {
-          found_items.append (item);
+        canvas.convert_to_item_space (this, ref artboard_x, ref artboard_y);
+        if (simple_is_item_at (
+                artboard_x, artboard_y,
+                cr, is_pointer_event)
+           ) {
+            found_items.append (this);
         }
-      }
 
-      return found_items;
+        foreach (var item in items) {
+            var item_x = x;
+            var item_y = y;
+
+            canvas.convert_to_item_space (item, ref item_x, ref item_y);
+
+            var item_is_inside = item.simple_is_item_at (
+                x, y,
+                cr, is_pointer_event
+                );
+
+            if (item_is_inside) {
+                found_items.append (item);
+            }
+        }
+
+        return found_items;
     }
 }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -234,4 +234,38 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     public double get_label_height () {
         return label_height + LABEL_BOTTOM_PADDING;
     }
+
+    public unowned GLib.List<Goo.CanvasItem> get_items_at (
+      double x, double y,
+      Cairo.Context cr, bool is_pointer_event,
+      bool parent_is_visible, GLib.List<Goo.CanvasItem> found_items) {
+      var artboard_x = x;
+      var artboard_y = y;
+
+      canvas.convert_to_item_space (this, ref artboard_x, ref artboard_y);
+      if (simple_is_item_at (
+          artboard_x, artboard_y,
+          cr, is_pointer_event)
+      ) {
+        found_items.append (this);
+      }
+
+      foreach (var item in items) {
+        var item_x = x;
+        var item_y = y;
+
+        canvas.convert_to_item_space (item, ref item_x, ref item_y);
+
+        var item_is_inside = item.simple_is_item_at (
+          x, y,
+          cr, is_pointer_event
+        );
+
+        if (item_is_inside) {
+          found_items.append (item);
+        }
+      }
+
+      return found_items;
+    }
 }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -90,7 +90,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         double _x = 0,
         double _y = 0,
         Goo.CanvasItem? _parent = null
-    ) {
+        ) {
         parent_item = _parent;
 
         canvas = parent_item.get_canvas () as Akira.Lib.Canvas;
@@ -131,28 +131,32 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public uint get_items_length () {
-      return this.items.length ();
+        return this.items.length ();
     }
 
     public void move_items (double delta_x, double delta_y) {
-      foreach (var item in items) {
-        item.move (delta_x, delta_y);
-      }
+        foreach (var item in items) {
+            item.translate (delta_x, delta_y);
+        }
     }
 
     public bool is_inside (double x, double y) {
-      return x <= this.bounds.x2
-        && x >= this.bounds.x1
-        && y >= this.bounds.y1
-        && y <= this.bounds.y2;
+        return x <= this.bounds.x2
+            && x >= this.bounds.x1
+            && y >= this.bounds.y1
+            && y <= this.bounds.y2;
     }
 
     public void add_child (Goo.CanvasItem item, int position = -1) {
-      this.items.append (item as Models.CanvasItem);
+        var canvas_item = item as Models.CanvasItem;
 
-      item.set_parent (this);
+        if (canvas_item.id == null) {
+            return;
+        }
 
-      request_update ();
+        this.items.append (canvas_item);
+        item.set_parent (this);
+        request_update ();
     }
 
     private void get_label_extent () {
@@ -164,7 +168,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
             "Sans",
             Cairo.FontSlant.NORMAL,
             Cairo.FontWeight.NORMAL
-        );
+            );
         cr.set_font_size (LABEL_FONT_SIZE);
 
         cr.text_extents (id, out extents);
@@ -186,7 +190,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
             "Sans",
             Cairo.FontSlant.NORMAL,
             Cairo.FontWeight.NORMAL
-        );
+            );
         cr.set_font_size (LABEL_FONT_SIZE);
 
         cr.move_to (x, y - LABEL_BOTTOM_PADDING);
@@ -205,9 +209,17 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         cr.fill ();
 
         if (items.length () > 0) {
-          foreach (var item in items) {
-            item.request_update ();
-          }
+            foreach (var item in items) {
+                cr.save ();
+
+                cr.translate (item.relative_x, item.relative_y);
+
+                if (item is Goo.CanvasItemSimple) {
+                    (item as Goo.CanvasRect).simple_paint (cr, bounds);
+                }
+
+                cr.restore ();
+            }
         }
     }
 

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -84,6 +84,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     private double label_height;
     private List<Models.CanvasItem> items;
     public new Akira.Lib.Canvas canvas { get; set; }
+    public Models.CanvasArtboard artboard { get; set; }
 
     public CanvasArtboard (
         double _x = 0,
@@ -94,6 +95,9 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
 
         canvas = parent_item.get_canvas () as Akira.Lib.Canvas;
         parent_item.add_child (this, -1);
+
+        // Artboards can't be nested
+        artboard = null;
 
         item_type = Models.CanvasItemType.ARTBOARD;
         id = Models.CanvasItem.create_item_id (this);
@@ -144,7 +148,6 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public void add_child (Goo.CanvasItem item, int position = -1) {
-      debug (@"Adding child: $((item as Models.CanvasItem).id)");
       this.items.append (item as Models.CanvasItem);
 
       item.set_parent (this);

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -237,7 +237,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
                 cr.transform (item.compute_transform (Cairo.Matrix.identity ()));
 
                 if (item is Goo.CanvasItemSimple) {
-                    (item as Goo.CanvasRect).simple_paint (cr, bounds);
+                  (item as Goo.CanvasItemSimple).simple_paint (cr, bounds);
                 }
 
                 cr.restore ();

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -85,6 +85,8 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     private List<Models.CanvasItem> items;
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard? artboard { get; set; }
+    public double relative_x { get; set; }
+    public double relative_y { get; set; }
 
     public CanvasArtboard (
         double _x = 0,

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -257,7 +257,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public double get_label_height () {
-        return label_height + LABEL_BOTTOM_PADDING;
+        return label_extents.height + LABEL_BOTTOM_PADDING;
     }
 
     public unowned GLib.List<Goo.CanvasItem> get_items_at (

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -145,6 +145,10 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         }
     }
 
+    public void remove_item (Models.CanvasItem item) {
+      items.remove (item);
+    }
+
     public bool is_inside (double x, double y) {
         return x <= this.bounds.x2
             && x >= this.bounds.x1

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -88,6 +88,9 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 
+    public double initial_relative_x { get; set; }
+    public double initial_relative_y { get; set; }
+
     public CanvasArtboard (
         double _x = 0,
         double _y = 0,

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -139,12 +139,6 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         return this.items.length ();
     }
 
-    public void move_items (double delta_x, double delta_y) {
-        foreach (var item in items) {
-            // item.translate (delta_x, delta_y);
-        }
-    }
-
     public void remove_item (Models.CanvasItem item) {
         items.remove (item);
     }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -80,7 +80,10 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     public double height { get; set; }
     public Goo.CanvasItem parent_item { get; set; }
 
+    // Artboard related properties
     private double label_height;
+    private List<Models.CanvasItem> items;
+    public new Akira.Lib.Canvas canvas { get; set; }
 
     public CanvasArtboard (
         double _x = 0,
@@ -89,7 +92,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     ) {
         parent_item = _parent;
 
-        canvas = parent_item.get_canvas ();
+        canvas = parent_item.get_canvas () as Akira.Lib.Canvas;
         parent_item.add_child (this, -1);
 
         item_type = Models.CanvasItemType.ARTBOARD;
@@ -118,6 +121,35 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
 
         // Get artboard name pixel extent
         get_label_extent ();
+
+        // Init items list
+        items = new List<Models.CanvasItem> ();
+    }
+
+    public uint get_items_length () {
+      return this.items.length ();
+    }
+
+    public void move_items (double delta_x, double delta_y) {
+      foreach (var item in items) {
+        item.move (delta_x, delta_y);
+      }
+    }
+
+    public bool is_inside (double x, double y) {
+      return x <= this.bounds.x2
+        && x >= this.bounds.x1
+        && y >= this.bounds.y1
+        && y <= this.bounds.y2;
+    }
+
+    public void add_child (Goo.CanvasItem item, int position = -1) {
+      debug (@"Adding child: $((item as Models.CanvasItem).id)");
+      this.items.append (item as Models.CanvasItem);
+
+      item.set_parent (this);
+
+      request_update ();
     }
 
     private void get_label_extent () {
@@ -168,6 +200,12 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         cr.set_source_rgba (1, 1, 1, 1);
         cr.rectangle (x, y, width, height);
         cr.fill ();
+
+        if (items.length () > 0) {
+          foreach (var item in items) {
+            item.request_update ();
+          }
+        }
     }
 
     public override bool simple_is_item_at (double x, double y, Cairo.Context cr, bool is_pointer_event) {

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -59,7 +59,7 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public int z_index { get; set; }
 
     public new Akira.Lib.Canvas canvas { get; set; }
-    public Models.CanvasArtboard artboard { get; set; }
+    public Models.CanvasArtboard? artboard { get; set; }
 
     public double relative_x { get; set; }
     public double relative_y { get; set; }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -75,13 +75,12 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         int _border_size = 1,
         Gdk.RGBA _border_color,
         Gdk.RGBA _fill_color,
-        Goo.CanvasItem? parent = null
+        Goo.CanvasItem? _parent = null,
+        Models.CanvasArtboard? _artboard = null
     ) {
-        Object (
-            parent: parent
-        );
+        artboard = _artboard;
+        parent = _artboard != null ? _artboard : _parent;
         canvas = parent.get_canvas () as Akira.Lib.Canvas;
-        parent.add_child (this, -1);
 
         item_type = Models.CanvasItemType.ELLIPSE;
         id = Models.CanvasItem.create_item_id (this);
@@ -97,11 +96,12 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         center_y = - 0.5;
         show_fill_panel = true;
         show_border_panel = true;
+        relative_x = 0;
+        relative_y = 0;
 
         set_transform (Cairo.Matrix.identity ());
-        // Keep the item always in the origin
-        // move the entire coordinate system every time
-        translate (_center_x, _center_y);
+
+        position_item (_center_x, _center_y);
 
         color = _fill_color;
         has_border = settings.set_border;

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -61,6 +61,9 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard artboard { get; set; }
 
+    public double relative_x { get; set; }
+    public double relative_y { get; set; }
+
     public CanvasEllipse (
         double _center_x = 0,
         double _center_y = 0,

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -64,6 +64,9 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 
+    public double initial_relative_x { get; set; }
+    public double initial_relative_y { get; set; }
+
     public CanvasEllipse (
         double _center_x = 0,
         double _center_y = 0,

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -59,6 +59,7 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public int z_index { get; set; }
 
     public new Akira.Lib.Canvas canvas { get; set; }
+    public Models.CanvasArtboard artboard { get; set; }
 
     public CanvasEllipse (
         double _center_x = 0,

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -58,6 +58,8 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public string layer_icon { get; set; default = "shape-circle-symbolic"; }
     public int z_index { get; set; }
 
+    public new Akira.Lib.Canvas canvas { get; set; }
+
     public CanvasEllipse (
         double _center_x = 0,
         double _center_y = 0,
@@ -71,6 +73,8 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         Object (
             parent: parent
         );
+        canvas = parent.get_canvas () as Akira.Lib.Canvas;
+        parent.add_child (this, -1);
 
         item_type = Models.CanvasItemType.ELLIPSE;
         id = Models.CanvasItem.create_item_id (this);

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -72,6 +72,9 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 
+    public double initial_relative_x { get; set; }
+    public double initial_relative_y { get; set; }
+
     public CanvasImage (Akira.Services.ImageProvider provider, Goo.CanvasItem? parent = null) {
         Object (
             parent: parent

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -66,10 +66,15 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
     public string layer_icon { get; set; default = "shape-image-symbolic"; }
     public int z_index { get; set; }
 
+    public new Akira.Lib.Canvas canvas { get; set; }
+
     public CanvasImage (Akira.Services.ImageProvider provider, Goo.CanvasItem? parent = null) {
         Object (
             parent: parent
         );
+
+        canvas = parent.get_canvas () as Akira.Lib.Canvas;
+        parent.add_child (this, -1);
 
         item_type = Models.CanvasItemType.IMAGE;
         id = Models.CanvasItem.create_item_id (this);

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -67,6 +67,7 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
     public int z_index { get; set; }
 
     public new Akira.Lib.Canvas canvas { get; set; }
+    public Models.CanvasArtboard artboard { get; set; }
 
     public CanvasImage (Akira.Services.ImageProvider provider, Goo.CanvasItem? parent = null) {
         Object (

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -67,7 +67,7 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
     public int z_index { get; set; }
 
     public new Akira.Lib.Canvas canvas { get; set; }
-    public Models.CanvasArtboard artboard { get; set; }
+    public Models.CanvasArtboard? artboard { get; set; }
 
     public double relative_x { get; set; }
     public double relative_y { get; set; }

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -69,6 +69,9 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard artboard { get; set; }
 
+    public double relative_x { get; set; }
+    public double relative_y { get; set; }
+
     public CanvasImage (Akira.Services.ImageProvider provider, Goo.CanvasItem? parent = null) {
         Object (
             parent: parent

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -127,6 +127,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
       }
 
       if (this.artboard != null) {
+        debug (@"Moving item inside artboard by $(delta_x) $(delta_y)");
         this.relative_x = this.initial_relative_x + delta_x;
         this.relative_y = this.initial_relative_y + delta_y;
 

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -171,4 +171,29 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         set ("stroke-color-rgba", stroke_color_rgba);
         set ("line-width", (double) border_size);
     }
+
+    public bool simple_is_item_at (double x, double y, Cairo.Context cr, bool is_pointer_event) {
+      var width = get_coords ("width");
+      var height = get_coords ("height");
+
+      var item_x = relative_x;
+      var item_y = relative_y;
+
+      canvas.convert_from_item_space (
+        this.artboard,
+        ref item_x,
+        ref item_y
+      );
+
+      if (
+        x >= item_x
+        && x <= item_x + width
+        && y >= item_y
+        && y <= item_y + height
+      ) {
+        return true;
+      }
+
+      return false;
+    }
 }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -87,7 +87,10 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public void delete () {
-        // TODO: emit signal to update SideMenu
+        if (this.artboard != null) {
+          this.artboard.remove_item (this);
+        }
+
         remove ();
     }
 
@@ -127,7 +130,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
       }
 
       if (this.artboard != null) {
-        debug (@"Moving item inside artboard by $(delta_x) $(delta_y)");
         this.relative_x = this.initial_relative_x + delta_x;
         this.relative_y = this.initial_relative_y + delta_y;
 

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -70,9 +70,11 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public abstract int z_index { get; set; }
 
     public abstract Akira.Lib.Canvas canvas { get; set; }
+    public abstract Models.CanvasArtboard artboard { get; set; }
 
     public double get_coords (string coord_id) {
         double _coord = 0.0;
+
         get (coord_id, out _coord);
 
         return _coord;
@@ -113,7 +115,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         //item.set ("z-index", z_index);
     }
 
-    public virtual void move (double delta_x, double delta_y) {
+    public virtual void move (double delta_x, double delta_y, double initial_x = 0.0, double initial_y = 0.0) {
       if (this is Models.CanvasArtboard) {
         (this as Models.CanvasArtboard).move_items (delta_x, delta_y);
       }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -128,6 +128,28 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         //item.set ("z-index", z_index);
     }
 
+    public virtual void position_item (double _x, double _y) {
+      if (artboard != null) {
+        artboard.add_child (this, -1);
+
+        double item_x_from_artboard = _x;
+        double item_y_from_artboard = _y;
+
+        canvas.convert_to_item_space (artboard, ref item_x_from_artboard, ref item_y_from_artboard);
+
+        relative_x = item_x_from_artboard;
+        relative_y = item_y_from_artboard;
+      } else {
+        parent.add_child (this, -1);
+
+
+        // Keep the item always in the origin
+        // move the entire coordinate system every time
+        translate (_x, _y);
+      }
+    }
+
+
     public virtual void move (
       double delta_x, double delta_y,
       double delta_x_accumulator = 0.0, double delta_y_accumulator = 0.0) {
@@ -172,7 +194,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         // Rotate around the center by the amount
         // in item.rotation
         transform.translate (width / 2, height / 2);
-        transform.rotate (Utils.AffineTransform.degToRad (rotation));
+        transform.rotate (Utils.AffineTransform.deg_to_rad (rotation));
         transform.translate (- (width / 2), - (height / 2));
 
         return transform;

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -87,8 +87,14 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public void delete () {
+      debug (@"Removing item: $(id)");
+
         if (this.artboard != null) {
           this.artboard.remove_item (this);
+        }
+
+        if (this is Models.CanvasArtboard) {
+          (this as Models.CanvasArtboard).remove_all_items ();
         }
 
         remove ();

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -70,7 +70,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public abstract int z_index { get; set; }
 
     public abstract Akira.Lib.Canvas canvas { get; set; }
-    public abstract Models.CanvasArtboard artboard { get; set; }
+    public abstract Models.CanvasArtboard? artboard { get; set; }
 
     public abstract double relative_x { get; set; }
     public abstract double relative_y { get; set; }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -88,11 +88,11 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
 
     public void delete () {
         if (this.artboard != null) {
-          this.artboard.remove_item (this);
+            this.artboard.remove_item (this);
         }
 
         if (this is Models.CanvasArtboard) {
-          (this as Models.CanvasArtboard).remove_all_items ();
+            (this as Models.CanvasArtboard).remove_all_items ();
         }
 
         remove ();
@@ -129,60 +129,59 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public virtual void position_item (double _x, double _y) {
-      if (artboard != null) {
-        artboard.add_child (this, -1);
+        if (artboard != null) {
+            artboard.add_child (this, -1);
 
-        double item_x_from_artboard = _x;
-        double item_y_from_artboard = _y;
+            double item_x_from_artboard = _x;
+            double item_y_from_artboard = _y;
 
-        canvas.convert_to_item_space (artboard, ref item_x_from_artboard, ref item_y_from_artboard);
+            canvas.convert_to_item_space (artboard, ref item_x_from_artboard, ref item_y_from_artboard);
 
-        relative_x = item_x_from_artboard;
-        relative_y = item_y_from_artboard;
-      } else {
-        parent.add_child (this, -1);
+            relative_x = item_x_from_artboard;
+            relative_y = item_y_from_artboard;
+        } else {
+            parent.add_child (this, -1);
 
 
-        // Keep the item always in the origin
-        // move the entire coordinate system every time
-        translate (_x, _y);
-      }
+            // Keep the item always in the origin
+            // move the entire coordinate system every time
+            translate (_x, _y);
+        }
     }
 
-
     public virtual void move (
-      double delta_x, double delta_y,
-      double delta_x_accumulator = 0.0, double delta_y_accumulator = 0.0) {
-      if (this is Models.CanvasArtboard) {
-        (this as Models.CanvasArtboard).move_items (delta_x, delta_y);
-      }
+        double delta_x, double delta_y,
+        double delta_x_accumulator = 0.0, double delta_y_accumulator = 0.0) {
+        if (this is Models.CanvasArtboard) {
+            (this as Models.CanvasArtboard).move_items (delta_x, delta_y);
+        }
 
-      if (this.artboard != null) {
-        var transformed_delta_x = delta_x_accumulator;
-        var transformed_delta_y = delta_y_accumulator;
+        if (this.artboard != null) {
+            var transformed_delta_x = delta_x_accumulator;
+            var transformed_delta_y = delta_y_accumulator;
 
-        this.relative_x = this.initial_relative_x + transformed_delta_x;
-        this.relative_y = this.initial_relative_y + transformed_delta_y;
+            this.relative_x = this.initial_relative_x + transformed_delta_x;
+            this.relative_y = this.initial_relative_y + transformed_delta_y;
 
 
-        return;
-      }
+            return;
+        }
 
-      this.translate (delta_x, delta_y);
+        this.translate (delta_x, delta_y);
     }
 
     public virtual Cairo.Matrix get_real_transform () {
-      Cairo.Matrix transform = Cairo.Matrix.identity ();
+        Cairo.Matrix transform = Cairo.Matrix.identity ();
 
-      if (artboard == null) {
-        get_transform (out transform);
-      } else {
-        artboard.get_transform (out transform);
+        if (artboard == null) {
+            get_transform (out transform);
+        } else {
+            artboard.get_transform (out transform);
 
-        transform = compute_transform (transform);
-      }
+            transform = compute_transform (transform);
+        }
 
-      return transform;
+        return transform;
     }
 
     public virtual Cairo.Matrix compute_transform (Cairo.Matrix transform) {
@@ -201,25 +200,25 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public virtual double get_real_coord (string coord_id) {
-      var offset_x = this.artboard == null ? 0 : relative_x;
-      var offset_y = this.artboard == null ? 0 : relative_y;
+        var offset_x = this.artboard == null ? 0 : relative_x;
+        var offset_y = this.artboard == null ? 0 : relative_y;
 
-      var item_x = get_coords ("x") - offset_x;
-      var item_y = get_coords ("y") - offset_y;
+        var item_x = get_coords ("x") - offset_x;
+        var item_y = get_coords ("y") - offset_y;
 
-      switch (coord_id) {
-        case "x":
-          return item_x;
-        case "y":
-          return item_y;
-        default:
-          return 0.0;
-      }
+        switch (coord_id) {
+            case "x":
+                return item_x;
+            case "y":
+                return item_y;
+            default:
+                return 0.0;
+        }
     }
 
     public virtual void store_relative_position () {
-      this.initial_relative_x = this.relative_x;
-      this.initial_relative_y = this.relative_y;
+        this.initial_relative_x = this.relative_x;
+        this.initial_relative_y = this.relative_y;
     }
 
     public virtual void reset_colors () {
@@ -262,27 +261,27 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public bool simple_is_item_at (double x, double y, Cairo.Context cr, bool is_pointer_event) {
-      var width = get_coords ("width");
-      var height = get_coords ("height");
+        var width = get_coords ("width");
+        var height = get_coords ("height");
 
-      var item_x = relative_x;
-      var item_y = relative_y;
+        var item_x = relative_x;
+        var item_y = relative_y;
 
-      canvas.convert_from_item_space (
-        this.artboard,
-        ref item_x,
-        ref item_y
-      );
+        canvas.convert_from_item_space (
+            this.artboard,
+            ref item_x,
+            ref item_y
+            );
 
-      if (
-        x >= item_x
-        && x <= item_x + width
-        && y >= item_y
-        && y <= item_y + height
-      ) {
-        return true;
-      }
+        if (
+            x >= item_x
+            && x <= item_x + width
+            && y >= item_y
+            && y <= item_y + height
+           ) {
+            return true;
+        }
 
-      return false;
+        return false;
     }
 }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -72,6 +72,9 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public abstract Akira.Lib.Canvas canvas { get; set; }
     public abstract Models.CanvasArtboard artboard { get; set; }
 
+    public abstract double relative_x { get; set; }
+    public abstract double relative_y { get; set; }
+
     public double get_coords (string coord_id) {
         double _coord = 0.0;
 

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -69,6 +69,8 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public abstract string layer_icon { get; set; }
     public abstract int z_index { get; set; }
 
+    public abstract Akira.Lib.Canvas canvas { get; set; }
+
     public double get_coords (string coord_id) {
         double _coord = 0.0;
         get (coord_id, out _coord);
@@ -106,9 +108,17 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public static void update_z_index (Goo.CanvasItem item) {
-        var z_index = item.get_canvas ().get_root_item ().find_child (item);
+        //var z_index = (item as Models.CanvasItej).canvas.get_root_item ().find_child (item);
 
-        item.set ("z-index", z_index);
+        //item.set ("z-index", z_index);
+    }
+
+    public virtual void move (double delta_x, double delta_y) {
+      if (this is Models.CanvasArtboard) {
+        (this as Models.CanvasArtboard).move_items (delta_x, delta_y);
+      }
+
+      this.translate (delta_x, delta_y);
     }
 
     public virtual void reset_colors () {

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -91,6 +91,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
             this.artboard.remove_item (this);
         }
 
+
         if (this is Models.CanvasArtboard) {
             (this as Models.CanvasArtboard).remove_all_items ();
         }
@@ -152,9 +153,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public virtual void move (
         double delta_x, double delta_y,
         double delta_x_accumulator = 0.0, double delta_y_accumulator = 0.0) {
-        if (this is Models.CanvasArtboard) {
-            (this as Models.CanvasArtboard).move_items (delta_x, delta_y);
-        }
 
         if (this.artboard != null) {
             var transformed_delta_x = delta_x_accumulator;

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -123,6 +123,13 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         (this as Models.CanvasArtboard).move_items (delta_x, delta_y);
       }
 
+      if (this.artboard != null) {
+        this.relative_x += delta_x;
+        this.relative_y += delta_y;
+
+        return;
+      }
+
       this.translate (delta_x, delta_y);
     }
 

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -78,6 +78,9 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 
+    public double initial_relative_x { get; set; }
+    public double initial_relative_y { get; set; }
+
     public CanvasRect (
         double _x = 0,
         double _y = 0,

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -72,6 +72,8 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public bool is_radius_uniform { get; set; }
     public bool is_radius_autoscale { get; set; }
 
+    public new Akira.Lib.Canvas canvas { get; set; }
+
     public CanvasRect (
         double _x = 0,
         double _y = 0,
@@ -85,6 +87,9 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         Object (
             parent: parent
         );
+
+        canvas = parent.get_canvas () as Akira.Lib.Canvas;
+        parent.add_child (this, -1);
 
         item_type = Models.CanvasItemType.RECT;
         id = Models.CanvasItem.create_item_id (this);

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -73,6 +73,7 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public bool is_radius_autoscale { get; set; }
 
     public new Akira.Lib.Canvas canvas { get; set; }
+    public Models.CanvasArtboard artboard { get; set; }
 
     public CanvasRect (
         double _x = 0,
@@ -82,10 +83,12 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         int _border_size = 1,
         Gdk.RGBA _border_color,
         Gdk.RGBA _fill_color,
-        Goo.CanvasItem? parent = null
+        Goo.CanvasItem? parent = null,
+        Models.CanvasArtboard? artboard = null
     ) {
         Object (
-            parent: parent
+            parent: parent,
+            artboard: artboard
         );
 
         canvas = parent.get_canvas () as Akira.Lib.Canvas;

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -96,9 +96,6 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         parent = _artboard != null ? _artboard : _parent;
         canvas = parent.get_canvas () as Akira.Lib.Canvas;
 
-        canvas = parent.get_canvas () as Akira.Lib.Canvas;
-        parent.add_child (this, -1);
-
         item_type = Models.CanvasItemType.RECT;
         id = Models.CanvasItem.create_item_id (this);
         Models.CanvasItem.init_item (this);

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -75,6 +75,9 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard artboard { get; set; }
 
+    public double relative_x { get; set; }
+    public double relative_y { get; set; }
+
     public CanvasRect (
         double _x = 0,
         double _y = 0,
@@ -87,7 +90,7 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         Models.CanvasArtboard? artboard = null
     ) {
         Object (
-            parent: parent,
+            parent: artboard,
             artboard: artboard
         );
 
@@ -104,6 +107,8 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         height = 1;
         x = 0;
         y = 0;
+        relative_x = 0;
+        relative_y = 0;
 
         show_border_radius_panel = true;
         show_fill_panel = true;
@@ -111,10 +116,25 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         is_radius_uniform = true;
         is_radius_autoscale = false;
 
+        if (artboard != null) {
+            artboard.add_child (this, -1);
+
+            double item_x_from_artboard = _x;
+            double item_y_from_artboard = _y;
+
+            canvas.convert_to_item_space (artboard, ref item_x_from_artboard, ref item_y_from_artboard);
+
+            relative_x = item_x_from_artboard;
+            relative_y = item_y_from_artboard;
+        } else {
+            parent.add_child (this, -1);
+        }
+
         set_transform (Cairo.Matrix.identity ());
         // Keep the item always in the origin
         // move the entire coordinate system every time
         translate (_x, _y);
+
 
         color = _fill_color;
         has_border = settings.set_border;

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -73,7 +73,7 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public bool is_radius_autoscale { get; set; }
 
     public new Akira.Lib.Canvas canvas { get; set; }
-    public Models.CanvasArtboard artboard { get; set; }
+    public Models.CanvasArtboard? artboard { get; set; }
 
     public double relative_x { get; set; }
     public double relative_y { get; set; }
@@ -86,13 +86,12 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         int _border_size = 1,
         Gdk.RGBA _border_color,
         Gdk.RGBA _fill_color,
-        Goo.CanvasItem? parent = null,
-        Models.CanvasArtboard? artboard = null
+        Goo.CanvasItem? _parent = null,
+        Models.CanvasArtboard? _artboard = null
     ) {
-        Object (
-            parent: artboard,
-            artboard: artboard
-        );
+        artboard = _artboard;
+        parent = _artboard != null ? _artboard : _parent;
+        canvas = parent.get_canvas () as Akira.Lib.Canvas;
 
         canvas = parent.get_canvas () as Akira.Lib.Canvas;
         parent.add_child (this, -1);

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -120,24 +120,7 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
 
         set_transform (Cairo.Matrix.identity ());
 
-        if (artboard != null) {
-            artboard.add_child (this, -1);
-
-            double item_x_from_artboard = _x;
-            double item_y_from_artboard = _y;
-
-            canvas.convert_to_item_space (artboard, ref item_x_from_artboard, ref item_y_from_artboard);
-
-            relative_x = item_x_from_artboard;
-            relative_y = item_y_from_artboard;
-        } else {
-            parent.add_child (this, -1);
-
-
-            // Keep the item always in the origin
-            // move the entire coordinate system every time
-            translate (_x, _y);
-        }
+        position_item (_x, _y);
 
         color = _fill_color;
         has_border = settings.set_border;

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -118,6 +118,8 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         is_radius_uniform = true;
         is_radius_autoscale = false;
 
+        set_transform (Cairo.Matrix.identity ());
+
         if (artboard != null) {
             artboard.add_child (this, -1);
 
@@ -130,13 +132,12 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
             relative_y = item_y_from_artboard;
         } else {
             parent.add_child (this, -1);
+
+
+            // Keep the item always in the origin
+            // move the entire coordinate system every time
+            translate (_x, _y);
         }
-
-        set_transform (Cairo.Matrix.identity ());
-        // Keep the item always in the origin
-        // move the entire coordinate system every time
-        translate (_x, _y);
-
 
         color = _fill_color;
         has_border = settings.set_border;

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -61,6 +61,9 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard artboard { get; set; }
 
+    public double relative_x { get; set; }
+    public double relative_y { get; set; }
+
     public CanvasText (
         string _text = "",
         double _x = 0,

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -58,6 +58,8 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public string layer_icon { get; set; default = "shape-text-symbolic"; }
     public int z_index { get; set; }
 
+    public new Akira.Lib.Canvas canvas { get; set; }
+
     public CanvasText (
         string _text = "",
         double _x = 0,
@@ -75,6 +77,9 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
             width: _width,
             height: _height
         );
+
+        canvas = parent.get_canvas () as Akira.Lib.Canvas;
+        parent.add_child (this, -1);
 
         item_type = Models.CanvasItemType.TEXT;
         id = Models.CanvasItem.create_item_id (this);

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -59,7 +59,7 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public int z_index { get; set; }
 
     public new Akira.Lib.Canvas canvas { get; set; }
-    public Models.CanvasArtboard artboard { get; set; }
+    public Models.CanvasArtboard? artboard { get; set; }
 
     public double relative_x { get; set; }
     public double relative_y { get; set; }

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -59,6 +59,7 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public int z_index { get; set; }
 
     public new Akira.Lib.Canvas canvas { get; set; }
+    public Models.CanvasArtboard artboard { get; set; }
 
     public CanvasText (
         string _text = "",

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -75,18 +75,19 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
         double _height = 0,
         Goo.CanvasAnchorType _anchor = Goo.CanvasAnchorType.NW,
         string _font = "Open Sans 16",
-        Goo.CanvasItem? parent = null
+        Goo.CanvasItem? _parent = null,
+        Models.CanvasArtboard? _artboard = null
     ) {
         Object (
-            parent: parent,
             x: _x,
             y: _y,
             width: _width,
             height: _height
         );
 
+        artboard = _artboard;
+        parent = _artboard != null ? _artboard : _parent;
         canvas = parent.get_canvas () as Akira.Lib.Canvas;
-        parent.add_child (this, -1);
 
         item_type = Models.CanvasItemType.TEXT;
         id = Models.CanvasItem.create_item_id (this);
@@ -102,8 +103,7 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
         set ("height", _height);
 
         set_transform (Cairo.Matrix.identity ());
-        // Keep the item always in the origin
-        // move the entire coordinate system every time
-        translate (_x, _y);
+
+        position_item (_x, _y);
     }
 }

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -64,6 +64,9 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 
+    public double initial_relative_x { get; set; }
+    public double initial_relative_y { get; set; }
+
     public CanvasText (
         string _text = "",
         double _x = 0,

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -408,7 +408,7 @@ public class Akira.Utils.AffineTransform : Object {
         return GLib.Math.round (size);
     }
 
-    public static double degToRad (double deg) {
+    public static double deg_to_rad (double deg) {
         return deg * Math.PI / 180.0;
     }
 }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -258,6 +258,14 @@ public class Akira.Utils.AffineTransform : Object {
         // initial_event, in order to convert it to the "new" translated
         // item space after the transformation has been applied.
         canvas.convert_from_item_space (selected_item, ref initial_x, ref initial_y);
+        // The CanvasItem.move function expects delta to be the difference
+        // between current position and the initial movement one,
+        // which is not the case for scaling, since the delta
+        // is calculated again at each iteration, so the we should
+        // update the initial_relative coordinate each time we call
+        // move from here
+        selected_item.store_relative_position ();
+
         selected_item.move (origin_move_delta_x, origin_move_delta_y);
         canvas.convert_to_item_space (selected_item, ref initial_x, ref initial_y);
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -194,6 +194,7 @@ public class Akira.Utils.AffineTransform : Object {
             case NobManager.Nob.BOTTOM_RIGHT:
                 new_width = initial_width + delta_x;
                 new_height = initial_height + delta_y;
+
                 if ((canvas.ctrl_is_pressed || selected_item.size_locked) && new_height > MIN_SIZE) {
                     new_height = GLib.Math.round (new_width / selected_item.size_ratio);
                 }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -104,8 +104,8 @@ public class Akira.Utils.AffineTransform : Object {
         delta_y_accumulator += delta_y;
 
         selected_item.move (
-          delta_x, delta_y,
-          delta_x_accumulator, delta_y_accumulator
+            delta_x, delta_y,
+            delta_x_accumulator, delta_y_accumulator
         );
 
         initial_x = x;
@@ -246,24 +246,23 @@ public class Akira.Utils.AffineTransform : Object {
         delta_y_accumulator += origin_move_delta_y;
 
         selected_item.move (
-          origin_move_delta_x,
-          origin_move_delta_y,
-          delta_x_accumulator,
-          delta_y_accumulator
+            origin_move_delta_x,
+            origin_move_delta_y,
+            delta_x_accumulator,
+            delta_y_accumulator
         );
 
         set_size (new_width, new_height, selected_item);
-
         /*
-        if (new_width < MIN_SIZE) {
-            canvas.window.event_bus.flip_item (false);
-            return;
-        }
+           if (new_width < MIN_SIZE) {
+           canvas.window.event_bus.flip_item (false);
+           return;
+           }
 
-        if (new_height < MIN_SIZE) {
-            canvas.window.event_bus.flip_item (false, true);
-            return;
-        }
+           if (new_height < MIN_SIZE) {
+           canvas.window.event_bus.flip_item (false, true);
+           return;
+           }
 
         // Before translating, recover the original "canvas" position of
         // initial_event, in order to convert it to the "new" translated
@@ -279,7 +278,7 @@ public class Akira.Utils.AffineTransform : Object {
         //selected_item.store_relative_position ();
 
         //canvas.convert_to_item_space (selected_item, ref initial_x, ref initial_y);
-        */
+         */
     }
 
     public static void rotate_from_event (

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -258,6 +258,7 @@ public class Akira.Utils.AffineTransform : Object {
         // initial_event, in order to convert it to the "new" translated
         // item space after the transformation has been applied.
         canvas.convert_from_item_space (selected_item, ref initial_x, ref initial_y);
+
         // The CanvasItem.move function expects delta to be the difference
         // between current position and the initial movement one,
         // which is not the case for scaling, since the delta

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -57,7 +57,7 @@ public class Akira.Utils.AffineTransform : Object {
         double delta_x = GLib.Math.round (x - initial_x);
         double delta_y = GLib.Math.round (y - initial_y);
 
-        selected_item.translate (delta_x, delta_y);
+        selected_item.move (delta_x, delta_y);
     }
 
     public static void scale_from_event (

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -257,7 +257,7 @@ public class Akira.Utils.AffineTransform : Object {
         // initial_event, in order to convert it to the "new" translated
         // item space after the transformation has been applied.
         canvas.convert_from_item_space (selected_item, ref initial_x, ref initial_y);
-        selected_item.translate (origin_move_delta_x, origin_move_delta_y);
+        selected_item.move (origin_move_delta_x, origin_move_delta_y);
         canvas.convert_to_item_space (selected_item, ref initial_x, ref initial_y);
 
         set_size (new_width, new_height, selected_item);


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
This is the initial work to bring _basic_ container functionality to the Artboard item. 
Items created inside an artboard and items moved inside one should become children of the artboard. 
At the same time, the Layers Panel should reflect the children of an artboard and enable the user to actionate them (`hide` and `lock`). 

As always, I'd like to get some feedback on how "far" should I get with this PR. 
I'd like to progress up until the "Item should snap to Artboard's edges" task. 

I have some questions, too:

- How can the user remove an item from an Artboard? 
- If the user enlarges an existing Artboard to contain some new items, should those new items be considered as Artboard's children? In other words, can Artboards _fagocitate_  other items while growing?
- More to come...

## Steps to Test
- Create and artboard
- Create a shape **inside** the artboard
- Move the artboard from the handle. The items should move together with the artboard

## Screenshots 
![artboard_content_translation](https://user-images.githubusercontent.com/11556031/76171955-23fa9b80-6191-11ea-8cd7-1e0956324702.gif)

## Implemented Features
- [x] Creating an item inside an Artboard should make the item a child of the Artboard
- [x] Moving an artboard should move its children in a rigid way
- [x] Child coordinates are relative to Artboard origin
- [x] Deleting an item inside an Artboard should remove it from that Artboard's children
- [x] Item have hover effect when hovering over the Artboard
- [x] Item can be selected & moved by clicking on them

Known Issues / Things To Do
- [ ] Items inside Artboard could be rotated with the nob
- [ ] Artboard should not be allowed to be rotated
- [ ] Artboard's label should be 15px regardless of the scale of the Canvas
- [ ] Artboard cannot be originated when inside another Artboard
- [ ] Dragging and dropping an item outside of an Artboard should remove it from the Artboard's children
- [ ] Moving an item inside an artboard should make the item a child of the Artboard
- [ ] The layers panel should show the children of an artboard
- [ ] Hide & Lock should work also on Artboard layer

## This PR fixes/implements the following **bugs/features**:
- Implements (partially) #122 
