### PR TITLE
Store recently opened files

### DIFF
--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -83,6 +83,12 @@
             <description>Automatically reopen the latest file on startup.</description>
         </key>
 
+        <key name="recently-opened" type="as">
+            <default>[]</default>
+            <summary>Recently opened files</summary>
+            <description>Keep track of the 10 most recently opened files.</description>
+        </key>
+
         <key name="export-folder" type="s">
             <default>''</default>
             <summary>Default export folder.</summary>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -106,5 +106,10 @@ public class Akira.Application : Gtk.Application {
 
         var window = new Akira.Window (this);
         this.add_window (window);
+
+        // Load the most recently opened/saved file.
+        if (settings.open_quick) {
+            window.action_manager.action_load_first ();
+        }
     }
 }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -97,6 +97,9 @@ public class Akira.Application : Gtk.Application {
         base.window_removed (window);
     }
 
+    /**
+     * Update the list of recently opened files in all the currently opened Windows.
+     */
     public void update_recent_files_list () {
         foreach (Akira.Window window in windows) {
             window.event_bus.update_recent_files_list ();

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -97,6 +97,12 @@ public class Akira.Application : Gtk.Application {
         base.window_removed (window);
     }
 
+    public void update_recent_files_list () {
+        foreach (Akira.Window window in windows) {
+            window.event_bus.update_recent_files_list ();
+        }
+    }
+
     protected override void activate () {
         Gtk.Settings.get_default ().set_property ("gtk-icon-theme-name", "elementary");
         Gtk.Settings.get_default ().set_property ("gtk-theme-name", "elementary");

--- a/src/FileFormat/AkiraFile.vala
+++ b/src/FileFormat/AkiraFile.vala
@@ -29,7 +29,7 @@ public class Akira.FileFormat.AkiraFile : Akira.FileFormat.ZipArchiveHandler {
     private File content_file { get; set; }
     public string path {
         owned get {
-            return opened_file.get_parent ().get_path () + opened_file.get_basename ();
+            return opened_file.get_parent ().get_path () + "/" + opened_file.get_basename ();
         }
     }
 
@@ -44,6 +44,7 @@ public class Akira.FileFormat.AkiraFile : Akira.FileFormat.ZipArchiveHandler {
             var content_json = get_content_as_json (content_file);
             new FileFormat.JsonLoader (window, content_json);
 
+            update_recent_list ();
             debug ("Version from file: %s", content_json.get_string_member ("version"));
         } catch (Error e) {
             error ("Could not load file: %s", e.message);
@@ -85,5 +86,30 @@ public class Akira.FileFormat.AkiraFile : Akira.FileFormat.ZipArchiveHandler {
         content_file = File.new_for_path (Path.build_filename (base_path, "content.json"));
 
         make_file (content_file);
+    }
+
+    /**
+     * Update the GSettings array of recently opened files.
+     */
+    private void update_recent_list() {
+        string[] array = {};
+        // Add the last opened file always on top.
+        array += path;
+
+        for (var i = 0; i <= settings.recently_opened.length; i++) {
+            // Don't store more than 10 files.
+            if (i == 9) {
+                break;
+            }
+
+            // If the same file was already in the list, don't save it again.
+            if (path == settings.recently_opened[i]) {
+                continue;
+            }
+
+            array += settings.recently_opened[i];
+        }
+
+        settings.set_strv ("recently-opened", array);
     }
 }

--- a/src/FileFormat/AkiraFile.vala
+++ b/src/FileFormat/AkiraFile.vala
@@ -60,6 +60,7 @@ public class Akira.FileFormat.AkiraFile : Akira.FileFormat.ZipArchiveHandler {
             write_content_to_file (content_file, json);
 
             write_to_archive ();
+            update_recent_list.begin ();
         } catch (Error e) {
             warning ("%s\n", e.message);
         }

--- a/src/FileFormat/AkiraFile.vala
+++ b/src/FileFormat/AkiraFile.vala
@@ -123,5 +123,7 @@ public class Akira.FileFormat.AkiraFile : Akira.FileFormat.ZipArchiveHandler {
         }
 
         settings.set_strv ("recently-opened", array);
+
+        window.app.update_recent_files_list ();
     }
 }

--- a/src/FileFormat/AkiraFile.vala
+++ b/src/FileFormat/AkiraFile.vala
@@ -91,7 +91,7 @@ public class Akira.FileFormat.AkiraFile : Akira.FileFormat.ZipArchiveHandler {
     /**
      * Update the GSettings array of recently opened files.
      */
-    private void update_recent_list() {
+    private void update_recent_list () {
         string[] array = {};
         // Add the last opened file always on top.
         array += path;

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -412,21 +412,58 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
             }
 
             // Skip if the file doesn't exist.
+            var file = File.new_for_path (settings.recently_opened[i]);
+            if (!file.query_exists ()) {
+                continue;
+            }
+
+            // Get the file name.
+            string[] split_string = settings.recently_opened[i].split ("/");
+            var file_name = split_string[split_string.length - 1].replace (".akira", "");
 
             var button = new Gtk.ModelButton ();
 
             // Add quick accelerators only for the first 3 items.
+            string? accels = null;
             if (i < 3) {
+                switch (i) {
+                    case 0:
+                        accels = Akira.Services.ActionManager.ACTION_PREFIX
+                            + Akira.Services.ActionManager.ACTION_LOAD_FIRST;
+                        break;
+                    case 1:
+                        accels = Akira.Services.ActionManager.ACTION_PREFIX
+                            + Akira.Services.ActionManager.ACTION_LOAD_SECOND;
+                        break;
+                    case 2:
+                        accels = Akira.Services.ActionManager.ACTION_PREFIX
+                            + Akira.Services.ActionManager.ACTION_LOAD_THIRD;
+                        break;
+                }
+
                 button.get_child ().destroy ();
-                var label = new Gtk.Label (settings.recently_opened[i]);
+                var label = new Granite.AccelLabel.from_action_name (file_name, accels);
                 button.add (label);
-                // button.action_name = accels;
+                button.action_name = accels;
             } else {
-                button.text = settings.recently_opened[i];
+                button.text = file_name;
             }
+
+            button.tooltip_text = settings.recently_opened[i];
+
+            button.clicked.connect (() => {
+                if (file != null) {
+                    File[] files = {};
+                    files += file;
+                    window.app.open (files, "");
+                } else {
+                    warning ("unable to open file");
+                }
+            });
 
             recent_files_grid.add (button);
         }
+
         recent_files_grid.show_all ();
         fetched = true;
     }

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -57,8 +57,6 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         }
     }
 
