### PR TITLE
Improve the Image Import workflow

### DIFF
--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -80,6 +80,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         (new_item as Models.CanvasImage).resize_pixbuf (-1, -1, true);
 
         selected_bound_manager.add_item_to_selection (new_item);
+
+        // Imported images should keep their aspect ratio by default.
+        window.event_bus.lock_ratio ();
         selected_bound_manager.set_initial_coordinates (start_x, start_y);
     }
 

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -122,8 +122,6 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
         manager.get_pixbuf.begin (-1, -1, (obj, res) => {
             try {
                 original_pixbuf = manager.get_pixbuf.end (res);
-                // Imported images should keep their aspect ratio by default.
-                canvas.window.event_bus.lock_ratio ();
             } catch (Error e) {
                 warning (e.message);
                 canvas.window.event_bus.canvas_notification (e.message);

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -358,11 +358,10 @@ public class Akira.Services.ActionManager : Object {
     private void action_image_tool () {
         dialog = new Gtk.FileChooserNative (
             _("Choose image file"), window, Gtk.FileChooserAction.OPEN, _("Select"), _("Close"));
-        dialog.set_current_folder (settings.export_folder);
 
-        preview_image = new Gtk.Image();
+        preview_image = new Gtk.Image ();
         dialog.preview_widget = preview_image;
-        dialog.update_preview.connect(on_update_preview);
+        dialog.update_preview.connect (on_update_preview);
 
         dialog.select_multiple = true;
 
@@ -425,13 +424,6 @@ public class Akira.Services.ActionManager : Object {
             case Gtk.ResponseType.OK:
                 SList<File> files = dialog.get_files ();
                 files.@foreach ((file) => {
-                    // try {
-                    //     debug ("set folder");
-                    //     dialog.set_current_folder_file (file);
-                    // } catch (Error e) {
-                    //     warning (e.message);
-                    // }
-
                     if (!Akira.Utils.Image.is_valid_image (file)) {
                         window.event_bus.canvas_notification (
                             _("Error! .%s files are not supported!"
@@ -444,6 +436,7 @@ public class Akira.Services.ActionManager : Object {
                 });
                 break;
         }
+        dialog.destroy();
     }
 
     private void action_escape () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -436,7 +436,7 @@ public class Akira.Services.ActionManager : Object {
                 });
                 break;
         }
-        dialog.destroy();
+        dialog.destroy ();
     }
 
     private void action_escape () {


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Improve the image import experience by leveraging more built in methods of the `Gtk.FileChooser`

## Known Issues / Things To Do
- The recently opened folder is not properly set. Related to #279

## This PR fixes/implements the following **bugs/features**:
- [x] Properly lock the size ratio after every image import.
- [x] Create a widget preview for images.
- [x] Remember the last opened folder.

### Fixes
- Fixes #279