### PR TITLE
Move the delete action to the Action Manager

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -142,10 +142,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 export_manager.clear ();
                 break;
 
-            case Gdk.Key.Delete:
-                selected_bound_manager.delete_selection ();
-                break;
-
             case Gdk.Key.space:
                 if (edit_mode != EditMode.MODE_PANNING) {
                     edit_mode = EditMode.MODE_PAN;

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -138,6 +138,8 @@ public class Akira.Services.ActionManager : Object {
         typing_accelerators.set (ACTION_ELLIPSE_TOOL, "e");
         typing_accelerators.set (ACTION_TEXT_TOOL, "t");
         typing_accelerators.set (ACTION_IMAGE_TOOL, "i");
+        typing_accelerators.set (ACTION_DELETE, "Delete");
+        typing_accelerators.set (ACTION_DELETE, "BackSpace");
     }
 
     construct {
@@ -326,7 +328,10 @@ public class Akira.Services.ActionManager : Object {
         window.event_bus.insert_item ("rectangle");
     }
 
-    private void action_delete () {}
+    // Delete the currently selected items.
+    private void action_delete () {
+        window.main_window.main_canvas.canvas.selected_bound_manager.delete_selection ();
+    }
 
     private void action_flip_h () {
         window.event_bus.flip_item (true);


### PR DESCRIPTION
Hitting `Delete` or `BackSpace` should work from anywhere, not just when the Canvas is focused.
Enable the delete action in the Action Manager to allow delete items from the Layers Panel.
This actions is disabled when the focus moves into an entry widget.