### PR TITLE
Layers Panel Drag & Drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 src/config.vala
 build/
+builddir/
 _build/
 .flatpak-builder/
 *~

--- a/data/css/artboard.css
+++ b/data/css/artboard.css
@@ -34,10 +34,6 @@
     color: @fg_color;
 }
 
-.highlight-drop-area .artboard:last-child {
-    box-shadow: inset 0 -2px 0 shade (@bg_color, 0.5);
-}
-
 .artboard-container {
     background-color: @bg_color;
 }

--- a/data/css/artboard.css
+++ b/data/css/artboard.css
@@ -30,7 +30,8 @@
 
 .artboard:selected,
 .artboard:selected .revealer-button image,
-.artboard:selected .layer-action image {
+.artboard:selected .layer-action image,
+.artboard:selected .artboard-container image {
     color: @fg_color;
 }
 

--- a/data/css/layer.css
+++ b/data/css/layer.css
@@ -48,12 +48,12 @@
     box-shadow: none;
 }
 
-.layer.hover > grid > .layer-action,
-.layer.hover > grid > grid > .layer-action {
+.layer.hover > revealer > grid > .layer-action,
+.layer.hover > revealer > grid > grid > .layer-action {
     opacity: 0.5;
 }
 
-.layer.hover > grid > .layer-action:hover,
+.layer.hover > revealer > grid > .layer-action:hover,
 .layer-action:hover {
     opacity: 1;
 }
@@ -101,16 +101,6 @@
 .group-container .layer {
     padding-left: 15px;
 }
-
-/*.indicator {
-    background-color: @primary;
-    border-radius: 0 2px 2px 0;
-}
-
-.indicator-circle {
-    border-radius: 50%;
-    background-color: @primary;
-}*/
 
 .grid-motion {
     background-color: @primary;

--- a/data/css/layer.css
+++ b/data/css/layer.css
@@ -88,11 +88,6 @@
     -gtk-icon-transform: rotate(-90deg);
 }
 
-/* drag and drop */
-.layer.highlight > grid > grid {
-    box-shadow: inset 0 0 0 2px @primary;
-}
-
 /* group */
 .group-container {
     background-color: @bg_color;
@@ -102,6 +97,7 @@
     padding-left: 15px;
 }
 
+/* drag and drop */
 .grid-motion {
     background-color: @primary;
 }

--- a/data/css/layer.css
+++ b/data/css/layer.css
@@ -102,12 +102,16 @@
     padding-left: 15px;
 }
 
-.indicator {
+/*.indicator {
     background-color: @primary;
     border-radius: 0 2px 2px 0;
 }
 
 .indicator-circle {
     border-radius: 50%;
+    background-color: @primary;
+}*/
+
+.grid-motion {
     background-color: @primary;
 }

--- a/data/css/layer.css
+++ b/data/css/layer.css
@@ -3,6 +3,10 @@
     transition: all 240ms ease;
 }
 
+.layer.transparent {
+    opacity: 0.5;
+}
+
 /* selected status */
 .layer,
 .layer:selected {
@@ -48,12 +52,12 @@
     box-shadow: none;
 }
 
