### PR TITLE
Another round of bug fixes

### DIFF
--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -272,15 +272,16 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
 
     public async void generate_export_preview () {
         if (list_store.get_n_items () > 0) {
+            var array = manager.pixbufs.values.to_array ();
             for (int i = 0; i < list_store.get_n_items () ; i++) {
                 var model = (Akira.Models.ExportModel) list_store.get_object (i);
-                model.pixbuf = manager.pixbufs.index (i);
+                model.pixbuf = array[i];
             }
             return;
         }
 
-        for (int i = 0; i < manager.pixbufs.length ; i++) {
-            var model = new Akira.Models.ExportModel (manager.pixbufs.index (i), "Untitled");
+        foreach (var entry in manager.pixbufs.entries) {
+            var model = new Akira.Models.ExportModel (entry.value, entry.key);
             list_store.append (model);
         }
     }

--- a/src/Dialogs/ShortcutsDialog.vala
+++ b/src/Dialogs/ShortcutsDialog.vala
@@ -25,7 +25,7 @@ public class Akira.Dialogs.ShortcutsDialog : Gtk.Dialog {
     public ShortcutsDialog (Akira.Window window) {
         Object (
             window: window,
-            border_width: 0,
+            border_width: 10,
             deletable: true,
             resizable: true,
             modal: true

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -198,11 +198,13 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
         handle.enter_notify_event.connect (event => {
             get_style_context ().add_class ("hover");
+            window.event_bus.hover_over_layer (model.item);
             return false;
         });
 
         handle.leave_notify_event.connect (event => {
             get_style_context ().remove_class ("hover");
+            window.event_bus.hover_over_layer (null);
             return false;
         });
 
@@ -486,6 +488,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
             handle.grab_focus ();
             window.event_bus.request_add_item_to_selection (model.item);
+            window.event_bus.hover_over_layer (null);
         }
 
         if (event.type == Gdk.EventType.BUTTON_RELEASE) {

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -303,8 +303,8 @@ public class Akira.Lib.Managers.ExportManager : Object {
             // Create the rendered image with Cairo.
             surface = new Cairo.ImageSurface (
                 format,
-                (int) Math.round (item.get_coords ("width")),
-                (int) Math.round (item.get_coords ("height"))
+                (int) Math.round (item.bounds.x2 - item.bounds.x1),
+                (int) Math.round (item.bounds.y2 - item.bounds.y1)
             );
             context = new Cairo.Context (surface);
 
@@ -313,8 +313,8 @@ public class Akira.Lib.Managers.ExportManager : Object {
                 context.set_source_rgba (1, 1, 1, 1);
                 context.rectangle (
                     0, 0,
-                    (int) Math.round (item.get_coords ("width")),
-                    (int) Math.round (item.get_coords ("height")));
+                    (int) Math.round (item.bounds.x2 - item.bounds.x1),
+                    (int) Math.round (item.bounds.y2 - item.bounds.y1));
                 context.fill ();
             }
 
@@ -354,8 +354,8 @@ public class Akira.Lib.Managers.ExportManager : Object {
     public Gdk.Pixbuf rescale_image (Gdk.Pixbuf pixbuf, Lib.Models.CanvasItem? item = null) {
         Gdk.Pixbuf scaled_image;
 
-        var width = item != null ? item.get_coords ("width") : area.width;
-        var height = item != null ? item.get_coords ("height") : area.height;
+        var width = item != null ? item.bounds.x2 - item.bounds.x1 : area.width;
+        var height = item != null ? item.bounds.y2 - item.bounds.y1 : area.height;
 
         switch (settings.export_scale) {
             case 0:

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -43,13 +43,13 @@ public class Akira.Lib.Managers.ExportManager : Object {
     public Cairo.Surface surface;
     public Cairo.Context context;
     public Gdk.PixbufLoader loader;
-    public Array<Gdk.Pixbuf> pixbufs { get; set construct; }
+    public Gee.HashMap<string, Gdk.Pixbuf> pixbufs { get; set construct; }
 
     public ExportManager (Akira.Lib.Canvas canvas) {
         Object (
             canvas: canvas
         );
-        pixbufs = new Array<Gdk.Pixbuf> ();
+        pixbufs = new Gee.HashMap<string, Gdk.Pixbuf> ();
     }
 
     public Goo.CanvasRect create_area (Gdk.EventButton event) {
@@ -227,9 +227,8 @@ public class Akira.Lib.Managers.ExportManager : Object {
     }
 
     public void generate_area_pixbuf () throws Error {
-        // Clear pixbuf array directly as we're dealing with an area export
-        // therefore only one value is present.
-        pixbufs._remove_index (0);
+        // Clear pixbuf array from previously stored values.
+        pixbufs.clear ();
 
         if (settings.export_format == "png") {
             format = Cairo.Format.ARGB32;
@@ -281,14 +280,12 @@ public class Akira.Lib.Managers.ExportManager : Object {
             throw (e);
         }
 
-        pixbufs.append_val (scaled);
+        pixbufs.set (_("Untitled"), scaled);
     }
 
     public void generate_selection_pixbuf () throws Error {
         // Clear pixbuf array from previously stored values.
-        for (int i = 0; i < pixbufs.length; i++) {
-            pixbufs._remove_index (i);
-        }
+        pixbufs.clear ();
 
         if (settings.export_format == "png") {
             format = Cairo.Format.ARGB32;
@@ -300,6 +297,7 @@ public class Akira.Lib.Managers.ExportManager : Object {
         for (var i = 0; i < canvas.selected_bound_manager.selected_items.length (); i++) {
             var label_height = 0.0;
             var item = canvas.selected_bound_manager.selected_items.nth_data (i);
+            var name = _("Untitled %i").printf (i);
 
             // Weird goocanvas issue which sets the border to 0.**** instead of 0
             // which causes a half pixel white border on export.
@@ -313,6 +311,7 @@ public class Akira.Lib.Managers.ExportManager : Object {
             if (item is Akira.Lib.Models.CanvasArtboard) {
                 var artboard = item as Akira.Lib.Models.CanvasArtboard;
                 label_height = artboard.get_label_height ();
+                name = artboard.name != null ? artboard.name : name;
             }
 
             // Create the rendered image with Cairo.
@@ -362,7 +361,7 @@ public class Akira.Lib.Managers.ExportManager : Object {
                 throw (e);
             }
 
-            pixbufs.append_val (scaled);
+            pixbufs.set (name, scaled);
         }
     }
 

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -300,6 +300,14 @@ public class Akira.Lib.Managers.ExportManager : Object {
         for (var i = 0; i < canvas.selected_bound_manager.selected_items.length (); i++) {
             var item = canvas.selected_bound_manager.selected_items.nth_data (i);
 
+            // Weird goocanvas issue which sets the border to 0.**** instead of 0
+            // which causes a half pixel white border on export.
+            if (item.line_width < 1) {
+                var fill_color = item.fill_color_rgba;
+                item.set ("stroke-color-rgba", fill_color);
+                item.set ("line-width", 0.0);
+            }
+
             // Create the rendered image with Cairo.
             surface = new Cairo.ImageSurface (
                 format,

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -298,6 +298,7 @@ public class Akira.Lib.Managers.ExportManager : Object {
 
         // Loop through all the currently selected elements.
         for (var i = 0; i < canvas.selected_bound_manager.selected_items.length (); i++) {
+            var label_height = 0.0;
             var item = canvas.selected_bound_manager.selected_items.nth_data (i);
 
             // Weird goocanvas issue which sets the border to 0.**** instead of 0
@@ -308,11 +309,17 @@ public class Akira.Lib.Managers.ExportManager : Object {
                 item.set ("line-width", 0.0);
             }
 
+            // If the item is an artboard, account for the label's height.
+            if (item is Akira.Lib.Models.CanvasArtboard) {
+                var artboard = item as Akira.Lib.Models.CanvasArtboard;
+                label_height = artboard.get_label_height ();
+            }
+
             // Create the rendered image with Cairo.
             surface = new Cairo.ImageSurface (
                 format,
                 (int) Math.round (item.bounds.x2 - item.bounds.x1),
-                (int) Math.round (item.bounds.y2 - item.bounds.y1)
+                (int) Math.round (item.bounds.y2 - item.bounds.y1 - label_height)
             );
             context = new Cairo.Context (surface);
 
@@ -322,12 +329,12 @@ public class Akira.Lib.Managers.ExportManager : Object {
                 context.rectangle (
                     0, 0,
                     (int) Math.round (item.bounds.x2 - item.bounds.x1),
-                    (int) Math.round (item.bounds.y2 - item.bounds.y1));
+                    (int) Math.round (item.bounds.y2 - item.bounds.y1 - label_height));
                 context.fill ();
             }
 
             // Move to the currently selected item.
-            context.translate (-item.bounds.x1, -item.bounds.y1);
+            context.translate (-item.bounds.x1, -item.bounds.y1 - label_height);
 
             // Render the selected item.
             canvas.render (context, null, canvas.current_scale);
@@ -361,9 +368,16 @@ public class Akira.Lib.Managers.ExportManager : Object {
 
     public Gdk.Pixbuf rescale_image (Gdk.Pixbuf pixbuf, Lib.Models.CanvasItem? item = null) {
         Gdk.Pixbuf scaled_image;
+        var label_height = 0.0;
+
+        // If the item is an artboard, account for the label's height.
+        if (item != null && item is Akira.Lib.Models.CanvasArtboard) {
+            var artboard = item as Akira.Lib.Models.CanvasArtboard;
+            label_height = artboard.get_label_height ();
+        }
 
         var width = item != null ? item.bounds.x2 - item.bounds.x1 : area.width;
-        var height = item != null ? item.bounds.y2 - item.bounds.y1 : area.height;
+        var height = item != null ? item.bounds.y2 - item.bounds.y1 - label_height : area.height;
 
         switch (settings.export_scale) {
             case 0:

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -78,18 +78,12 @@ public class Akira.Lib.Managers.HoverManager : Object {
             return;
         }
 
-        double line_width = 0.0;
-        item.get ("line-width", out line_width);
-
         // Each item is always at 0,0 relative to its coordinate system
-        double x = 0 - line_width / 2;
-        double y = 0 - line_width / 2;
+        double x = 0;
+        double y = 0;
 
         double width = item.get_coords ("width");
         double height = item.get_coords ("height");
-
-        width += line_width;
-        height += line_width;
 
         if (!item.selected) {
             hover_effect = new Goo.CanvasRect (

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -37,6 +37,10 @@ public class Akira.Lib.Managers.HoverManager : Object {
         );
     }
 
+    construct {
+        canvas.window.event_bus.hover_over_layer.connect (on_layer_hovered);
+    }
+
     public void set_initial_coordinates (double event_x, double event_y) {
         initial_event_x = event_x;
         initial_event_y = event_y;
@@ -74,38 +78,48 @@ public class Akira.Lib.Managers.HoverManager : Object {
         remove_hover_effect ();
         current_hover_item = item;
 
-        if (item.locked) {
-            return;
-        }
-
-        // Each item is always at 0,0 relative to its coordinate system
-        double x = 0;
-        double y = 0;
-
-        double width = item.get_coords ("width");
-        double height = item.get_coords ("height");
+        create_hover_effect (item);
 
         if (!item.selected) {
-            hover_effect = new Goo.CanvasRect (
-                null,
-                x, y,
-                width, height,
-                "line-width", LINE_WIDTH / canvas.current_scale,
-                "stroke-color", STROKE_COLOR,
-                null
-            );
-
-            var transform = Cairo.Matrix.identity ();
-            item.get_transform (out transform);
-            hover_effect.set_transform (transform);
-
-            hover_effect.set ("parent", canvas.get_root_item ());
-            hover_effect.can_focus = false;
-
             canvas.window.event_bus.hover_over_item (item);
         }
 
         set_cursor_for_nob (Managers.NobManager.Nob.NONE);
+    }
+
+    private void on_layer_hovered (Models.CanvasItem? item) {
+        if (item == null) {
+            remove_hover_effect ();
+            return;
+        }
+
+        remove_hover_effect ();
+        create_hover_effect (item);
+    }
+
+    private void create_hover_effect (Models.CanvasItem? item) {
+        if (item.locked || item.selected) {
+            return;
+        }
+
+        double width = item.get_coords ("width");
+        double height = item.get_coords ("height");
+
+        hover_effect = new Goo.CanvasRect (
+            null,
+            0, 0,
+            width, height,
+            "line-width", LINE_WIDTH / canvas.current_scale,
+            "stroke-color", STROKE_COLOR,
+            null
+        );
+
+        var transform = Cairo.Matrix.identity ();
+        item.get_transform (out transform);
+        hover_effect.set_transform (transform);
+
+        hover_effect.set ("parent", canvas.get_root_item ());
+        hover_effect.can_focus = false;
     }
 
     public void remove_hover_effect () {

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -171,12 +171,6 @@ public class Akira.Lib.Managers.NobManager : Object {
             ref width, ref height
         );
 
-        // Account for line_width
-        x -= line_width / 2;
-        y -= line_width / 2;
-        width += line_width;
-        height += line_width;
-
         if (create) {
             //  debug ("create effect");
             select_effect = new Goo.CanvasRect (
@@ -232,9 +226,9 @@ public class Akira.Lib.Managers.NobManager : Object {
         // TOP LEFT nob
         nobs[Nob.TOP_LEFT].set_transform (transform);
         if (print_middle_width_nobs && print_middle_height_nobs) {
-            nobs[Nob.TOP_LEFT].translate (x - (nob_offset + (line_width / 2)), y - (nob_offset + (line_width / 2)));
+            nobs[Nob.TOP_LEFT].translate (x - (nob_offset), y - (nob_offset));
         } else {
-            nobs[Nob.TOP_LEFT].translate (x - nob_size - (line_width / 2), y - nob_size - (line_width / 2));
+            nobs[Nob.TOP_LEFT].translate (x - nob_size, y - nob_size);
         }
         nobs[Nob.TOP_LEFT].raise (select_effect);
 
@@ -242,9 +236,9 @@ public class Akira.Lib.Managers.NobManager : Object {
             // TOP CENTER nob
             nobs[Nob.TOP_CENTER].set_transform (transform);
             if (print_middle_height_nobs) {
-                nobs[Nob.TOP_CENTER].translate (x + (width / 2) - nob_offset, y - (nob_offset + (line_width / 2)));
+                nobs[Nob.TOP_CENTER].translate (x + (width / 2) - nob_offset, y - (nob_offset));
             } else {
-                nobs[Nob.TOP_CENTER].translate (x + (width / 2) - nob_offset, y - (nob_size + (line_width / 2)));
+                nobs[Nob.TOP_CENTER].translate (x + (width / 2) - nob_offset, y - (nob_size));
             }
             set_nob_visibility (Nob.TOP_CENTER, true);
         } else {
@@ -256,9 +250,9 @@ public class Akira.Lib.Managers.NobManager : Object {
         // TOP RIGHT nob
         nobs[Nob.TOP_RIGHT].set_transform (transform);
         if (print_middle_width_nobs && print_middle_height_nobs) {
-            nobs[Nob.TOP_RIGHT].translate (x + width - (nob_offset - (line_width / 2)), y - (nob_offset + (line_width / 2)));
+            nobs[Nob.TOP_RIGHT].translate (x + width - (nob_offset), y - (nob_offset));
         } else {
-            nobs[Nob.TOP_RIGHT].translate (x + width + (line_width / 2), y - (nob_size + (line_width / 2)));
+            nobs[Nob.TOP_RIGHT].translate (x + width, y - (nob_size));
         }
         nobs[Nob.TOP_RIGHT].raise (select_effect);
 
@@ -266,9 +260,9 @@ public class Akira.Lib.Managers.NobManager : Object {
             // RIGHT CENTER nob
             nobs[Nob.RIGHT_CENTER].set_transform (transform);
             if (print_middle_width_nobs) {
-                nobs[Nob.RIGHT_CENTER].translate (x + width - (nob_offset - (line_width / 2)), y + (height / 2) - nob_offset);
+                nobs[Nob.RIGHT_CENTER].translate (x + width - (nob_offset), y + (height / 2) - nob_offset);
             } else {
-                nobs[Nob.RIGHT_CENTER].translate (x + width + (line_width / 2), y + (height / 2) - nob_offset);
+                nobs[Nob.RIGHT_CENTER].translate (x + width, y + (height / 2) - nob_offset);
             }
             set_nob_visibility (Nob.RIGHT_CENTER, true);
         } else {
@@ -281,10 +275,10 @@ public class Akira.Lib.Managers.NobManager : Object {
         nobs[Nob.BOTTOM_RIGHT].set_transform (transform);
         if (print_middle_width_nobs && print_middle_height_nobs) {
             nobs[Nob.BOTTOM_RIGHT].translate (
-                x + width - (nob_offset - (line_width / 2)), y + height - (nob_offset - (line_width / 2))
+                x + width - (nob_offset), y + height - (nob_offset)
             );
         } else {
-            nobs[Nob.BOTTOM_RIGHT].translate (x + width + (line_width / 2), y + height + (line_width / 2));
+            nobs[Nob.BOTTOM_RIGHT].translate (x + width, y + height);
         }
         nobs[Nob.BOTTOM_RIGHT].raise (select_effect);
 
@@ -293,10 +287,10 @@ public class Akira.Lib.Managers.NobManager : Object {
             nobs[Nob.BOTTOM_CENTER].set_transform (transform);
             if (print_middle_height_nobs) {
                 nobs[Nob.BOTTOM_CENTER].translate (
-                    x + (width / 2) - nob_offset, y + height - (nob_offset - (line_width / 2))
+                    x + (width / 2) - nob_offset, y + height - (nob_offset)
                 );
             } else {
-                nobs[Nob.BOTTOM_CENTER].translate (x + (width / 2) - nob_offset, y + height + (line_width / 2));
+                nobs[Nob.BOTTOM_CENTER].translate (x + (width / 2) - nob_offset, y + height);
             }
             set_nob_visibility (Nob.BOTTOM_CENTER, true);
         } else {
@@ -307,9 +301,9 @@ public class Akira.Lib.Managers.NobManager : Object {
         // BOTTOM LEFT nob
         nobs[Nob.BOTTOM_LEFT].set_transform (transform);
         if (print_middle_width_nobs && print_middle_height_nobs) {
-            nobs[Nob.BOTTOM_LEFT].translate (x - (nob_offset + (line_width / 2)), y + height - (nob_offset - (line_width / 2)));
+            nobs[Nob.BOTTOM_LEFT].translate (x - (nob_offset), y + height - (nob_offset));
         } else {
-            nobs[Nob.BOTTOM_LEFT].translate (x - (nob_size + (line_width / 2)), y + height + (line_width / 2));
+            nobs[Nob.BOTTOM_LEFT].translate (x - (nob_size), y + height);
         }
         nobs[Nob.BOTTOM_LEFT].raise (select_effect);
 
@@ -317,9 +311,9 @@ public class Akira.Lib.Managers.NobManager : Object {
             // LEFT CENTER nob
             nobs[Nob.LEFT_CENTER].set_transform (transform);
             if (print_middle_width_nobs) {
-                nobs[Nob.LEFT_CENTER].translate (x - (nob_offset + (line_width / 2)), y + (height / 2) - nob_offset);
+                nobs[Nob.LEFT_CENTER].translate (x - (nob_offset), y + (height / 2) - nob_offset);
             } else {
-                nobs[Nob.LEFT_CENTER].translate (x - (nob_size + (line_width / 2)), y + (height / 2) - nob_offset);
+                nobs[Nob.LEFT_CENTER].translate (x - (nob_size), y + (height / 2) - nob_offset);
             }
             set_nob_visibility (Nob.LEFT_CENTER, true);
         } else {

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -157,7 +157,6 @@ public class Akira.Lib.Managers.NobManager : Object {
     private void update_select_effect (List<Models.CanvasItem> selected_items) {
         double x = 0.0;
         double y = 0.0;
-        double line_width = 0.0;
         double width = 0.0;
         double height = 0.0;
 
@@ -167,7 +166,6 @@ public class Akira.Lib.Managers.NobManager : Object {
             selected_items,
             ref x, ref y,
             ref transform,
-            ref line_width,
             ref width, ref height
         );
 
@@ -194,7 +192,6 @@ public class Akira.Lib.Managers.NobManager : Object {
     private void update_nob_position (List<Models.CanvasItem> selected_items) {
         var transform = Cairo.Matrix.identity ();
 
-        double line_width = 0.0;
         double x = 0.0;
         double y = 0.0;
         double width = 0.0;
@@ -204,7 +201,6 @@ public class Akira.Lib.Managers.NobManager : Object {
             selected_items,
             ref x, ref y,
             ref transform,
-            ref line_width,
             ref width, ref height
         );
 
@@ -348,7 +344,6 @@ public class Akira.Lib.Managers.NobManager : Object {
         ref double x,
         ref double y,
         ref Cairo.Matrix transform,
-        ref double line_width,
         ref double _width,
         ref double _height
     ) {
@@ -356,7 +351,6 @@ public class Akira.Lib.Managers.NobManager : Object {
             var item = selected_items.nth_data (0);
 
             item.get_transform (out transform);
-            item.get ("line_width", out line_width);
             item.get ("width", out _width);
             item.get ("height", out _height);
             item.get ("x", out x);
@@ -365,7 +359,6 @@ public class Akira.Lib.Managers.NobManager : Object {
             return;
         }
 
-        line_width = 0.0;
         _width = width;
         _height = height;
         x = left;

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -175,4 +175,8 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
 
         return is_on_handle;
     }
+
+    public double get_label_height () {
+        return label_height + LABEL_BOTTOM_PADDING;
+    }
 }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -133,9 +133,11 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     private void reset_border () {
+        // Set a default border color in case no border is used
+        // to avoid half pixel transparency during export.
         if (hidden_border || !has_border) {
-            set ("stroke-color-rgba", null);
-            set ("line-width", null);
+            set ("stroke-color-rgba", fill_color_rgba);
+            set ("line-width", 0.0);
             return;
         }
 

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -29,6 +29,16 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     // Transform Panel attributes.
     public double opacity { get; set; }
     public double rotation { get; set; }
+    private double _global_radius { get; set; }
+    public double global_radius {
+        get {
+            return _global_radius;
+        }
+        set {
+            _global_radius = Math.round (value);
+            update_border ();
+        }
+    }
 
     // Fill Panel attributes.
     public bool has_fill { get; set; default = true; }
@@ -80,7 +90,7 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         id = Models.CanvasItem.create_item_id (this);
         Models.CanvasItem.init_item (this);
 
-        radius_x = _radius_x;
+        _global_radius = radius_x = _radius_x;
         radius_y = _radius_y;
         width = 1;
         height = 1;
@@ -111,8 +121,8 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
 
     public void update_border () {
         if (is_radius_uniform) {
-            set ("radius-x", radius_x);
-            set ("radius-y", radius_x);
+            set ("radius-x", global_radius);
+            set ("radius-y", global_radius);
         }
 
         // TODO: handle uneven border radius.

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -58,6 +58,7 @@ public class Akira.Services.EventBus : Object {
 
     // Layers panel signals.
     public signal void hover_over_item (Lib.Models.CanvasItem? item);
+    public signal void hover_over_layer (Lib.Models.CanvasItem? item);
     public signal void item_deleted (Lib.Models.CanvasItem item);
     public signal void item_locked (Lib.Models.CanvasItem item);
     public signal void change_item_z_index (Lib.Models.CanvasItem item, int position);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
A couple of our supporters on discord have pointed out some quirky bugs which I'm tackling in this patch.

## This PR fixes/implements the following **bugs/features**:
- [x] The border radius doesn't evenly update when typing a value.
- [x] The Selection Bounds should ignore the border thickness and stay true to the item's coordinates.
- [x] Export Selection bounds don't account for border thickness.
- [x] Export Artboards bounds should ignore the name element when generating the preview.
- [x] Export Artboards should pre-populate the file name with Artboard's name.
- [x] Show hover effect on item when hovering over a layer.