### PR TITLE
Disable flipping for CanvasArtboard (fixes #342)

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -189,6 +189,14 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         }
 
         selected_item = selected_items.nth_data (0);
+
+        if (selected_item is Lib.Models.CanvasArtboard) {
+            hflip_button.hide ();
+            vflip_button.hide ();
+        } else {
+            hflip_button.show ();
+            vflip_button.show ();
+        }
     }
 
     private void disconnect_previous_item () {

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -70,8 +70,8 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             height.enabled = has_item;
             width.enabled = has_item;
             rotation.enabled = has_item && !(_selected_item is Lib.Models.CanvasArtboard);
-            hflip_button.sensitive = has_item;
-            vflip_button.sensitive = has_item;
+            hflip_button.sensitive = has_item && !(_selected_item is Lib.Models.CanvasArtboard);
+            vflip_button.sensitive = has_item && !(_selected_item is Lib.Models.CanvasArtboard);
             opacity_entry.entry.sensitive = has_item && !(_selected_item is Lib.Models.CanvasArtboard);
             scale.sensitive = has_item && !(_selected_item is Lib.Models.CanvasArtboard);
             lock_changes.sensitive = has_item;
@@ -190,13 +190,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
 
         selected_item = selected_items.nth_data (0);
 
-        if (selected_item is Lib.Models.CanvasArtboard) {
-            hflip_button.hide ();
-            vflip_button.hide ();
-        } else {
-            hflip_button.show ();
-            vflip_button.show ();
-        }
     }
 
     private void disconnect_previous_item () {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -267,7 +267,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     }
 
     private void on_flip_item (bool clicked, bool vertical) {
-        if (selected_items.length () == 0) {
+        if (selected_items.length () == 0 || selected_items.nth_data (0) is Lib.Models.CanvasArtboard) {
             return;
         }
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
<!--- Please write a description here -->
Disabling hflip/vflip button if a Lib.Models.CanvasArtboard is selected.

## This PR fixes/implements the following **bugs/features**:
<!--- If there was an issue that this PR targets, adding it here will auto close it --> 

- Fixes #342

