### PR TITLE
Add About section in Settings Dialog

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 2
 
 [*.{vala,py}]
 indent_size = 4
+block_comment_start = /**
+block_comment = *
+block_comment_end = */

--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ Contact: [http://tysontan.com](http://tysontan.com)  / [tysontan@mail.com](mailt
 ## 📜 License
 #### [GNU GPLv3 / Creative Commons BY-SA](./COPYING)
 
-Copyright © 2019 Akira Project.
+Copyright © 2019-2020 Akira Project.

--- a/SUPPORTERS.md
+++ b/SUPPORTERS.md
@@ -1,0 +1,95 @@
+# List of Akir Supporters
+
+:tada: All the awesome people that donated to the project :tada:
+
+* LordVarkson
+* Coryn
+* Kiyoshi Aman
+* Pierre Paul Lefebvre
+* Jan Masak
+* Alexandru Nedel
+* Samuel Gyger
+* Patrick Nafarrete
+* Tyler Compton
+* Vagner Rodrigues
+* Frederick M. Rogers
+* Matko
+* veritanuda
+* Jof Rey
+* Paul Demers
+* Bob Patraque
+* Wilhelm Fitzpatrick
+* Sage Ross
+* Joshua Draxten
+* Nick Richards
+* Simon Hafner
+* Alexander Poselentsev
+* Aris Papathéodorou
+* Wesley Moore
+* Noel
+* Isak Westerlund
+* Sam Muirhead
+* Christopher Crouse
+* manokara
+* Sumner Evans
+* Steven Teskey
+* nicolas
+* Alexander Nesterenko
+* Xaviju
+* Joshua Heidrich
+* snorpey
+* Per Thomas Lundal
+* Gernot Premper
+* Markus Huggler
+* Luis Barron
+* Wtcher
+* maylme
+* Marek Pikuła
+* Rebecca Bulboaca
+* Benjamin Altpeter
+* Raí Biason Toffoletto
+* Daniel Foré
+* Guillaume Chau
+* Stephan Müller
+* Imanuel
+* Andrew Sauber
+* Alexey Bolonia
+* Andreas Libak Jørgensen
+* Arthur Nieuwland
+* Pyves & Ran
+* Aode (Lion)
+* Nacheta Menjibar
+* sStevemMartin
+* Jebedaia
+* Sebi
+* Shaleen Jain
+* Ezra Sharp
+* TheCrealm
+* rickard
+* Roberto
+* Bryan Paget
+* Shelby Cruver
+* Markus Rubey
+* Miura Seiji
+* Vladislav Petrov
+* Bruno Paz
+* Gonçalo
+* Ben Oliver
+* Tenné
+* Antonio Maciej Matamoros Ochman
+* Stephan Plöhn
+* Gabriel J Perez
+* Jonas Rudlang
+* Pietro Vertechi
+* dehahost
+* Marián Brém
+* Bacchus
+* Selwyn
+* User
+* Martin Kregar
+* oliver
+* James Dyson
+* Wout
+* Thomas Höß
+* Brian Hinton
+* Ryan Halliday

--- a/SUPPORTERS.md
+++ b/SUPPORTERS.md
@@ -1,4 +1,4 @@
-# List of Akir Supporters
+# List of Akira Supporters
 
 :tada: All the awesome people that donated to the project :tada:
 

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -190,7 +190,7 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         grid.halign = Gtk.Align.CENTER;
 
         var app_icon = new Gtk.Image ();
-        app_icon.gicon = new ThemedIcon ("com.github.akiraux.akira");
+        app_icon.gicon = new ThemedIcon (Constants.APP_ID);
         app_icon.pixel_size = 64;
         app_icon.margin_top = 12;
 

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -30,14 +30,10 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
     private Gtk.ColorButton border_color;
     private Gtk.SpinButton border_size;
 
-    enum Column {
-        ICONTYPE
-    }
-
     public SettingsDialog (Akira.Window _window) {
         Object (
             window: _window,
-            border_width: 5,
+            border_width: 6,
             deletable: true,
             resizable: false,
             modal: true,
@@ -54,6 +50,7 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         stack.add_titled (get_general_box (), "general", _("General"));
         stack.add_titled (get_interface_box (), "interface", _("Interface"));
         stack.add_titled (get_shapes_box (), "shapes", _("Shapes"));
+        stack.add_titled (get_about_box (), "about", _("About"));
 
         var stack_switcher = new Gtk.StackSwitcher ();
         stack_switcher.set_stack (stack);
@@ -182,6 +179,96 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
 
         border_switch.bind_property ("active", border_color, "sensitive", BindingFlags.SYNC_CREATE);
         border_switch.bind_property ("active", border_size, "sensitive", BindingFlags.SYNC_CREATE);
+
+        return grid;
+    }
+
+    private Gtk.Widget get_about_box () {
+        var grid = new Gtk.Grid ();
+        grid.row_spacing = 6;
+        grid.column_spacing = 12;
+        grid.halign = Gtk.Align.CENTER;
+
+        var app_icon = new Gtk.Image ();
+        app_icon.gicon = new ThemedIcon ("com.github.akiraux.akira");
+        app_icon.pixel_size = 64;
+        app_icon.margin_top = 12;
+
+        var app_name = new Gtk.Label (APP_NAME);
+        app_name.get_style_context ().add_class ("h2");
+        app_name.margin_top = 6;
+
+        var app_description = new Gtk.Label (_("The Linux Design Tool"));
+        app_description.get_style_context ().add_class ("h3");
+
+        var app_version = new Gtk.Label ("v" + Constants.VERSION + " - alpha");
+        app_version.get_style_context ().add_class ("dim-label");
+        app_version.selectable = true;
+
+        var disclaimer = new Gtk.Label (
+            _("WARNING!\nAkira is still under development and not ready for production. Missing features, random bugs, and black holes opening in your kitchen are to be expected."
+            )
+        );
+        disclaimer.justify = Gtk.Justification.CENTER;
+        disclaimer.max_width_chars = 60;
+        disclaimer.wrap = true;
+        disclaimer.margin_top = disclaimer.margin_bottom = 12;
+
+        var patreons_label = new Gtk.Label (_("Thanks to our awesome supporters!"));
+        patreons_label.get_style_context ().add_class ("h4");
+
+        var patreons_url = new Gtk.LinkButton.with_label (
+            "https://github.com/akiraux/Akira/blob/master/SUPPORTERS.md",
+            _("View the list of supporters")
+        );
+        patreons_url.halign = Gtk.Align.CENTER;
+        patreons_url.margin_bottom = 12;
+
+        grid.attach (app_icon, 0, 0);
+        grid.attach (app_name, 0, 1);
+        grid.attach (app_description, 0, 2);
+        grid.attach (app_version, 0, 3);
+        grid.attach (disclaimer, 0, 4);
+        grid.attach (patreons_label, 0, 5);
+        grid.attach (patreons_url, 0, 6);
+
+        // Button grid at the bottom of the About page.
+        var button_grid = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
+        button_grid.halign = Gtk.Align.CENTER;
+        button_grid.spacing = 6;
+
+        var donate_button = new Gtk.Button.with_label (_("Make a Donation"));
+        donate_button.clicked.connect (() => {
+            try {
+                AppInfo.launch_default_for_uri ("https://github.com/akiraux/Akira#-support", null);
+            } catch (Error e) {
+                warning (e.message);
+            }
+        });
+
+        var translate_button = new Gtk.Button.with_label (_("Suggest Translations"));
+        translate_button.clicked.connect (() => {
+            try {
+                AppInfo.launch_default_for_uri ("https://github.com/akiraux/Akira/issues", null);
+            } catch (Error e) {
+                warning (e.message);
+            }
+        });
+
+        var bug_button = new Gtk.Button.with_label (_("Report a Problem"));
+        bug_button.clicked.connect (() => {
+            try {
+                AppInfo.launch_default_for_uri ("https://github.com/akiraux/Akira/issues", null);
+            } catch (Error e) {
+                warning (e.message);
+            }
+        });
+
+        button_grid.add (donate_button);
+        button_grid.add (translate_button);
+        button_grid.add (bug_button);
+
+        grid.attach (button_grid, 0, 7);
 
         return grid;
     }

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -2,9 +2,8 @@ namespace Constants {
    public const string DATADIR = "@DATADIR@";
    public const string PKGDATADIR = "@PKGDATADIR@";
    public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
-   public const string RELEASE_NAME = "@RELEASE_NAME@";
+   public const string PROJECT_NAME = "@PROJECT_NAME@";
    public const string VERSION = "@VERSION@";
-   public const string VERSION_INFO = "@VERSION_INFO@";
    public const string INSTALL_PREFIX = "@PREFIX@";
    public const string APP_ID = "@APP_ID@";
    public const string PROFILE = "@PROFILE@";


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Add an `About` section in the Settings Dialog.

## Steps to Test
Open the Settings Dialog and access the About Tab.

## Screenshots 
![Screenshot from 2020-04-16 19-50-10](https://user-images.githubusercontent.com/2527103/79527402-5dd68180-801c-11ea-97da-29551568afc8.png)

## This PR fixes/implements the following **bugs/features**:
- Add About dialog.
- Show Akira version from meson file.
- Implement an MD file to list all the Patreon supporters.

- Fixes #328
