### PR TITLE
Use the GDK_EXCHANGE cursor for rotate nob

### DIFF
--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -164,7 +164,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
                 selected_cursor = Gdk.CursorType.LEFT_SIDE;
                 break;
             case Managers.NobManager.Nob.ROTATE:
-                selected_cursor = Gdk.CursorType.ICON;
+                selected_cursor = Gdk.CursorType.EXCHANGE;
                 break;
         }
 


### PR DESCRIPTION
Use the `Gdk.CursorType.EXCHANGE` for the rotate Nob.
Not the most beautiful cursor but at least it looks accurate and it's DE native.

- Fixes #161