-    private bool fetched = false;
-
     public HeaderBar (Akira.Window window) {
         Object (
             toggled: true,
@@ -180,19 +178,6 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         recent_files_grid.orientation = Gtk.Orientation.VERTICAL;
         recent_files_grid.width_request = 220;
         recent_files_grid.name = "files-menu";
-
-        var back_button = new Gtk.ModelButton ();
-        back_button.text = _("Main Menu");
-        back_button.inverted = true;
-        back_button.menu_name = "main";
-        back_button.expand = true;
-
-        var sub_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
-        sub_separator.margin_top = sub_separator.margin_bottom = 3;
-
-        recent_files_grid.add (back_button);
-        recent_files_grid.add (sub_separator);
-        recent_files_grid.show_all ();
 
         var open_recent_button = new Gtk.ModelButton ();
         open_recent_button.text = _("Open Recent");
@@ -384,6 +369,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
             update_button_sensitivity (false);
         });
         window.event_bus.set_scale.connect (on_set_scale);
+        window.event_bus.update_recent_files_list.connect (fetch_recent_files);
     }
 
     private void on_set_scale (double scale) {
@@ -399,11 +385,22 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
      * if those files still exists.
      */
     public async void fetch_recent_files () {
-        // Interrupt if the list was already fetched. We don't want/need to
-        // refresh this list at every opening.
-        if (fetched) {
-            return;
-        }
+        recent_files_grid.@foreach (child => {
+            recent_files_grid.remove (child);
+        });
+
+        // Add default buttons.
+        var back_button = new Gtk.ModelButton ();
+        back_button.text = _("Main Menu");
+        back_button.inverted = true;
+        back_button.menu_name = "main";
+        back_button.expand = true;
+
+        var sub_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
+        sub_separator.margin_top = sub_separator.margin_bottom = 3;
+
+        recent_files_grid.add (back_button);
+        recent_files_grid.add (sub_separator);
 
         // Loop a first time to clear missing files and prevent wrong accelerators.
         string[] all_files = {};
@@ -488,7 +485,6 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         }
 
         recent_files_grid.show_all ();
-        fetched = true;
     }
 
     private void on_file_edited () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -30,6 +30,9 @@ public class Akira.Services.ActionManager : Object {
     public const string ACTION_OPEN = "action_open";
     public const string ACTION_SAVE = "action_save";
     public const string ACTION_SAVE_AS = "action_save_as";
+    public const string ACTION_LOAD_FIRST = "action_load_first";
+    public const string ACTION_LOAD_SECOND = "action_load_second";
+    public const string ACTION_LOAD_THIRD = "action_load_third";
     public const string ACTION_SHOW_PIXEL_GRID = "action-show-pixel-grid";
     public const string ACTION_SHOW_UI_GRID = "action-show-ui-grid";
     public const string ACTION_PRESENTATION = "action_presentation";
@@ -64,6 +67,9 @@ public class Akira.Services.ActionManager : Object {
         { ACTION_OPEN, action_open },
         { ACTION_SAVE, action_save },
         { ACTION_SAVE_AS, action_save_as },
+        { ACTION_LOAD_FIRST, action_load_first },
+        { ACTION_LOAD_SECOND, action_load_second },
+        { ACTION_LOAD_THIRD, action_load_third },
         { ACTION_SHOW_PIXEL_GRID, action_show_pixel_grid },
         { ACTION_SHOW_UI_GRID, action_show_ui_grid },
         { ACTION_PRESENTATION, action_presentation },
@@ -103,6 +109,9 @@ public class Akira.Services.ActionManager : Object {
         action_accelerators.set (ACTION_OPEN, "<Control>o");
         action_accelerators.set (ACTION_SAVE, "<Control>s");
         action_accelerators.set (ACTION_SAVE_AS, "<Control><Shift>s");
+        action_accelerators.set (ACTION_LOAD_FIRST, "<Control><Shift>1");
+        action_accelerators.set (ACTION_LOAD_SECOND, "<Control><Shift>2");
+        action_accelerators.set (ACTION_LOAD_THIRD, "<Control><Shift>3");
         action_accelerators.set (ACTION_SHOW_PIXEL_GRID, "<Control><Shift>p");
         action_accelerators.set (ACTION_SHOW_UI_GRID, "<Control><Shift>g");
         action_accelerators.set (ACTION_PRESENTATION, "<Control>period");
@@ -184,6 +193,15 @@ public class Akira.Services.ActionManager : Object {
 
     private void action_save_as () {
         window.file_manager.save_file_as ();
+    }
+
+    private void action_load_first () {
+    }
+
+    private void action_load_second () {
+    }
+
+    private void action_load_third () {
     }
 
     private void action_show_pixel_grid () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -195,7 +195,7 @@ public class Akira.Services.ActionManager : Object {
         window.file_manager.save_file_as ();
     }
 
-    private void action_load_first () {
+    public void action_load_first () {
         if (settings.recently_opened.length == 0 || settings.recently_opened[0] == null) {
             window.event_bus.canvas_notification (_("No recently opened file available!"));
             return;

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -109,9 +109,9 @@ public class Akira.Services.ActionManager : Object {
         action_accelerators.set (ACTION_OPEN, "<Control>o");
         action_accelerators.set (ACTION_SAVE, "<Control>s");
         action_accelerators.set (ACTION_SAVE_AS, "<Control><Shift>s");
-        action_accelerators.set (ACTION_LOAD_FIRST, "<Control><Shift>1");
-        action_accelerators.set (ACTION_LOAD_SECOND, "<Control><Shift>2");
-        action_accelerators.set (ACTION_LOAD_THIRD, "<Control><Shift>3");
+        action_accelerators.set (ACTION_LOAD_FIRST, "<Control><Alt>1");
+        action_accelerators.set (ACTION_LOAD_SECOND, "<Control><Alt>2");
+        action_accelerators.set (ACTION_LOAD_THIRD, "<Control><Alt>3");
         action_accelerators.set (ACTION_SHOW_PIXEL_GRID, "<Control><Shift>p");
         action_accelerators.set (ACTION_SHOW_UI_GRID, "<Control><Shift>g");
         action_accelerators.set (ACTION_PRESENTATION, "<Control>period");
@@ -196,12 +196,60 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_load_first () {
+        if (settings.recently_opened.length == 0 || settings.recently_opened[0] == null) {
+            window.event_bus.canvas_notification (_("No recently opened file available!"));
+            return;
+        }
+
+        var file = File.new_for_path (settings.recently_opened[0]);
+        if (!file.query_exists ()) {
+            window.event_bus.canvas_notification (
+                _("Unable to open file at '%s'").printf (settings.recently_opened[0])
+            );
+            return;
+        }
+
+        File[] files = {};
+        files += file;
+        window.app.open (files, "");
     }
 
     private void action_load_second () {
+        if (settings.recently_opened.length < 1 || settings.recently_opened[1] == null) {
+            window.event_bus.canvas_notification (_("No second most recently opened file available!"));
+            return;
+        }
+
+        var file = File.new_for_path (settings.recently_opened[1]);
+        if (!file.query_exists ()) {
+            window.event_bus.canvas_notification (
+                _("Unable to open file at '%s'").printf (settings.recently_opened[1])
+            );
+            return;
+        }
+
+        File[] files = {};
+        files += file;
+        window.app.open (files, "");
     }
 
     private void action_load_third () {
+        if (settings.recently_opened.length < 2 || settings.recently_opened[2] == null) {
+            window.event_bus.canvas_notification (_("No third most recently opened file available!"));
+            return;
+        }
+
+        var file = File.new_for_path (settings.recently_opened[2]);
+        if (!file.query_exists ()) {
+            window.event_bus.canvas_notification (
+                _("Unable to open file at '%s'").printf (settings.recently_opened[2])
+            );
+            return;
+        }
+
+        File[] files = {};
+        files += file;
+        window.app.open (files, "");
     }
 
     private void action_show_pixel_grid () {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -24,6 +24,7 @@ public class Akira.Services.EventBus : Object {
     // File signals.
     public signal void file_edited ();
     public signal void file_saved (string? file_name);
+    public signal void update_recent_files_list ();
 
     // Layout signals.
     public signal void change_sensitivity (string type);

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -10,11 +10,11 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 *              Bilal Elmoussaoui <bil.elmoussaoui@gmail.com>
@@ -83,6 +83,10 @@ public class Akira.Services.Settings : GLib.Settings {
     public bool open_quick {
         get { return get_boolean ("open-quick"); }
         set { set_boolean ("open-quick", value); }
+    }
+    public string[] recently_opened {
+        get { return get_strv ("recently-opened"); }
+        set { set_strv ("recently-opened", value); }
     }
 
     // Export Settings.

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -85,7 +85,7 @@ public class Akira.Services.Settings : GLib.Settings {
         set { set_boolean ("open-quick", value); }
     }
     public string[] recently_opened {
-        get { return get_strv ("recently-opened"); }
+        owned get { return get_strv ("recently-opened"); }
         set { set_strv ("recently-opened", value); }
     }
 

--- a/src/Utils/Dialogs.vala
+++ b/src/Utils/Dialogs.vala
@@ -28,22 +28,27 @@ public class Akira.Utils.Dialogs : Object {
         );
     }
 
-    public bool message_dialog (string title, string description, string icon, string primary_button) {
+    public Granite.MessageDialog message_dialog (
+        string title,
+        string description,
+        string icon,
+        string primary_button,
+        string? secondary_button = null
+    ) {
         var dialog = new Granite.MessageDialog.with_image_from_icon_name (
             title, description, icon, Gtk.ButtonsType.CANCEL);
         dialog.transient_for = window;
+
+        if (secondary_button != null) {
+            var button2 = new Gtk.Button.with_label (secondary_button);
+            button2.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+            dialog.add_action_widget (button2, 2);
+        }
 
         var button = new Gtk.Button.with_label (primary_button);
         button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
         dialog.add_action_widget (button, Gtk.ResponseType.ACCEPT);
 
-        dialog.show_all ();
-        if (dialog.run () == Gtk.ResponseType.ACCEPT) {
-            dialog.destroy ();
-            return true;
-        }
-
-        dialog.destroy ();
-        return false;
+        return dialog;
     }
 }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Keep track of the 10 most recently opened files and list them in the header bar file submenu.

## Screenshots 
![Screenshot from 2020-04-18 17-48-29](https://user-images.githubusercontent.com/2527103/79677007-1a595000-81a1-11ea-92dc-d1d325e3079e.png)

![Screenshot from 2020-04-18 18-18-44](https://user-images.githubusercontent.com/2527103/79677009-1c231380-81a1-11ea-9747-e53f2db98023.png)

## This PR fixes/implements the following **bugs/features**:
- [x] Store the array of file paths in the `GSettings`.
- [x] Refresh the list when the submenu is opened.
- [x] Discard unreachable files.
- [x] Limit to 10 files.
- [x] Add accelerators to quickly load the first 3 files.
- [x] Enable the `Open Quick` options.
- [x] Add `Save and Close` option to the File save dialog.