-.layer.hover > revealer > grid > .layer-action,
-.layer.hover > revealer > grid > grid > .layer-action {
+.layer.hover > grid > .layer-action,
+.layer.hover > grid > grid > .layer-action {
     opacity: 0.5;
 }
 
-.layer.hover > revealer > grid > .layer-action:hover,
+.layer.hover > grid > .layer-action:hover,
 .layer-action:hover {
     opacity: 1;
 }

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -44,7 +44,6 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
     public Gtk.Image button_icon;
     public Gtk.Revealer revealer;
     public Gtk.ListBox container;
-    public int layers_count { get; set; default = 0; }
 
     public Akira.Lib.Models.CanvasArtboard model { get; construct; }
 
@@ -104,8 +103,12 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         container.get_style_context ().add_class ("artboard-container");
         container.activate_on_single_click = false;
         container.selection_mode = Gtk.SelectionMode.SINGLE;
-        Gtk.drag_dest_set (container, Gtk.DestDefaults.ALL, TARGET_ENTRIES_LAYER, Gdk.DragAction.MOVE);
-        container.drag_data_received.connect (on_drag_data_received);
+
+        // Block all the events from bubbling up and triggering the Artbord's events.
+        container.event.connect (() => {
+            return true;
+        });
+
         revealer.add (container);
 
         var motion_grid = new Gtk.Grid ();
@@ -114,12 +117,13 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
 
         motion_revealer = new Gtk.Revealer ();
         motion_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN;
+        motion_revealer.reveal_child = false;
         motion_revealer.add (motion_grid);
 
         handle = new Gtk.EventBox ();
         handle.hexpand = true;
         handle.add (label_grid);
-        handle.event.connect (on_click_event);
+        handle.event.connect (on_handle_event);
 
         button_locked = new Gtk.ToggleButton ();
         button_locked.tooltip_text = _("Lock Layer");
@@ -219,141 +223,6 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         });
     }
 
-    private void on_drag_data_received (Gdk.DragContext context, int x, int y, Gtk.SelectionData selection_data,
-        uint target_type, uint time) {
-
-        Akira.Layouts.Partials.Layer target;
-        Gtk.Widget row;
-        Akira.Layouts.Partials.Layer source;
-        int new_position;
-        var before_group = false;
-
-        target = (Akira.Layouts.Partials.Layer) container.get_row_at_y (y);
-        row = ((Gtk.Widget[]) selection_data.get_data ())[0];
-        source = (Akira.Layouts.Partials.Layer) row.get_ancestor (typeof (Akira.Layouts.Partials.Layer));
-        int index = target.get_index ();
-        Gtk.Allocation alloc;
-
-        if (target == null) {
-            new_position = -1;
-        } else if (target.grouped && source.layer_group == null) {
-            source.get_allocation (out alloc);
-            y = y - (index * alloc.height);
-
-            var group = (Akira.Layouts.Partials.Layer) target.container.get_row_at_y (y);
-
-            if (group is Akira.Layouts.Partials.Layer) {
-                new_position = group.get_index ();
-            } else {
-                new_position = -1;
-            }
-
-            if ((y + alloc.height) < (alloc.height / 2)) {
-                new_position = target.get_index () > 1 && source.get_index () > new_position ?
-                    target.get_index () - 1 : target.get_index ();
-                debug ("Layer dropped ABOVE group: %i", new_position);
-                before_group = true;
-            } else {
-                before_group = false;
-                debug ("Layer dropped INSIDE a group from OUTSIDE: %i", new_position);
-
-                if (y > ((new_position * alloc.height) - (alloc.height / 2)) && new_position > 1) {
-                    debug ("drop below");
-                    new_position++;
-                }
-            }
-        } else if (target.grouped && source.layer_group != null) {
-            source.get_allocation (out alloc);
-            y = y - (index * alloc.height);
-
-            var group = (Akira.Layouts.Partials.Layer) target.container.get_row_at_y (y);
-
-            if (group is Akira.Layouts.Partials.Layer) {
-                new_position = group.get_index ();
-            } else {
-                new_position = -1;
-            }
-
-            if ((y + alloc.height) < (alloc.height / 2)) {
-                new_position = target.get_index () > 1 && source.get_index () > new_position ?
-                    target.get_index () - 1 : target.get_index ();
-                debug ("Layer dropped ABOVE group: %i", new_position);
-                before_group = true;
-            } else {
-                before_group = false;
-                debug ("%i", y);
-                debug ("%i", new_position);
-                debug ("%i", (new_position * alloc.height) - (alloc.height / 2));
-
-                if (y > ((new_position * alloc.height) - (alloc.height / 2)) && source.get_index () > new_position) {
-                    debug ("dropped below");
-                    new_position++;
-                } else if (y <= ((new_position * alloc.height) - (alloc.height / 2))
-                    && source.get_index () < new_position) {
-                    debug ("dropped above");
-                    new_position--;
-                }
-                debug ("Layer dropped WHITIN group: %i", new_position);
-            }
-        } else if (!target.grouped && source.layer_group != null) {
-            var parent = (Akira.Layouts.Partials.Artboard) target.get_ancestor (
-                typeof (Akira.Layouts.Partials.Artboard));
-            var group = parent.container.get_row_at_y (y);
-            group.get_allocation (out alloc);
-
-            if (group is Akira.Layouts.Partials.Layer) {
-                new_position = group.get_index ();
-            } else {
-                new_position = -1;
-            }
-
-            if (y > ((new_position * alloc.height) - (alloc.height / 2))) {
-                debug ("drop below");
-                new_position++;
-            }
-
-            debug ("Layer dropped OUTSIDE from INSIDE a group: %i", new_position);
-        } else {
-            target.get_allocation (out alloc);
-            new_position = target.get_index ();
-
-            if (y <= ((new_position * alloc.height) - (alloc.height / 2))
-                && new_position > 1 && source.get_index () < new_position) {
-                new_position--;
-            }
-            debug ("Layer dropped: %i", new_position);
-        }
-
-        if (source == target) {
-            return;
-        }
-
-        if (source.layer_group != null) {
-            source.layer_group.container.remove (source);
-            source.layer_group = null;
-        } else {
-            container.remove (source);
-        }
-
-        if (before_group) {
-            container.insert (source, new_position);
-        } else if (target.grouped && source.layer_group == null) {
-            source.layer_group = target;
-            target.container.insert (source, new_position);
-        } else if (target.grouped && source.layer_group != null) {
-            source.layer_group = target;
-            target.container.insert (source, new_position);
-        } else if (!target.grouped && source.layer_group != null) {
-            source.layer_group = null;
-            container.insert (source, new_position);
-        } else {
-            container.insert (source, new_position);
-        }
-
-        window.main_window.right_sidebar.layers_panel.reload_zebra ();
-        show_all ();
-    }
-
     private void build_drag_and_drop () {
         // Make this a draggable widget.
         Gtk.drag_source_set (this, Gdk.ModifierType.BUTTON1_MASK, TARGET_ENTRIES, Gdk.DragAction.MOVE);
@@ -411,75 +280,30 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         motion_revealer.reveal_child = false;
     }
 
