### PR TITLE
WIP: Artboard Children Z Ordering

### DIFF
--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -445,7 +445,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         }
 
         // Account for nobs and select effect.
-        if (item_position == window.items_manager.get_item_top_position ()) {
+        if (item_position == window.items_manager.get_item_top_position (selected_item)) {
             move_up.sensitive = false;
             move_top.sensitive = false;
         }

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -426,12 +426,14 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
     }
 
     private void update_button_sensitivity (bool selected) {
-        move_up.sensitive = (selected_item != null);
-        move_down.sensitive = (selected_item != null);
-        move_top.sensitive = (selected_item != null);
-        move_bottom.sensitive = (selected_item != null);
+        var z_buttons_sensitive = selected_item != null && !(selected_item is Lib.Models.CanvasArtboard);
 
-        if (selected_item == null || selected_item.get_canvas () == null) {
+        move_up.sensitive = z_buttons_sensitive;
+        move_down.sensitive = z_buttons_sensitive;
+        move_top.sensitive = z_buttons_sensitive;
+        move_bottom.sensitive = z_buttons_sensitive;
+
+        if (!z_buttons_sensitive || selected_item.get_canvas () == null) {
             return;
         }
 

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -197,7 +197,7 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
             // TODO: Differentiate between layer and artboard
             // based upon item "type" of some sort
             var item_model = item as Akira.Lib.Models.CanvasItem;
-            return new Akira.Layouts.Partials.Layer (window, item_model);
+            return new Akira.Layouts.Partials.Layer (window, item_model, container);
         });
     }
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -134,7 +134,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         item.delete ();
         window.event_bus.item_deleted (item);
         window.event_bus.file_edited ();
-
     }
 
     public Models.CanvasItem add_artboard (double x, double y) {

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -211,10 +211,19 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     }
 
     public int get_item_z_index (Models.CanvasItem item) {
+        if (item.artboard != null) {
+            var items_count = (int) item.artboard.items.get_n_items ();
+            return items_count - 1 - item.artboard.items.index (item);
+        }
+
         return get_free_items_count () - 1 - free_items.index (item);
     }
 
-    public int get_item_top_position () {
+    public int get_item_top_position (Models.CanvasItem item) {
+        if (item.artboard != null) {
+            return (int) item.artboard.items.get_n_items () - 1;
+        }
+
         return get_free_items_count () - 1;
     }
 

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -189,6 +189,11 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         Models.CanvasItem selected_item = selected_items.nth_data (0);
 
+        // Cannot move artboard z-index wise
+        if (selected_item is Models.CanvasArtboard) {
+            return;
+        }
+
         int items_count = window.items_manager.get_free_items_count ();
         int pos_selected = items_count - 1 - window.items_manager.get_item_position (selected_item);
 

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -225,7 +225,14 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         cr.fill ();
 
         if (items.get_n_items () > 0) {
-            foreach (Lib.Models.CanvasItem item in items) {
+            var items_length = items.get_n_items ();
+
+            // Painting items in reversed order in order to
+            // print last item inserted (top of the stack) on top
+            // of the items inserted before
+            for (var i = 0; i < items_length; i++) {
+                var item = items.nth_data (items_length - 1 - i);
+
                 cr.save ();
 
                 cr.transform (item.compute_transform (Cairo.Matrix.identity ()));

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -231,7 +231,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
             // print last item inserted (top of the stack) on top
             // of the items inserted before
             for (var i = 0; i < items_length; i++) {
-                var item = items.nth_data (items_length - 1 - i);
+                var item = items[items_length - 1 - i];
 
                 cr.save ();
 

--- a/src/Models/ListModel.vala
+++ b/src/Models/ListModel.vala
@@ -35,8 +35,8 @@ public class Akira.Models.ListModel<Model> : GLib.Object, GLib.ListModel {
         return list.nth_data (position) as Object;
     }
 
-    public Model? nth_data (uint position) {
-        return list.nth_data (position);
+    public new Model get (uint index) {
+        return list.nth_data (index);
     }
 
     public Type get_item_type () {

--- a/src/Models/ListModel.vala
+++ b/src/Models/ListModel.vala
@@ -35,6 +35,10 @@ public class Akira.Models.ListModel<Model> : GLib.Object, GLib.ListModel {
         return list.nth_data (position) as Object;
     }
 
+    public Model? nth_data (uint position) {
+        return list.nth_data (position);
+    }
+
     public Type get_item_type () {
         return typeof (Model);
     }

--- a/src/Models/ListModel.vala
+++ b/src/Models/ListModel.vala
@@ -79,6 +79,13 @@ public class Akira.Models.ListModel<Model> : GLib.Object, GLib.ListModel {
         items_changed (position, 1, 0);
     }
 
+    public void swap_items (int source_index, int target_index) {
+        // Remove item at source position
+        var item_to_swap = remove_at (source_index);
+        // Insert item at target position
+        insert_at (target_index, item_to_swap);
+    }
+
     public void insert_at (int position, Model item) {
         list.insert (item, position);
         items_changed (position, 0, 1);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?

This PR is to enable z ordering relative to Artboard

## Steps to Test

* Create an Artboard
* Add item to the Artboard
* Change z-index of the Item using known shortcuts or the z-index buttons in HeaderBar
* Check the Canvas status and Layer panel status

## Screenshots

![akira-z-index-change-inside-artboard](https://user-images.githubusercontent.com/11556031/78946722-cb862900-7ac3-11ea-8502-e818d7afc030.gif)


## Known Issues / Things To Do

* [x] Item inserted last in an Artboard are painted on top of the existing ones
* [x] Changing z-index of an Artboard's children changes Artboard's layer in LayerPanel
* [x] Changing z-index of an Artboard's children is reflected in Canvas Artboard items painting
* [x] HeaderBar button sensitivity works for Artboard childrens too
