### PR TITLE
Limit build architectures

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -8,6 +8,12 @@ description: |
 grade: stable
 confinement: strict
 
+architectures:
+  - build-on: i386
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+
 apps:
   akira:
     extensions: [gnome-3-28]


### PR DESCRIPTION
As we depend on the elementary PPA for their SDK packages, we should limit Akira to only build on architectures supported by those packages. That means no s390x mainframe builds and no powerpc builds for you! :D
(honestly, it would be hilarious to run elementary os and akira on an S390 mainframe) :D
