### PR TITLE
Fix loading of free items

### DIFF
--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -159,7 +159,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     }
 
     public void add_item (Akira.Lib.Models.CanvasItem item) {
-        free_items.add_item.begin (item, false);
+        free_items.add_item.begin (item);
         window.event_bus.file_edited ();
     }
 
@@ -550,6 +550,12 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             item.bounds.y1 = transform.get_double_member ("y0");
             item.bounds.x2 = transform.get_double_member ("x0") + obj.get_double_member ("width");
             item.bounds.y2 = transform.get_double_member ("y0") + obj.get_double_member ("height");
+        }
+
+        // Since free items are loaded upside down, always raise to the top position
+        // the newly added free item.
+        if (artboard == null & !(item is Models.CanvasArtboard)) {
+            item.lower (null);
         }
     }
 

--- a/src/Models/ListModel.vala
+++ b/src/Models/ListModel.vala
@@ -57,7 +57,7 @@ public class Akira.Models.ListModel<Model> : GLib.Object, GLib.ListModel {
         return (int) list.index (find_item (item));
     }
 
-    public async void add_item (Model model_item, bool append = true) {
+    public async void add_item (Model model_item, bool append = false) {
         if (append) {
             list.append (model_item);
             items_changed (get_n_items () - 1, 0, 1);


### PR DESCRIPTION
Super quick fix for the loading of free items.
Since the free items are loaded upside down, the layers list was correct but the z-index of the items on the canvas was upside down.

- Fixes #351
