### PR TITLE
Properly lock size ratio of images on import

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -180,6 +180,9 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
 
         window.event_bus.selected_items_changed.connect (on_selected_items_changed);
         window.event_bus.item_coord_changed.connect (on_item_coord_changed);
+        window.event_bus.lock_ratio.connect (() => {
+            lock_changes.active = true;
+        });
     }
 
     private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -123,8 +123,7 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
             try {
                 original_pixbuf = manager.get_pixbuf.end (res);
                 // Imported images should keep their aspect ratio by default.
-                size_ratio = original_pixbuf.get_width () / original_pixbuf.get_height ();
-                size_locked = true;
+                canvas.window.event_bus.lock_ratio ();
             } catch (Error e) {
                 warning (e.message);
                 canvas.window.event_bus.canvas_notification (e.message);

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -54,6 +54,7 @@ public class Akira.Services.EventBus : Object {
     public signal void fill_deleted ();
     public signal void item_coord_changed ();
     public signal void item_value_changed ();
+    public signal void lock_ratio ();
 
     // Item signals.
     public signal void change_z_selected (bool raise, bool total);


### PR DESCRIPTION
Super tiny PR to fix the set of the locked ratio when importing images.
I was trying to do it manually when loading the image, but since the transform panel has that method already, it's better to simply trigger it via an event after the image has been loaded.

- Fixes #341
