### PR TITLE
Update the add image method for the new items manager

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -93,26 +93,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         window.event_bus.insert_item.connect (on_insert_item);
     }
 
-    public void insert_item_default (Akira.Lib.Models.CanvasItem item, bool select) {
-        double start_x, start_y, scale, rotation;
-        start_x = Akira.Layouts.MainCanvas.CANVAS_SIZE / 2;
-        start_y = Akira.Layouts.MainCanvas.CANVAS_SIZE / 2;
-
-        if (selected_bound_manager.selected_items.length () > 0) {
-            selected_bound_manager.selected_items.nth_data (0).get_simple_transform (
-                out start_x, out start_y, out scale, out rotation
-            );
-        }
-
-        window.items_manager.add_item (item);
-        Utils.AffineTransform.set_position (item, start_x, start_y);
-
-        if (select) {
-            selected_bound_manager.reset_selection ();
-            selected_bound_manager.add_item_to_selection (item);
-        }
-    }
-
     public void update_bounds () {
         get_bounds (out bounds_x, out bounds_y, out bounds_w, out bounds_h);
     }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -85,6 +85,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     public Akira.Models.ListModel<Models.CanvasItem> items;
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard? artboard { get; set; }
+
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -20,7 +20,7 @@
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
-public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
+public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
     // Identifiers.
     public Models.CanvasItemType item_type { get; set; }
     public string id { get; set; }
@@ -31,7 +31,6 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
         get {
             return alpha * 100.0;
         }
-
         set {
             set ("alpha", value / 100.0);
         }
@@ -75,13 +74,16 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
     public double initial_relative_x { get; set; }
     public double initial_relative_y { get; set; }
 
-    public CanvasImage (Akira.Services.ImageProvider provider, Goo.CanvasItem? parent = null) {
-        Object (
-            parent: parent
-        );
-
+    public CanvasImage (
+        double _x = 0,
+        double _y = 0,
+        Services.ImageProvider provider,
+        Goo.CanvasItem? _parent = null,
+        Models.CanvasArtboard? _artboard = null
+    ) {
+        artboard = _artboard;
+        parent = _artboard != null ? _artboard : _parent;
         canvas = parent.get_canvas () as Akira.Lib.Canvas;
-        parent.add_child (this, -1);
 
         item_type = Models.CanvasItemType.IMAGE;
         id = Models.CanvasItem.create_item_id (this);
@@ -91,9 +93,13 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, CanvasItem {
         height = 1;
         x = 0;
         y = 0;
+        relative_x = 0;
+        relative_y = 0;
         scale_to_fit = true;
 
         set_transform (Cairo.Matrix.identity ());
+
+        position_item (_x, _y);
 
         provider.get_pixbuf.begin (-1, -1, (obj, res) => {
             try {

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -122,8 +122,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         item.set ("fill-alpha", 255);
         item.set ("stroke-alpha", 255);
 
-        update_z_index (item);
-
         var canvas_item = item as Models.CanvasItem;
 
         // Populate the name with the item's id
@@ -135,12 +133,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
                 canvas_item.artboard.changed (true);
             });
         }
-    }
-
-    public static void update_z_index (Goo.CanvasItem item) {
-        //var z_index = (item as Models.CanvasItem).canvas.get_root_item ().find_child (item);
-
-        //item.set ("z-index", z_index);
     }
 
     public virtual void position_item (double _x, double _y) {
@@ -156,7 +148,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
             relative_y = item_y_from_artboard;
         } else {
             parent.add_child (this, -1);
-
 
             // Keep the item always in the origin
             // move the entire coordinate system every time
@@ -175,7 +166,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
             this.relative_x = this.initial_relative_x + transformed_delta_x;
             this.relative_y = this.initial_relative_y + transformed_delta_y;
 
-
             return;
         }
 
@@ -189,7 +179,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
             get_transform (out transform);
         } else {
             artboard.get_transform (out transform);
-
             transform = compute_transform (transform);
         }
 

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -288,25 +288,16 @@ public class Akira.Services.ActionManager : Object {
 
     private void on_choose_image_response (Gtk.FileChooserNative dialog, int response_id) {
         window.event_bus.request_change_mode (Akira.Lib.Canvas.EditMode.MODE_SELECTION);
+
         switch (response_id) {
             case Gtk.ResponseType.ACCEPT:
             case Gtk.ResponseType.OK:
                 SList<File> files = dialog.get_files ();
-                weak Akira.Lib.Canvas canvas = window.main_window.main_canvas.canvas;
                 files.@foreach ((file) => {
                     var provider = new Akira.Services.FileImageProvider (file);
-                    var item = new Akira.Lib.Models.CanvasImage (
-                        provider, canvas.get_root_item ()
-                    );
-                    var select = files.index (file) + 1 == files.length () ? true : false;
-
-                    canvas.insert_item_default (item, select);
-                    canvas.window.event_bus.item_inserted (item);
+                    window.items_manager.insert_image (provider);
                 });
-
                 break;
-        default:
-            break;
         }
     }
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Updates the current method to insert images to leverage the new `ItemsManager` implementation.

## Steps to Test
- Import an image when nothing is selected, should be positioned in the middle of the canvas.
- Import an image when an item is selected, should be positioned above that item.
- Import an image when an item inside an artboard is selected, should be added to that artboard.

- Fixes #317
