### PR TITLE
Child items in Artboard layer

### DIFF
--- a/data/css/artboard.css
+++ b/data/css/artboard.css
@@ -14,7 +14,7 @@
   border-bottom: 1px solid shade (@bg_color, 0.8);
 }
 
-.artboard.hover .layer-action {
+.artboard.hover > grid > grid > .layer-action {
   opacity: 0.5;
 }
 

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -194,6 +194,14 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
             get_style_context ().remove_class ("hover");
             return false;
         });
+
+        container.bind_model (model.items, item => {
+            // TODO: Differentiate between layer and artboard
+            // based upon item "type" of some sort
+            var layer_model = (Akira.Models.LayerModel) item;
+
+            return new Akira.Layouts.Partials.Layer (window, layer_model);
+        });
     }
 
     private void on_drag_data_received (Gdk.DragContext context, int x, int y, Gtk.SelectionData selection_data,

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -93,7 +93,7 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
 
         container = new Gtk.ListBox ();
         container.get_style_context ().add_class ("artboard-container");
-        container.activate_on_single_click = true;
+        container.activate_on_single_click = false;
         container.selection_mode = Gtk.SelectionMode.SINGLE;
         Gtk.drag_dest_set (container, Gtk.DestDefaults.ALL, TARGET_ENTRIES_LAYER, Gdk.DragAction.MOVE);
         container.drag_data_received.connect (on_drag_data_received);
@@ -174,9 +174,7 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
             }
         });
 
