### PR TITLE
Improve the size lock and ratio of newly imported images

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -180,9 +180,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
 
         window.event_bus.selected_items_changed.connect (on_selected_items_changed);
         window.event_bus.item_coord_changed.connect (on_item_coord_changed);
-        window.event_bus.lock_ratio.connect (() => {
-            lock_changes.active = true;
-        });
     }
 
     private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {
@@ -252,7 +249,9 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
                 var icon = val.get_boolean () ? "changes-prevent-symbolic" : "changes-allow-symbolic";
                 lock_changes.image = new Gtk.Image.from_icon_name (icon, Gtk.IconSize.BUTTON);
                 res = val.get_boolean ();
-                update_size_ratio ();
+                if (val.get_boolean ()) {
+                    update_size_ratio ();
+                }
                 return true;
             });
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -77,12 +77,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
 
         set_item_to_insert ("image");
         var new_item = insert_item (start_x, start_y, manager);
-        (new_item as Models.CanvasImage).resize_pixbuf (-1, -1, true);
 
         selected_bound_manager.add_item_to_selection (new_item);
-
-        // Imported images should keep their aspect ratio by default.
-        window.event_bus.lock_ratio ();
         selected_bound_manager.set_initial_coordinates (start_x, start_y);
     }
 

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -122,6 +122,13 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
         manager.get_pixbuf.begin (-1, -1, (obj, res) => {
             try {
                 original_pixbuf = manager.get_pixbuf.end (res);
+                pixbuf = original_pixbuf;
+                width = original_pixbuf.get_width ();
+                height = original_pixbuf.get_height ();
+
+                // Imported images should have their size ratio locked by default.
+                size_locked = true;
+                size_ratio = width / height;
             } catch (Error e) {
                 warning (e.message);
                 canvas.window.event_bus.canvas_notification (e.message);

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -54,7 +54,6 @@ public class Akira.Services.EventBus : Object {
     public signal void fill_deleted ();
     public signal void item_coord_changed ();
     public signal void item_value_changed ();
-    public signal void lock_ratio ();
 
     // Item signals.
     public signal void change_z_selected (bool raise, bool total);


### PR DESCRIPTION
A super tiny PR to improve how we handle newly imported images.
Instead of triggering an event and trying to set the size lock through the transform panel, we should let the CanvasItem itself determine that upon creation, in order to avoid issues in case the image is pretty big and the Pixbuf generation takes too much.
