### PR TITLE
Fix segfault when deleting an artboard

### DIFF
--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -127,14 +127,12 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 if (item.artboard == null) {
                     free_items.remove_item.begin (item);
                 }
-
                 break;
         }
 
         item.delete ();
         window.event_bus.item_deleted (item);
         window.event_bus.file_edited ();
-
     }
 
     public Models.CanvasItem add_artboard (double x, double y) {

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -143,19 +143,6 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         items.remove_item.begin (item);
     }
 
-    public void remove_all_items () {
-        Models.CanvasItem item;
-
-        while (items != null) {
-            // Get the new head of the list
-            item = items.get_item (0) as Lib.Models.CanvasItem;
-
-            canvas.window.event_bus.request_delete_item (item);
-        }
-
-        items = new Akira.Models.ListModel<Models.CanvasItem> ();
-    }
-
     public bool is_inside (double x, double y) {
         return x <= bounds.x2
             && x >= bounds.x1

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019-202 Alecaddd (https://alecaddd.com)
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -93,13 +93,9 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public void delete () {
-        if (this.artboard != null) {
+        if (this.artboard != null && !(this is Models.CanvasArtboard)) {
             this.artboard.remove_item (this);
-        }
-
-
-        if (this is Models.CanvasArtboard) {
-            (this as Models.CanvasArtboard).remove_all_items ();
+            return;
         }
 
         remove ();

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -93,8 +93,8 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public void delete () {
-        if (this.artboard != null && !(this is Models.CanvasArtboard)) {
-            this.artboard.remove_item (this);
+        if (artboard != null) {
+            artboard.remove_item (this);
             return;
         }
 
@@ -168,7 +168,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         double delta_x, double delta_y,
         double delta_x_accumulator = 0.0, double delta_y_accumulator = 0.0) {
 
-        if (this.artboard != null) {
+        if (artboard != null) {
             var transformed_delta_x = delta_x_accumulator;
             var transformed_delta_y = delta_y_accumulator;
 
@@ -212,8 +212,8 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public virtual double get_real_coord (string coord_id) {
-        var offset_x = this.artboard == null ? 0 : relative_x;
-        var offset_y = this.artboard == null ? 0 : relative_y;
+        var offset_x = artboard == null ? 0 : relative_x;
+        var offset_y = artboard == null ? 0 : relative_y;
 
         var item_x = get_coords ("x") - offset_x;
         var item_y = get_coords ("y") - offset_y;
@@ -280,7 +280,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         var item_y = relative_y;
 
         canvas.convert_from_item_space (
-            this.artboard,
+            artboard,
             ref item_x,
             ref item_y
             );


### PR DESCRIPTION
It seems we were trying to remove the same item multiple times as the code wasn't preventing an extra `delete()` when dealing with Artboards.
This should fix it.