-    public bool on_click_event (Gdk.Event event) {
-        if (event.type == Gdk.EventType.@2BUTTON_PRESS) {
-            entry.text = label.label;
-            entry.visible = true;
-            entry.no_show_all = false;
-            label.visible = false;
-            label.no_show_all = true;
+    private bool on_handle_event (Gdk.Event event) {
+        switch (event.type) {
+            case Gdk.EventType.@2BUTTON_PRESS:
+                entry.text = label.label;
+                entry.visible = true;
+                entry.no_show_all = false;
+                label.visible = false;
+                label.no_show_all = true;
 
-            editing = true;
+                editing = true;
 
-            Timeout.add (200, () => {
-                entry.grab_focus ();
-                return false;
-            });
-        }
+                Timeout.add (200, () => {
+                    entry.grab_focus ();
+                    return false;
+                });
 
-        if (event.type == Gdk.EventType.BUTTON_PRESS) {
-            window.event_bus.request_add_item_to_selection (model);
+                return true;
 
-            return true;
+            case Gdk.EventType.BUTTON_PRESS:
+                window.event_bus.request_add_item_to_selection (model);
+                return true;
         }
 
         return false;
-    }
-
-    //  private bool delete_object () {
-    //      if (is_selected () && !editing) {
-    //          window.main_window.right_sidebar.layers_panel.remove (this);
-
-    //          return true;
-    //      }
-
-    //      var layers = container.get_selected_rows ();
-
-    //      check_delete_object (layers);
-
-    //      container.foreach (child => {
-    //          if (child is Akira.Layouts.Partials.Layer) {
-    //              Akira.Layouts.Partials.Layer layer = (Akira.Layouts.Partials.Layer) child;
-    //              if (layer.grouped) {
-    //                  check_delete_object (layer.container.get_selected_rows ());
-    //              }
-    //          }
-    //      });
-
-    //      window.main_window.right_sidebar.layers_panel.reload_zebra ();
-
-    //      return true;
-    //  }
-
-    public void check_delete_object (GLib.List<weak Gtk.ListBoxRow> layers) {
-        layers.foreach (row => {
-            Akira.Layouts.Partials.Layer layer = (Akira.Layouts.Partials.Layer) row;
-            do_delete_object (layer);
-
-            if (layer.grouped) {
-                check_delete_object (layer.container.get_selected_rows ());
-            }
-        });
-    }
-
-    public void do_delete_object (Akira.Layouts.Partials.Layer layer) {
-        if (layer.is_selected () && !layer.editing) {
-            if (layer.layer_group != null) {
-                layer.layer_group.container.remove (layer);
-            } else {
-                container.remove (layer);
-            }
-        }
     }
 
     public void update_on_enter () {
@@ -519,16 +343,6 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         label.label = new_label;
 
         window.event_bus.set_focus_on_canvas ();
-    }
-
-    public void count_layers () {
-        layers_count = 0;
-
-        container.foreach (child => {
-            if (child is Akira.Layouts.Partials.Layer) {
-                layers_count++;
-            }
-        });
     }
 
     private bool handle_focus_in (Gdk.EventFocus event) {

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -221,7 +221,6 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
 
     private void on_drag_data_received (Gdk.DragContext context, int x, int y, Gtk.SelectionData selection_data,
         uint target_type, uint time) {
-        window.main_window.right_sidebar.indicator.visible = false;
 
         Akira.Layouts.Partials.Layer target;
         Gtk.Widget row;

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -338,7 +338,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         drag_motion.connect (on_drag_motion);
         drag_leave.connect (on_drag_leave);
 
-        drag_end.connect (clear_indicator);
+        drag_end.connect (on_drag_end);
     }
 
     private void on_drag_begin (Gtk.Widget widget, Gdk.DragContext context) {
@@ -417,7 +417,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         should_scroll = false;
     }
 
-    public void clear_indicator (Gdk.DragContext context) {
+    public void on_drag_end (Gdk.DragContext context) {
         main_revealer.reveal_child = true;
     }
 

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -64,17 +64,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     public Gtk.Revealer revealer;
     public Gtk.ListBox container;
 
-    private bool _locked { get; set; default = false; }
-    public bool locked {
-        get { return _locked; } set { _locked = value; }
-    }
-
-    // Keep __hidden with double underscore for FreeBSD compatibility
-    private bool __hidden { get; set; default = false; }
-    public bool hidden {
-        get { return __hidden; } set { __hidden = value; }
-    }
-
     private bool _editing { get; set; default = false; }
     public bool editing {
         get { return _editing; } set { _editing = value; }
@@ -507,6 +496,10 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
      * @return {bool} True to stop propagation, False to let other events run.
      */
     public bool on_click_event (Gdk.Event event) {
+        if (model.locked) {
+            return true;
+        }
+
         switch (event.type) {
             case Gdk.EventType.@2BUTTON_PRESS:
                 entry.text = label.label;
@@ -542,7 +535,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
                     (parent as Gtk.ListBox).select_row (this);
                 }
 
-                break;
+                // We're returning false to not interrupt the natural bubbling of the click event.
+                return false;
         }
 
         return false;
@@ -734,8 +728,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
             icon_hidden.visible = ! active;
             icon_hidden.no_show_all = active;
-
-            hidden = active;
         });
     }
 

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -459,6 +459,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
             if (layer.model.artboard != null) {
                 item_to_swap.artboard.remove_item (item_to_swap);
                 window.event_bus.item_deleted (item_to_swap);
+                item_to_swap.artboard = null;
                 item_to_swap.set_parent (window.main_window.main_canvas.canvas.get_root_item ());
             } else {
                 item_to_swap = window.items_manager.free_items.remove_at (source);

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -42,8 +42,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
     // Drag and Drop properties.
     public Gtk.Revealer motion_revealer;
-    public Gtk.Revealer main_revealer;
 
+    public Gtk.Revealer main_revealer;
     public Gtk.Image icon;
     public Gtk.Image icon_folder_open;
     public Gtk.Image icon_locked;
@@ -330,9 +330,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     private void build_drag_and_drop () {
         // Make this a draggable widget.
         Gtk.drag_source_set (this, Gdk.ModifierType.BUTTON1_MASK, TARGET_ENTRIES, Gdk.DragAction.MOVE);
-
         drag_begin.connect (on_drag_begin);
-        // drag_data_get.connect (on_drag_data_get);
+        drag_data_get.connect (on_drag_data_get);
 
         // Make this widget a DnD destination.
         Gtk.drag_dest_set (this, Gtk.DestDefaults.MOTION, TARGET_ENTRIES, Gdk.DragAction.MOVE);
@@ -380,13 +379,13 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         Gtk.SelectionData selection_data,
         uint target_type, uint time) {
 
-        uchar[] data = new uchar[(sizeof (Akira.Layouts.Partials.Layer))];
+        // uchar[] data = new uchar[(sizeof (Akira.Layouts.Partials.Layer))];
 
-        ((Gtk.Widget[])data)[0] = widget;
+        // ((Gtk.Widget[])data)[0] = widget;
 
-        selection_data.set (
-            Gdk.Atom.intern_static_string ("LAYER"), 32, data
-            );
+        // selection_data.set (
+        //     Gdk.Atom.intern_static_string ("LAYER"), 32, data
+        // );
     }
 
     public bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -388,7 +388,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         // );
     }
 
-    public bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {
+    private bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {
         motion_revealer.reveal_child = true;
 
         int row_index = get_index ();
@@ -412,12 +412,12 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         return true;
     }
 
-    public void on_drag_leave (Gdk.DragContext context, uint time) {
+    private void on_drag_leave (Gdk.DragContext context, uint time) {
         motion_revealer.reveal_child = false;
         should_scroll = false;
     }
 
-    public void on_drag_end (Gdk.DragContext context) {
+    private void on_drag_end (Gdk.DragContext context) {
         main_revealer.reveal_child = true;
     }
 

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -41,9 +41,9 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     };
 
     // Drag and Drop properties.
-    public Gtk.Revealer motion_revealer;
+    private Gtk.Revealer motion_revealer;
+    private bool dragged = false;
 
-    public Gtk.Revealer main_revealer;
     public Gtk.Image icon;
     public Gtk.Image icon_folder_open;
     public Gtk.Image icon_locked;
@@ -242,13 +242,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     }
 
     private void is_group () {
-        main_revealer = new Gtk.Revealer ();
-        main_revealer.reveal_child = true;
-        main_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN;
-
         if (!grouped) {
-            main_revealer.add (label_grid);
-            add (main_revealer);
+            add (label_grid);
             return;
         }
 
@@ -291,8 +286,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         group_grid.attach (label_grid, 0, 0, 1, 1);
         group_grid.attach (revealer, 0, 1, 1, 1);
 
-        main_revealer.add (group_grid);
-        add (main_revealer);
+        add (group_grid);
     }
 
     private void reveal_actions () {
@@ -364,7 +358,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
         Gtk.drag_set_icon_surface (context, surface);
 
-        main_revealer.reveal_child = false;
+        get_style_context ().add_class ("transparent");
+        dragged = true;
     }
 
     private void on_drag_data_get (
@@ -428,9 +423,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
             target = 1;
         }
 
-        // We need to reveal the item before removing it.
-        layer.main_revealer.reveal_child = true;
-
         // Remove item at source position
         var item_to_swap = items_source.remove_at (source);
 
@@ -441,6 +433,9 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         if (model.artboard != null) {
             model.artboard.changed (true);
         }
+
+        get_style_context ().remove_class ("transparent");
+        dragged = false;
     }
 
     /**
@@ -457,10 +452,12 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     }
 
     private bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {
-        motion_revealer.reveal_child = true;
-
         int row_index = get_index ();
         var row = (Akira.Layouts.Partials.Layer) (parent as Gtk.ListBox).get_row_at_index (row_index);
+
+        if (!dragged) {
+            motion_revealer.reveal_child = true;
+        }
 
         Gtk.Allocation alloc;
         get_allocation (out alloc);
@@ -486,7 +483,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     }
 
     private void on_drag_end (Gdk.DragContext context) {
-        main_revealer.reveal_child = true;
+        get_style_context ().remove_class ("transparent");
+        dragged = false;
     }
 
     /**

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -405,14 +405,80 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         var layer = (Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
 
         int items_count = 0;
+        int items_count_artboard = 0;
         int pos_source = -1;
         int pos_target = 0;
 
-        // If the layers belong to the same Artboard.
+        // Save the coordinates before removing the item.
+        var x_pos = layer.model.get_global_coord ("x");
+        var y_pos = layer.model.get_global_coord ("y");
+
+        // If the layer is a free item.
+        if (model.artboard == null) {
+            items_count = (int) window.items_manager.free_items.get_n_items ();
+            pos_target = items_count - 1 - window.items_manager.free_items.index (model);
+
+            // If the source belongs to an artboard.
+            if (layer.model.artboard != null) {
+                items_count_artboard = (int) layer.model.artboard.items.get_n_items ();
+                pos_source = items_count_artboard - 1 - layer.model.artboard.items.index (layer.model);
+            } else {
+                pos_source = items_count - 1 - window.items_manager.free_items.index (layer.model);
+            }
+
+            // Interrupt if item position doesn't exist.
+            if (pos_source == -1) {
+                return;
+            }
+
+            // z-index is the exact opposite of items placement as the last item
+            // is the topmost element. Because of this, we need some trickery to
+            // properly handle the list's order.
+            var target = items_count - 1 - pos_target;
+            var source = layer.model.artboard != null ?
+                items_count_artboard - 1 - pos_source :
+                items_count - 1 - pos_source;
+
+            // Interrupt if the item was dropped in the same position.
+            if (layer.model.artboard == null && source - 1 == target) {
+                return;
+            }
+
+            // Since the top position is handled by the emtpy panel drop method,
+            // if the drop target is in position 0, it means the layer should
+            // be added underneath it, at position 1.
+            if (target == 0) {
+                target = 1;
+            }
+
+            // We need to reveal the item before removing it.
+            layer.main_revealer.reveal_child = true;
+
+            var item_to_swap = layer.model;
+            // Remove item at source position.
+            if (layer.model.artboard != null) {
+                item_to_swap.artboard.remove_item (item_to_swap);
+                window.event_bus.item_deleted (item_to_swap);
+                item_to_swap.set_parent (window.main_window.main_canvas.canvas.get_root_item ());
+            } else {
+                item_to_swap = window.items_manager.free_items.remove_at (source);
+            }
+
+            // Insert item at target position.
+            item_to_swap.position_item (x_pos, y_pos);
+            window.items_manager.free_items.insert_at (target, item_to_swap);
+
+            window.event_bus.request_add_item_to_selection (item_to_swap);
+            window.event_bus.z_selected_changed ();
+
+            return;
+        }
+
+        // If the layers belong to the same artboard.
         if (model.artboard != null && model.artboard == layer.model.artboard) {
             items_count = (int) model.artboard.items.get_n_items ();
-            pos_source = items_count - 1 - model.artboard.items.index (layer.model);
             pos_target = items_count - 1 - model.artboard.items.index (model);
+            pos_source = items_count - 1 - model.artboard.items.index (layer.model);
 
             // Interrupt if item position doesn't exist.
             if (pos_source == -1) {
@@ -448,6 +514,13 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
             window.event_bus.z_selected_changed ();
             model.artboard.changed (true);
+
+            return;
+        }
+
+        // If the source and target artboards don't match
+        if (model.artboard != null && model.artboard != layer.model.artboard) {
+            // todo
         }
     }
 

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -10,11 +10,11 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 * Authored by: Giacomo Alberini <giacomoalbe@gmail.com>

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -138,7 +138,6 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
         }
 
         window.event_bus.change_item_z_index (source.model.item, new_position);
-        window.event_bus.toggle_sidebar_indicator (false);
     }
     */
 

--- a/src/Layouts/RightSideBar.vala
+++ b/src/Layouts/RightSideBar.vala
@@ -22,8 +22,6 @@
 public class Akira.Layouts.RightSideBar : Gtk.Grid {
     public weak Akira.Window window { get; construct; }
 
-    public Gtk.Overlay layers_overlay;
-    public Gtk.Grid indicator;
     public Akira.Layouts.Partials.LayersPanel layers_panel;
     public Akira.Layouts.Partials.PagesPanel pages_panel;
     public Gtk.ScrolledWindow layers_scroll;
@@ -70,40 +68,9 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
             ((Gtk.Container) scrolled_child).set_focus_vadjustment (new Gtk.Adjustment (0, 0, 0, 0, 0, 0));
         }
 
-        layers_overlay = new Gtk.Overlay ();
-        layers_overlay.add (layers_scroll);
-
-        indicator = new Gtk.Grid ();
-        indicator.expand = false;
-        indicator.valign = Gtk.Align.START;
-        indicator.width_request = get_allocated_width ();
-        indicator.margin_start = 20;
-        indicator.margin_end = 5;
-        indicator.height_request = 1;
-        indicator.can_focus = false;
-
-        var circle = new Gtk.Grid ();
-        circle.get_style_context ().add_class ("indicator-circle");
-        circle.width_request = 6;
-        circle.height_request = 6;
-        circle.valign = Gtk.Align.CENTER;
-        var line = new Gtk.Grid ();
-        line.get_style_context ().add_class ("indicator");
-        line.expand = true;
-        line.height_request = 2;
-        line.valign = Gtk.Align.CENTER;
-
-        indicator.attach (circle, 0, 0, 1, 1);
-        indicator.attach (line, 1, 0, 1, 1);
-        layers_overlay.add_overlay (indicator);
-        layers_overlay.set_overlay_pass_through (indicator, true);
-
-        indicator.visible = false;
-        indicator.no_show_all = true;
-
         var top_panel = new Gtk.Grid ();
         top_panel.attach (build_search_bar (), 0, 0, 1, 1);
-        top_panel.attach (layers_overlay, 0, 1, 1, 1);
+        top_panel.attach (layers_scroll, 0, 1, 1, 1);
 
         pane.pack1 (top_panel, false, false);
 
@@ -113,10 +80,6 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         pages_scroll.add (pages_panel);
 
         attach (pane, 0 , 0 , 1, 1);
-
-        window.event_bus.toggle_sidebar_indicator.connect ((show_indicator) => {
-            indicator.visible = show_indicator;
-        });
     }
 
     private Gtk.Grid build_search_bar () {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -70,7 +70,6 @@ public class Akira.Services.EventBus : Object {
     public signal void item_deleted (Lib.Models.CanvasItem item);
     public signal void item_locked (Lib.Models.CanvasItem item);
     public signal void change_item_z_index (Lib.Models.CanvasItem item, int position);
-    public signal void toggle_sidebar_indicator (bool show);
 
     // Others.
     public signal void disconnect_typing_accel ();


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Enable the usual Gtk Drag and Drop for Layers and Artboards in the Layer panel.

## Steps to Test
1. Create a bunch of layers and artboards.
2. Reorder them with drag and drop.
3. Be sure the z-index order was properly updated.

## Screenshots 
![dnd-layers](https://user-images.githubusercontent.com/2527103/85929651-790b0c00-b86b-11ea-8444-d57f4988267a.gif)

## This PR fixes/implements the following **bugs/features**:
- [x] Enable Layer drag motion and don't interfere with click event box.
- [x] Show drop indicator on drag motion for layers, artboards, search field, and empty panel.
- [x] Reorder z-index on drop.
- [x] Change artboard accordingly on drop.
