### PR TITLE
Add gettext dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can install Akira by compiling it from the source
  - `libjson-glib-1.0`
  - `goocanvas-2.0`
  - `libarchive`
+ - `gettext`
  - `cairo`
  - `meson`
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
<!--- Please write a description here -->
To build Akira you also need the `gettext` dependency
