### PR TITLE
Artboard redraw on child property change

### DIFF
--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -80,7 +80,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
 
         create_hover_effect (item);
 
-        if (!item.selected) {
+        if (!item.selected && !item.locked) {
             canvas.window.event_bus.hover_over_item (item);
         }
 

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -230,8 +230,10 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
 
                 cr.transform (item.compute_transform (Cairo.Matrix.identity ()));
 
-                if (item is Goo.CanvasItemSimple) {
-                    (item as Goo.CanvasItemSimple).simple_paint (cr, bounds);
+                var canvas_item = item as Goo.CanvasItemSimple;
+
+                if (canvas_item != null && item.visibility == Goo.CanvasItemVisibility.VISIBLE) {
+                    canvas_item.simple_paint (cr, bounds);
                 }
 
                 cr.restore ();

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -121,10 +121,19 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         item.set ("stroke-alpha", 255);
 
         update_z_index (item);
+
+        var canvas_item = item as Models.CanvasItem;
+
+        if (canvas_item.artboard != null) {
+            canvas_item.notify.connect (() => {
+                canvas_item.artboard.changed (true);
+            });
+        }
+
     }
 
     public static void update_z_index (Goo.CanvasItem item) {
-        //var z_index = (item as Models.CanvasItej).canvas.get_root_item ().find_child (item);
+        //var z_index = (item as Models.CanvasItem).canvas.get_root_item ().find_child (item);
 
         //item.set ("z-index", z_index);
     }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?

This PR restores the normal operation related to Artboard child property change.

## Steps to Test

* Create an artboard
* Draw a shape inside it
* Change one of the property of the item (fill, stroke, radius, visibility, opacity)
