### PR TITLE
Complete layers Drag and Drop implementation

### DIFF
--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -231,11 +231,11 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         drag_data_get.connect (on_drag_data_get);
 
         // Make this widget a DnD destination.
-        Gtk.drag_dest_set (this, Gtk.DestDefaults.MOTION, TARGET_ENTRIES_LAYER, Gdk.DragAction.MOVE);
-        drag_motion.connect (on_drag_motion);
-        drag_leave.connect (on_drag_leave);
-        drag_drop.connect (on_drag_drop);
-        drag_data_received.connect (on_drag_data_received);
+        Gtk.drag_dest_set (artboard_handle, Gtk.DestDefaults.MOTION, TARGET_ENTRIES_LAYER, Gdk.DragAction.MOVE);
+        artboard_handle.drag_motion.connect (on_drag_motion);
+        artboard_handle.drag_leave.connect (on_drag_leave);
+        artboard_handle.drag_drop.connect (on_drag_drop);
+        artboard_handle.drag_data_received.connect (on_drag_data_received);
     }
 
     private void on_drag_begin (Gtk.Widget widget, Gdk.DragContext context) {
@@ -330,7 +330,7 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         var source = items_count - 1 - pos_source;
 
         // Interrupt if the item was dropped in the same position.
-        if (source - 1 == 0) {
+        if (source == 0) {
             debug ("same position");
             return;
         }

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -311,7 +311,38 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         uint target_type, uint time
     ) {
         // This works thanks to on_drag_data_get ().
-        // var layer = (Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
+        var layer = (Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
+
+        // Change artboard if necessary.
+        window.items_manager.change_artboard (layer.model, model);
+
+        var items_count = (int) model.items.get_n_items ();
+        var pos_source = items_count - 1 - model.items.index (layer.model);
+
+        // Interrupt if item position doesn't exist.
+        if (pos_source == -1) {
+            return;
+        }
+
+        // z-index is the exact opposite of items placement as the last item
+        // is the topmost element. Because of this, we need some trickery to
+        // properly handle the list's order.
+        var source = items_count - 1 - pos_source;
+
+        // Interrupt if the item was dropped in the same position.
+        if (source - 1 == 0) {
+            debug ("same position");
+            return;
+        }
+
+        // Remove item at source position
+        var item_to_swap = model.items.remove_at (source);
+
+        // Insert item at target position
+        model.items.insert_at (0, item_to_swap);
+        window.event_bus.z_selected_changed ();
+
+        model.changed (true);
     }
 
     private bool on_handle_event (Gdk.Event event) {

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -365,6 +365,13 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
                 return;
             }
 
+            // If the initial position is higher than the targeted dropped layer, it
+            // means the layer was dragged from the bottom up, therefore we need to
+            // increase the dropped target by 1 since we don't deal with location 0.
+            if (source > target) {
+                target++;
+            }
+
             // Remove item at source position.
             var artboard_to_swap = window.items_manager.artboards.remove_at (source);
 

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -49,7 +49,8 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
     public Akira.Lib.Models.CanvasArtboard model { get; construct; }
 
     // Drag and Drop properties.
-    public Gtk.Revealer motion_revealer;
+    private Gtk.Revealer motion_revealer;
+    public Gtk.Revealer motion_artboard_revealer;
 
     private bool _editing { get; set; default = false; }
     public bool editing {
@@ -121,6 +122,15 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         motion_revealer.reveal_child = false;
         motion_revealer.add (motion_grid);
 
+        var motion_artboard_grid = new Gtk.Grid ();
+        motion_artboard_grid.get_style_context ().add_class ("grid-motion");
+        motion_artboard_grid.height_request = 2;
+
+        motion_artboard_revealer = new Gtk.Revealer ();
+        motion_artboard_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN;
+        motion_artboard_revealer.reveal_child = false;
+        motion_artboard_revealer.add (motion_artboard_grid);
+
         handle = new Gtk.EventBox ();
         handle.hexpand = true;
         handle.add (label_grid);
@@ -180,6 +190,7 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         grid.attach (artboard_handle, 0, 0, 1, 1);
         grid.attach (motion_revealer, 0, 1, 1, 1);
         grid.attach (revealer, 0, 2, 1, 1);
+        grid.attach (motion_artboard_revealer, 0, 3, 1, 1);
 
         add (grid);
 
@@ -265,8 +276,6 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         row.artboard_handle.draw (cr);
 
         Gtk.drag_set_icon_surface (context, surface);
-
-        //  main_revealer.reveal_child = false;
     }
 
     private void on_drag_data_get (Gtk.Widget widget, Gdk.DragContext context, Gtk.SelectionData selection_data,

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -430,14 +430,25 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         // Remove item at source position
         var item_to_swap = items_source.remove_at (source);
 
+        // If the item is a free item, we need to remove it from the Canvas.
+        if (layer.model.artboard == null) {
+            item_to_swap.parent.remove_child (item_to_swap.parent.find_child (item_to_swap));
+        }
+
         // Insert item at target position
         items_source.insert_at (target, item_to_swap);
         window.event_bus.z_selected_changed ();
 
         if (model.artboard != null) {
             model.artboard.changed (true);
-        } else {
-            window.main_window.main_canvas.canvas.update ();
+        }
+
+        // If the item is a free item, we need to add it to the Canvas root element.
+        if (layer.model.artboard == null) {
+            var root = window.main_window.main_canvas.canvas.get_root_item ();
+            // Fetch the new correct position.
+            target = items_count - 1 - items_source.index (item_to_swap);
+            root.add_child (item_to_swap, target);
         }
 
         get_style_context ().remove_class ("transparent");

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -385,6 +385,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         Gtk.SelectionData selection_data,
         uint target_type, uint time
     ) {
+        debug ("dropped");
         // This works thanks to on_drag_data_get ().
         var layer = (Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
 
@@ -413,15 +414,18 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
         // Interrupt if the item was dropped in the same position.
         if (source - 1 == target) {
+            debug ("same position");
             return;
         }
 
-        // Since the top position is handled by the empty panel drop method,
-        // if the drop target is in position 0, it means the layer should
-        // be added underneath it, at position 1.
-        if (target == 0) {
-            target = 1;
+        // If the initial position is higher than the targeted dropped layer, it
+        // means the layer was dragged from the bottom up, therefore we need to
+        // increase the dropped target by 1 since we don't deal with location 0.
+        if (source > target) {
+            target++;
         }
+
+        debug ("%i - %i", source, target);
 
         // Remove item at source position
         var item_to_swap = items_source.remove_at (source);
@@ -432,6 +436,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
         if (model.artboard != null) {
             model.artboard.changed (true);
+        } else {
+            window.main_window.main_canvas.canvas.update ();
         }
 
         get_style_context ().remove_class ("transparent");

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -449,9 +449,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
             target = items_count - 1 - items_source.index (item_to_swap);
             root.add_child (item_to_swap, target);
         }
-
-        get_style_context ().remove_class ("transparent");
-        dragged = false;
     }
 
     /**

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -385,7 +385,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         Gtk.SelectionData selection_data,
         uint target_type, uint time
     ) {
-        debug ("dropped");
         // This works thanks to on_drag_data_get ().
         var layer = (Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
 

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -385,7 +385,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         Gtk.SelectionData selection_data,
         uint target_type, uint time
     ) {
-        // This works thanks to on_drag_data_get ().
         var layer = (Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
 
         // Change artboard if necessary.

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -36,8 +36,10 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
     private const int SCROLL_DISTANCE = 30;
     private const int SCROLL_DELAY = 50;
 
+    // Drag and Drop properties.
+    private Gtk.Revealer motion_revealer;
+
     private const Gtk.TargetEntry TARGET_ENTRIES[] = {
-        { "ARTBOARD", Gtk.TargetFlags.SAME_APP, 0 },
         { "LAYER", Gtk.TargetFlags.SAME_APP, 0 }
     };
 
@@ -60,6 +62,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
 
         artboards_list.activate_on_single_click = false;
         artboards_list.selection_mode = Gtk.SelectionMode.SINGLE;
+        artboards_list.expand = true;
 
         items_list.bind_model (window.items_manager.free_items, item => {
             var item_model = item as Lib.Models.CanvasItem;
@@ -73,8 +76,18 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
 
         get_style_context ().add_class ("layers-panel");
 
+        // Motion revealer for Drag and Drop on the top search bar.
+        var motion_grid = new Gtk.Grid ();
+        motion_grid.get_style_context ().add_class ("grid-motion");
+        motion_grid.height_request = 2;
+
+        motion_revealer = new Gtk.Revealer ();
+        motion_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_DOWN;
+        motion_revealer.add (motion_grid);
+
         attach (items_list, 0, 1);
-        attach (artboards_list, 0, 2);
+        attach (motion_revealer, 0, 2);
+        attach (artboards_list, 0, 3);
 
         build_drag_and_drop ();
         redraw_list ();
@@ -91,13 +104,13 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
 
     private void build_drag_and_drop () {
         Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, TARGET_ENTRIES, Gdk.DragAction.MOVE);
-
         drag_motion.connect (on_drag_motion);
         drag_leave.connect (on_drag_leave);
         drag_data_received.connect (on_drag_data_received);
     }
 
     public bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {
+        motion_revealer.reveal_child = true;
         check_scroll (y);
 
         if (should_scroll && !scrolling) {
@@ -109,6 +122,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
     }
 
     public void on_drag_leave (Gdk.DragContext context, uint time) {
+        motion_revealer.reveal_child = false;
         should_scroll = false;
     }
 
@@ -122,6 +136,48 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
         uint target_type, uint time
     ) {
         debug ("dropped");
+        var layer = (Akira.Layouts.Partials.Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
+        var artboard = layer.model.artboard;
+
+        // Change artboard if necessary.
+        window.items_manager.change_artboard (layer.model, null);
+
+        // If the moved layer had an artboard, no need to do anything else.
+        if (artboard != null) {
+            return;
+        }
+
+        var items_count = (int) window.items_manager.free_items.get_n_items ();
+        var pos_source = items_count - 1 - window.items_manager.free_items.index (layer.model);
+
+        // Interrupt if item position doesn't exist.
+        if (pos_source == -1) {
+            return;
+        }
+
+        // z-index is the exact opposite of items placement as the last item
+        // is the topmost element. Because of this, we need some trickery to
+        // properly handle the list's order.
+        var source = items_count - 1 - pos_source;
+
+        // Interrupt if the item was dropped in the same position.
+        if (source == items_count - 1) {
+            debug ("same position");
+            return;
+        }
+
+        // Remove item at source position.
+        var item_to_swap = window.items_manager.free_items.remove_at (source);
+        item_to_swap.parent.remove_child (item_to_swap.parent.find_child (item_to_swap));
+
+        // Insert item at target position.
+        window.items_manager.free_items.insert_at (items_count - 1, item_to_swap);
+        window.event_bus.z_selected_changed ();
+
+        var root = window.main_window.main_canvas.canvas.get_root_item ();
+        // Fetch the new correct position.
+        var target = items_count - 1 - window.items_manager.free_items.index (item_to_swap);
+        root.add_child (item_to_swap, target);
     }
 
     private void check_scroll (int y) {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -205,7 +205,6 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
             return;
         }
 
-        debug ("dropped");
         var layer = (Layouts.Partials.Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
         var layer_artboard = layer.model.artboard;
 

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -76,7 +76,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
         attach (items_list, 0, 1);
         attach (artboards_list, 0, 2);
 
-        // build_drag_and_drop ();
+        build_drag_and_drop ();
         redraw_list ();
 
         window.event_bus.item_inserted.connect (redraw_list);
@@ -89,57 +89,13 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
         show_all ();
     }
 
-    //  private void build_drag_and_drop () {
-    //      Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, TARGET_ENTRIES, Gdk.DragAction.MOVE);
+    private void build_drag_and_drop () {
+        Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, TARGET_ENTRIES, Gdk.DragAction.MOVE);
 
-    //      // drag_data_received.connect (on_drag_data_received);
-    //      drag_motion.connect (on_drag_motion);
-    //      drag_leave.connect (on_drag_leave);
-    //  }
-
-    /*
-    private void on_drag_data_received (
-        Gdk.DragContext context,
-        int x, int y,
-        Gtk.SelectionData selection_data,
-        uint target_type, uint time) {
-
-        Akira.Layouts.Partials.Layer? target;
-        Gtk.Widget row;
-        Akira.Layouts.Partials.Layer? source;
-        int new_position;
-
-        row = ((Gtk.Widget[]) selection_data.get_data ())[0];
-        source = row as Akira.Layouts.Partials.Layer;
-
-        Gtk.Allocation alloc;
-        source.get_allocation (out alloc);
-
-        // In order to determine which position should the dragged
-        // item occupy, we need to check in which gap it is.
-        // By adding half of the height of a row we know between which
-        // rows we want to inser the dragged layer
-        var target_row_y = y + alloc.height / 2;
-
-        target = (Akira.Layouts.Partials.Layer) items_list.get_row_at_y (target_row_y);
-
-        if (target == null) {
-            new_position = -1;
-        } else {
-            // New position needs to take into account the fact
-            // that the higher the item in the canvas the lower the index
-            // in the list. So the actual new position is the length of the
-            // list minus the index of the element
-            new_position = (int) list_model.get_n_items () - target.get_index ();
-        }
-
-        if (source == target) {
-            return;
-        }
-
-        window.event_bus.change_item_z_index (source.model.item, new_position);
+        drag_motion.connect (on_drag_motion);
+        drag_leave.connect (on_drag_leave);
+        drag_data_received.connect (on_drag_data_received);
     }
-    */
 
     public bool on_drag_motion (Gdk.DragContext context, int x, int y, uint time) {
         check_scroll (y);
@@ -154,6 +110,18 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
 
     public void on_drag_leave (Gdk.DragContext context, uint time) {
         should_scroll = false;
+    }
+
+    /**
+     * Handle the received layer, find the position of the targeted layer and trigger
+     * a z-index update.
+     */
+    private void on_drag_data_received (
+        Gdk.DragContext context, int x, int y,
+        Gtk.SelectionData selection_data,
+        uint target_type, uint time
+    ) {
+        debug ("dropped");
     }
 
     private void check_scroll (int y) {

--- a/src/Layouts/RightSideBar.vala
+++ b/src/Layouts/RightSideBar.vala
@@ -39,7 +39,10 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
     // Drag and Drop properties.
     private Gtk.Revealer motion_revealer;
 
+    private Gtk.TargetList drop_targets { get; set; default = null; }
+
     private const Gtk.TargetEntry TARGET_ENTRIES[] = {
+        { "ARTBOARD", Gtk.TargetFlags.SAME_APP, 0 },
         { "LAYER", Gtk.TargetFlags.SAME_APP, 0 }
     };
 
@@ -55,6 +58,8 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
     construct {
         get_style_context ().add_class ("sidebar-r");
         width_request = 220;
+
+        drop_targets = new Gtk.TargetList (TARGET_ENTRIES);
 
         var pane = new Gtk.Paned (Gtk.Orientation.VERTICAL);
         pane.expand = true;
@@ -116,18 +121,16 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         search_grid.get_style_context ().add_class ("border-bottom");
         search_grid.add (search);
 
-        // Build Drag and Drop for layers moving atop the search entry.
+        // Build Drag and Drop for items moving atop the search entry.
         Gtk.drag_dest_set (search, Gtk.DestDefaults.ALL, TARGET_ENTRIES, Gdk.DragAction.MOVE);
         search.drag_motion.connect (on_drag_motion);
         search.drag_leave.connect (on_drag_leave);
-        search.drag_end.connect (on_drag_end);
         search.drag_data_received.connect (on_drag_data_received);
 
-        // Build Drag and Drop for layers moving atop the search grid.
+        // Build Drag and Drop for items moving atop the search grid.
         Gtk.drag_dest_set (search_grid, Gtk.DestDefaults.ALL, TARGET_ENTRIES, Gdk.DragAction.MOVE);
         search_grid.drag_motion.connect (on_drag_motion);
         search_grid.drag_leave.connect (on_drag_leave);
-        search_grid.drag_end.connect (on_drag_end);
         search_grid.drag_data_received.connect (on_drag_data_received);
 
         return search_grid;
@@ -142,10 +145,6 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         motion_revealer.reveal_child = false;
     }
 
-    private void on_drag_end (Gdk.DragContext context) {
-        motion_revealer.reveal_child = true;
-    }
-
     /**
      * Handle the received layer, find the position of the targeted layer and trigger
      * a z-index update.
@@ -155,20 +154,57 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         Gtk.SelectionData selection_data,
         uint target_type, uint time
     ) {
-        // This works thanks to on_drag_data_get ().
+        int items_count, pos_source, source;
+
+        var type = Gtk.drag_dest_find_target (this, context, drop_targets);
+
+        if (type == Gdk.Atom.intern_static_string ("ARTBOARD")) {
+            var artboard = (Layouts.Partials.Artboard) (
+                (Gtk.Widget[]) selection_data.get_data ()
+            )[0];
+
+            items_count = (int) window.items_manager.artboards.get_n_items ();
+            pos_source = items_count - 1 - window.items_manager.artboards.index (artboard.model);
+
+            // Interrupt if item position doesn't exist.
+            if (pos_source == -1) {
+                return;
+            }
+
+            // z-index is the exact opposite of items placement as the last item
+            // is the topmost element. Because of this, we need some trickery to
+            // properly handle the list's order.
+            source = items_count - 1 - pos_source;
+
+            // Interrupt if the item was dropped in the same position.
+            if (source == 0) {
+                debug ("same position");
+                return;
+            }
+
+            // Remove item at source position.
+            var artboard_to_swap = window.items_manager.artboards.remove_at (source);
+
+            // Insert item at target position.
+            window.items_manager.artboards.insert_at (0, artboard_to_swap);
+            window.event_bus.z_selected_changed ();
+
+            return;
+        }
+
         var layer = (Akira.Layouts.Partials.Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
-        var artboard = layer.model.artboard;
+        var layer_artboard = layer.model.artboard;
 
         // Change artboard if necessary.
         window.items_manager.change_artboard (layer.model, null);
 
         // If the moved layer had an artboard, no need to do anything else.
-        if (artboard != null) {
+        if (layer_artboard != null) {
             return;
         }
 
-        var items_count = (int) window.items_manager.free_items.get_n_items ();
-        var pos_source = items_count - 1 - window.items_manager.free_items.index (layer.model);
+        items_count = (int) window.items_manager.free_items.get_n_items ();
+        pos_source = items_count - 1 - window.items_manager.free_items.index (layer.model);
 
         // Interrupt if item position doesn't exist.
         if (pos_source == -1) {
@@ -178,7 +214,7 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         // z-index is the exact opposite of items placement as the last item
         // is the topmost element. Because of this, we need some trickery to
         // properly handle the list's order.
-        var source = items_count - 1 - pos_source;
+        source = items_count - 1 - pos_source;
 
         // Interrupt if the item was dropped in the same position.
         if (source == 0) {

--- a/src/Layouts/RightSideBar.vala
+++ b/src/Layouts/RightSideBar.vala
@@ -40,7 +40,6 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
     private Gtk.Revealer motion_revealer;
 
     private const Gtk.TargetEntry TARGET_ENTRIES[] = {
-        { "ARTBOARD", Gtk.TargetFlags.SAME_APP, 0 },
         { "LAYER", Gtk.TargetFlags.SAME_APP, 0 }
     };
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -557,6 +557,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         if (artboard == null & !(item is Models.CanvasArtboard)) {
             item.lower (null);
         }
+
+        // Reset the loaded attribute to prevent sorting issues inside artboards.
+        item.loaded = false;
     }
 
     /**

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -628,6 +628,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     public void change_artboard (Models.CanvasItem item, Models.CanvasArtboard? new_artboard) {
         // Interrupt if the item was moved within its original artboard.
         if (item.artboard == new_artboard) {
+            debug ("Same parent");
             return;
         }
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Complete the drag and drop implementations of the Layers Panel.

## Screenshots 
![drag-drop](https://user-images.githubusercontent.com/2527103/86548948-0c3ee400-bef3-11ea-9e67-3ad7907c45b7.gif)

## This PR fixes/implements the following **bugs/features**:
- [x] Fix wrong order when dropping a layer from bottom to top
- [x] Fix free items not reordering in the canvas
- [x] Enable drop layer on top of Artboard layer
- [x] Enable drop layer on top of the search field
- [x] Enable drop layer on empty layers panel 
- [x] Enable sorting of Artboards
