### PR TITLE
Fix items translation with mouse

### DIFF
--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -492,7 +492,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         item.set ("size-locked", obj.get_boolean_member ("size-locked"));
         item.set ("size-ratio", obj.get_double_member ("size-ratio"));
         item.set ("rotation", obj.get_double_member ("rotation"));
-        // Utils.AffineTransform.set_rotation (obj.get_double_member ("rotation"), item);
         item.set ("flipped-h", obj.get_boolean_member ("flipped-h"));
         item.set ("flipped-v", obj.get_boolean_member ("flipped-v"));
         item.set ("opacity", obj.get_double_member ("opacity"));
@@ -543,10 +542,23 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         item.set ("initial-relative-x", obj.get_double_member ("initial-relative-x"));
         item.set ("initial-relative-y", obj.get_double_member ("initial-relative-y"));
 
+        Cairo.Matrix matrix;
+        item.get_transform (out matrix);
+        var transform = obj.get_member ("transform").get_object ();
+
+        var new_matrix = Cairo.Matrix (
+            transform.get_double_member ("xx"),
+            transform.get_double_member ("yx"),
+            transform.get_double_member ("xy"),
+            transform.get_double_member ("yy"),
+            transform.get_double_member ("x0"),
+            transform.get_double_member ("y0")
+        );
+        item.set_transform (new_matrix);
+
         // If the item is an Artboard, we need to restore bounding coordinates otherwise
         // new child items won't be properly restored into it.
         if (item is Models.CanvasArtboard) {
-            var transform = obj.get_member ("transform").get_object ();
             item.bounds.x1 = transform.get_double_member ("x0");
             item.bounds.y1 = transform.get_double_member ("y0");
             item.bounds.x2 = transform.get_double_member ("x0") + obj.get_double_member ("width");

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -546,6 +546,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         item.get_transform (out matrix);
         var transform = obj.get_member ("transform").get_object ();
 
+        // Apply the Cairo Matrix to properly update position and rotation.
         var new_matrix = Cairo.Matrix (
             transform.get_double_member ("xx"),
             transform.get_double_member ("yx"),

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -492,6 +492,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         item.set ("size-locked", obj.get_boolean_member ("size-locked"));
         item.set ("size-ratio", obj.get_double_member ("size-ratio"));
         item.set ("rotation", obj.get_double_member ("rotation"));
+        // Utils.AffineTransform.set_rotation (obj.get_double_member ("rotation"), item);
         item.set ("flipped-h", obj.get_boolean_member ("flipped-h"));
         item.set ("flipped-v", obj.get_boolean_member ("flipped-v"));
         item.set ("opacity", obj.get_double_member ("opacity"));

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -97,10 +97,10 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         switch (selected_nob) {
             case Managers.NobManager.Nob.NONE:
                 Utils.AffineTransform.move_from_event (
+                    selected_item,
                     event_x, event_y,
                     ref initial_event_x, ref initial_event_y,
-                    ref delta_x_accumulator, ref delta_y_accumulator,
-                    selected_item
+                    ref delta_x_accumulator, ref delta_y_accumulator
                 );
                 update_selected_items ();
                 break;

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -97,10 +97,8 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         switch (selected_nob) {
             case Managers.NobManager.Nob.NONE:
                 Utils.AffineTransform.move_from_event (
-                    selected_item,
-                    event_x, event_y,
-                    ref initial_event_x, ref initial_event_y,
-                    ref delta_x_accumulator, ref delta_y_accumulator
+                    selected_item, event_x, event_y,
+                    ref initial_event_x, ref initial_event_y
                 );
                 update_selected_items ();
                 break;

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -105,9 +105,9 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
             case Managers.NobManager.Nob.ROTATE:
                 Utils.AffineTransform.rotate_from_event (
+                    selected_item,
                     event_x, event_y,
-                    initial_event_x, initial_event_y,
-                    selected_item
+                    initial_event_x, initial_event_y
                 );
                 break;
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -74,6 +74,9 @@ public class Akira.Utils.AffineTransform : Object {
         item.set_transform (new_matrix);
     }
 
+    /**
+     * Move the item based on the mouse click and drag event.
+     */
     public static void move_from_event (
         CanvasItem item,
         double event_x,

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -79,9 +79,7 @@ public class Akira.Utils.AffineTransform : Object {
         double event_x,
         double event_y,
         ref double initial_event_x,
-        ref double initial_event_y,
-        ref double delta_x_accumulator,
-        ref double delta_y_accumulator
+        ref double initial_event_y
     ) {
         Cairo.Matrix matrix;
 
@@ -104,9 +102,6 @@ public class Akira.Utils.AffineTransform : Object {
             );
             item.set_transform (new_matrix);
         }
-
-        delta_x_accumulator += delta_x;
-        delta_y_accumulator += delta_y;
 
         initial_event_x = event_x;
         initial_event_y = event_y;


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
This PR fixes the translation of items with a mouse drag, handling items with artboards, and fixing the movement when an item is rotate.

This is related to PR #322, which focuses on the items rotation and scaling.

## This PR fixes/implements the following **bugs/features**:
- [x] Fix item translation when rotated.
- [x] Fix item translation inside artboard.
- [x] Fix item not remembering the rotation on load if outside artboard.