-        key_press_event.connect (on_key_pressed);
-
-        model.notify["selected"].connect (() => {
+        model.item.notify["selected"].connect (() => {
             if (model.selected) {
               activate ();
               return;
@@ -406,20 +404,9 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         }
 
         if (event.type == Gdk.EventType.BUTTON_PRESS) {
-          activate ();
+            window.event_bus.request_add_item_to_selection (model.item);
 
-          handle.grab_focus ();
-          window.event_bus.request_add_item_to_selection (model.item);
-        }
-
-        return false;
-    }
-
-    private bool on_key_pressed (Gtk.Widget source, Gdk.EventKey key) {
-        switch (key.keyval) {
-            case Gdk.Key.Delete:
-                window.event_bus.request_delete_item (model.item);
-                break;
+            return true;
         }
 
         return false;
@@ -497,8 +484,6 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
 
         editing = false;
 
-        activate ();
-
         var new_label = entry.get_text ();
 
         if (label.label == new_label) {
@@ -506,6 +491,8 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         }
 
         label.label = model.name = new_label;
+
+        window.event_bus.set_focus_on_canvas ();
     }
 
     public void count_layers () {

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -479,8 +479,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         }
 
         if (event.type == Gdk.EventType.BUTTON_PRESS) {
-            activate ();
-
             // Selected layers cannot be hovering
             // We need to reflect the status of the canvas item
             get_style_context ().remove_class ("hovered");

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -194,7 +194,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         build_drag_and_drop ();
 
         handle.event.connect (on_click_event);
-        handle.key_release_event.connect (on_key_release_event);
 
         handle.enter_notify_event.connect (event => {
             get_style_context ().add_class ("hover");
@@ -208,7 +207,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
             return false;
         });
 
-        model.notify["selected"].connect (() => {
+        model.item.notify["selected"].connect (() => {
             if (model.selected) {
                 get_style_context ().remove_class ("hovered");
                 activate ();
@@ -348,10 +347,10 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     }
 
     private void on_drag_data_get (
-      Gtk.Widget widget,
-      Gdk.DragContext context,
-      Gtk.SelectionData selection_data,
-      uint target_type, uint time) {
+        Gtk.Widget widget,
+        Gdk.DragContext context,
+        Gtk.SelectionData selection_data,
+        uint target_type, uint time) {
 
         uchar[] data = new uchar[(sizeof (Akira.Layouts.Partials.Layer))];
 
@@ -359,7 +358,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
         selection_data.set (
             Gdk.Atom.intern_static_string ("LAYER"), 32, data
-        );
+            );
     }
 
     public bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {
@@ -486,11 +485,13 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
             // We need to reflect the status of the canvas item
             get_style_context ().remove_class ("hovered");
 
-            handle.grab_focus ();
             window.event_bus.request_add_item_to_selection (model.item);
             window.event_bus.hover_over_layer (null);
+
+            return true;
         }
 
+        /*
         if (event.type == Gdk.EventType.BUTTON_RELEASE) {
             if (entry.visible == true) {
                 return false;
@@ -549,16 +550,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
             return true;
         }
-
-        return false;
-    }
-
-    public bool on_key_release_event (Gdk.EventKey event) {
-        switch (event.keyval) {
-            case Gdk.Key.Delete:
-                window.event_bus.request_delete_item (model.item);
-                break;
-        }
+        */
 
         return false;
     }
@@ -607,8 +599,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
         editing = false;
 
-        activate ();
-
         var new_label = entry.get_text ();
 
         if (label.label == new_label) {
@@ -616,6 +606,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         }
 
         label.label = model.name = new_label;
+
+        window.event_bus.set_focus_on_canvas ();
     }
 
     private void lock_actions () {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -77,25 +77,35 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
         window.event_bus.z_selected_changed.connect (on_z_selected_changed);
     }
 
-    private void on_item_inserted (Lib.Models.CanvasItem new_item) {
-        var model = new Akira.Models.LayerModel (new_item, list_model);
-        list_model.add_item.begin (model, false);
+    private void on_item_inserted (Lib.Models.CanvasItem item) {
+        if (item.artboard != null) {
+            item_model_map.@get (item.artboard.id).add_child_item (item);
+        } else {
+            var model = new Akira.Models.LayerModel (item, list_model);
 
-        // This map is necessary for easily knowing which
-        // item is related to which model, since the canvas knows only
-        // real items and the layers panel only knows items model
-        item_model_map.@set (new_item.id, model);
+            list_model.add_item.begin (model, false);
+
+            // This map is necessary for easily knowing which
+            // item is related to which model, since the canvas knows only
+            // real items and the layers panel only knows items model
+            item_model_map.@set (item.id, model);
+        }
 
         reload_zebra ();
         show_all ();
     }
 
     private void on_item_deleted (Lib.Models.CanvasItem item) {
-        var model = item_model_map.@get (item.id);
+        if (item.artboard != null) {
+            item_model_map.@get (item.artboard.id).remove_child_item (item);
+        } else {
+            var model = item_model_map.@get (item.id);
 
-        list_model.remove_item.begin (model);
+            list_model.remove_item.begin (model);
+        }
 
         reload_zebra ();
+        show_all ();
     }
 
     private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -73,7 +73,6 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
 
         window.event_bus.item_inserted.connect (on_item_inserted);
         window.event_bus.item_deleted.connect (on_item_deleted);
-        window.event_bus.selected_items_changed.connect (on_selected_items_changed);
         window.event_bus.z_selected_changed.connect (on_z_selected_changed);
     }
 
@@ -106,53 +105,6 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
 
         reload_zebra ();
         show_all ();
-    }
-
-    private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {
-        // After activating a row it is necessary to
-        // put (keyboard) focus back to the canvas
-        window.event_bus.set_focus_on_canvas ();
-
-        /*
-        if (selected_items.length () == 0) {
-            var current_selected_item = item_model_map.@get (current_selected_item_id);
-
-            if (current_selected_item != null) {
-                current_selected_item.selected = false;
-            }
-
-            current_selected_item_id = null;
-            return;
-        }
-
-        var selected_item = selected_items.nth_data (0);
-
-        // Never select the same layer twice
-        if (selected_item.id == current_selected_item_id) {
-            return;
-        }
-
-        var current_selected_model = item_model_map.@get (current_selected_item_id);
-
-        // Remove select effect is not item is selected
-        if (current_selected_model != null) {
-            current_selected_model.selected = false;
-        }
-
-        // if item is inside an artboard, propagate the selection
-        // to that artboard
-        if (selected_item.artboard != null) {
-            item_model_map.@get (item.artboard.id).select_child_item (item);
-        } else {
-            var new_selected_model = item_model_map.@get (selected_item.id);
-
-            if (new_selected_model != null) {
-                new_selected_model.selected = true;
-            }
-            current_selected_item_id = selected_item.id;
-        }
-
-        */
     }
 
     private void on_z_selected_changed () {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -109,6 +109,11 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
     }
 
     private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {
+        // After activating a row it is necessary to
+        // put (keyboard) focus back to the canvas
+        window.event_bus.set_focus_on_canvas ();
+
+        /*
         if (selected_items.length () == 0) {
             var current_selected_item = item_model_map.@get (current_selected_item_id);
 
@@ -122,27 +127,32 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.ListBox {
 
         var selected_item = selected_items.nth_data (0);
 
+        // Never select the same layer twice
         if (selected_item.id == current_selected_item_id) {
             return;
         }
 
-        var new_selected_model = item_model_map.@get (selected_item.id);
-
-        if (new_selected_model != null) {
-            new_selected_model.selected = true;
-        }
-
         var current_selected_model = item_model_map.@get (current_selected_item_id);
 
+        // Remove select effect is not item is selected
         if (current_selected_model != null) {
             current_selected_model.selected = false;
         }
 
-        current_selected_item_id = selected_item.id;
+        // if item is inside an artboard, propagate the selection
+        // to that artboard
+        if (selected_item.artboard != null) {
+            item_model_map.@get (item.artboard.id).select_child_item (item);
+        } else {
+            var new_selected_model = item_model_map.@get (selected_item.id);
 
-        // After activating a row it is necessary to
-        // put (keyboard) focus back to the canvas
-        window.event_bus.set_focus_on_canvas ();
+            if (new_selected_model != null) {
+                new_selected_model.selected = true;
+            }
+            current_selected_item_id = selected_item.id;
+        }
+
+        */
     }
 
     private void on_z_selected_changed () {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -145,6 +145,10 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         item.selected = true;
         selected_items.append (item);
+
+        // After activating a row it is necessary to
+        // put (keyboard) focus back to the canvas
+        canvas.window.event_bus.set_focus_on_canvas ();
     }
 
     public void delete_selection () {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -134,6 +134,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         if (selected_items.index (item) != -1) {
             return;
         }
+
         // Just 1 selected element at the same time
         // TODO: allow for multi selection with shift pressed
         reset_selection ();

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -82,7 +82,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
 
     // Artboard related properties
     private Cairo.TextExtents label_extents;
-    private List<Models.CanvasItem> items;
+    public List<Models.CanvasItem> items;
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard? artboard { get; set; }
     public double relative_x { get; set; }

--- a/src/Models/LayerModel.vala
+++ b/src/Models/LayerModel.vala
@@ -65,6 +65,7 @@ public class Akira.Models.LayerModel : Models.ItemModel {
         }
         set {
             item.selected = value;
+            debug (@"Setting selected: $(value) to $(item.id)");
         }
     }
 

--- a/src/Models/LayerModel.vala
+++ b/src/Models/LayerModel.vala
@@ -74,6 +74,8 @@ public class Akira.Models.LayerModel : Models.ItemModel {
         }
     }
 
+    public Akira.Models.ListModel items { get; set; }
+
     public LayerModel (
         Lib.Models.CanvasItem item,
         Akira.Models.ListModel list_model
@@ -82,9 +84,35 @@ public class Akira.Models.LayerModel : Models.ItemModel {
             item: item,
             list_model: list_model
         );
+
+        if (is_artboard) {
+            items = new Akira.Models.ListModel ();
+        }
+    }
+
+    public void add_child_item (Akira.Lib.Models.CanvasItem item) {
+        if (!is_artboard) {
+            return;
+        }
+
+        items.add_item.begin (new Akira.Models.LayerModel (item, items));
+    }
+
+    public void remove_child_item (Akira.Lib.Models.CanvasItem item) {
+        if (!is_artboard) {
+            return;
+        }
+
+        var item_model = items.find_item (item);
+
+        if (item_model == null) {
+            return;
+        }
+
+        items.remove_item.begin (item_model);
     }
 
     public string to_string () {
-        return "Layer: %s Hidden: %d Lock: %d".printf (item.id, 0, 0);
+        return "Layer: %s Label: %s Hidden: %d Lock: %d".printf (item.id, name, 0, 0);
     }
 }

--- a/src/Models/ListModel.vala
+++ b/src/Models/ListModel.vala
@@ -45,6 +45,16 @@ public class Akira.Models.ListModel : GLib.Object, GLib.ListModel {
         return typeof (Akira.Models.ItemModel);
     }
 
+    public Akira.Models.ItemModel? find_item (Akira.Lib.Models.CanvasItem item) {
+        for (var i = 0; i < list.length (); i++) {
+            if (list.nth_data (i).item == item) {
+                return get_item (i) as Akira.Models.ItemModel;
+            }
+        }
+
+        return null;
+    }
+
     public async void add_item (Akira.Models.ItemModel model_item, bool append = true) {
         if (append) {
             list.append (model_item);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?

This PR will add to Artboard layer the possibiliy to show its children inside its container.

## Steps to Test

* Create an Artboard on the canvas
* Create an item inside it
* In the LayersPanel the layer is created inside the Artboard

## Screenshots

![akira-artboard-layer](https://user-images.githubusercontent.com/11556031/77231388-d7548e80-6b9a-11ea-8d72-e3980a475225.gif)

## Known Issues / Things To Do

* [x] Adding an item to an Artboard should add the layer to Artboard's layer
* [x] Deleting an item from the Artboard layer should delete it from the canvas
* [x] Deleting an item from the Canvas should delete it also from the Artboard's layer
* [x] Selecting an item from the Artboard layer should select it from the canvas
* [x] Selecting an item from the Canvas should select it also from the Artboard's layer
* [x] Hovering over an item from the Artboard layer should add the hover effect to it from the canvas
* [x] Hovering over an item from the Canvas should add the hover effect to it also from the Artboard's layer
