### PR TITLE
Improve resize event

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -363,7 +363,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         if (height.value == 0) {
             return;
         }
-        selected_item.size_ratio = width.value / height.value;
+        selected_item.update_size_ratio ();
     }
 
     private Gtk.Label group_title (string title) {

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -122,7 +122,7 @@ public class Akira.Lib.Managers.ExportManager : Object {
         area.translate (origin_move_delta_x, origin_move_delta_y);
         canvas.convert_to_item_space (area, ref initial_x, ref initial_y);
 
-        Utils.AffineTransform.set_size (new_width, new_height, area);
+        Utils.AffineTransform.set_size (area, new_width, new_height);
     }
 
     public void clear () {

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -83,46 +83,59 @@ public class Akira.Lib.Managers.ExportManager : Object {
     }
 
     public void resize_area (double x, double y) {
-        canvas.convert_to_item_space (area, ref x, ref y);
+        double area_width = area.width;
+        double area_height = area.height;
+        double area_x = area.x;
+        double area_y = area.y;
 
         double delta_x = x - initial_x;
         double delta_y = y - initial_y;
 
-        double item_width = area.width;
-        double item_height = area.height;
+        double new_width = delta_x;
+        double new_height = delta_y;
 
-        double new_width = item_width;
-        double new_height = item_height;
+        // Width size constraints.
+        if (Utils.AffineTransform.fix_size (x) < area_x && area_width != 1) {
+            // If the mouse event goes beyond the available width of the area
+            // super quickly, collapse the size to 1 and maintain the position.
+            new_width = -area_width + 1;
+        } else if (Utils.AffineTransform.fix_size (x) < area_x) {
+            // If the user keeps moving the mouse beyond the available width of the area
+            // prevent any size changes.
+            new_width = 0;
+        } else if (area_width == 1 && delta_x <= 0) {
+            // Don't update the size or position if the delta keeps increasing,
+            // meaning the user is still moving left.
+            new_width = 0;
+        }
 
-        double origin_move_delta_x = 0.0;
-        double origin_move_delta_y = 0.0;
+        // Height size constraints.
+        if (Utils.AffineTransform.fix_size (y) < area_y && area_height != 1) {
+            // If the mouse event goes beyond the available height of the area
+            // super quickly, collapse the size to 1 and maintain the position.
+            new_height = -area_height + 1;
+        } else if (Utils.AffineTransform.fix_size (y) < area_y) {
+            // If the user keeps moving the mouse beyond the available height of the area
+            // prevent any size changes.
+            new_height = 0;
+        } else if (area_height == 1 && delta_y <= 0) {
+            // Don't update the size or position if the delta keeps increasing,
+            // meaning the user is still moving down.
+            new_height = 0;
+        }
 
-        new_width = initial_width + delta_x;
-        new_height = initial_height + delta_y;
-        if (canvas.ctrl_is_pressed && new_height > MIN_SIZE) {
+        if (canvas.ctrl_is_pressed) {
             new_height = new_width;
+            if (area_width != area_height) {
+                new_height = area_width - area_height;
+            }
         }
-
-        if (new_width < initial_width) {
-            new_width = initial_width - delta_x;
-            origin_move_delta_x = item_width - new_width;
-        }
-
-        if (new_height < MIN_SIZE) {
-            new_height = initial_height - delta_y;
-            origin_move_delta_y = item_height - new_height;
-        }
-
-        new_width = Utils.AffineTransform.fix_size (new_width);
-        new_height = Utils.AffineTransform.fix_size (new_height);
-        origin_move_delta_x = Utils.AffineTransform.fix_size (origin_move_delta_x);
-        origin_move_delta_y = Utils.AffineTransform.fix_size (origin_move_delta_y);
-
-        canvas.convert_from_item_space (area, ref initial_x, ref initial_y);
-        area.translate (origin_move_delta_x, origin_move_delta_y);
-        canvas.convert_to_item_space (area, ref initial_x, ref initial_y);
 
         Utils.AffineTransform.set_size (area, new_width, new_height);
+
+        // Update the initial coordiante to keep getting the correct delta.
+        initial_x = x;
+        initial_y = y;
     }
 
     public void clear () {

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -608,6 +608,14 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             }
         }
 
+        // Update the size ratio to always be faithful to the udpated size.
+        foreach (var item in items) {
+            if (item is Models.CanvasArtboard) {
+                continue;
+            }
+            item.update_size_ratio ();
+        }
+
         // Interrupt if no artboard is currently present.
         if (artboards.get_n_items () == 0) {
             return;

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -142,6 +142,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         }
 
         item.selected = true;
+        item.update_size_ratio ();
         selected_items.append (item);
 
         // Move focus back to the canvas.

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -113,12 +113,12 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
             default:
                 Utils.AffineTransform.scale_from_event (
+                    selected_item,
+                    selected_nob,
                     event_x, event_y,
                     ref initial_event_x, ref initial_event_y,
                     ref delta_x_accumulator, ref delta_y_accumulator,
-                    initial_width, initial_height,
-                    selected_nob,
-                    selected_item
+                    initial_width, initial_height
                 );
                 break;
         }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -344,9 +344,8 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         return false;
     }
 
-    // Update the size ratio to respect the udpated size.
+    // Update the size ratio to respect the updated size.
     public void update_size_ratio () {
-        debug ("update");
         size_ratio = get_coords ("width") / get_coords ("height");
     }
 }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -343,4 +343,10 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
 
         return false;
     }
+
+    // Update the size ratio to respect the udpated size.
+    public void update_size_ratio () {
+        debug ("update");
+        size_ratio = get_coords ("width") / get_coords ("height");
+    }
 }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -122,6 +122,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         item.set ("stroke-alpha", 255);
 
         var canvas_item = item as Models.CanvasItem;
+        canvas_item.size_ratio = 1.0;
 
         // Populate the name with the item's id
         // to show it when added to the LayersPanel

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -180,22 +180,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         }
     }
 
-    // public virtual void move (
-    //     double delta_x, double delta_y,
-    //     double delta_x_accumulator = 0.0, double delta_y_accumulator = 0.0) {
-
-    //     if (artboard != null) {
-    //         var transformed_delta_x = delta_x_accumulator;
-    //         var transformed_delta_y = delta_y_accumulator;
-
-    //         relative_x = initial_relative_x + transformed_delta_x;
-    //         relative_y = initial_relative_y + transformed_delta_y;
-
-    //         return;
-    //     }
-
-    //     translate (delta_x, delta_y);
-    // }
     public virtual void move (double x, double y) {
         if (artboard != null) {
             relative_x += x;

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -179,21 +179,30 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         }
     }
 
-    public virtual void move (
-        double delta_x, double delta_y,
-        double delta_x_accumulator = 0.0, double delta_y_accumulator = 0.0) {
+    // public virtual void move (
+    //     double delta_x, double delta_y,
+    //     double delta_x_accumulator = 0.0, double delta_y_accumulator = 0.0) {
 
+    //     if (artboard != null) {
+    //         var transformed_delta_x = delta_x_accumulator;
+    //         var transformed_delta_y = delta_y_accumulator;
+
+    //         relative_x = initial_relative_x + transformed_delta_x;
+    //         relative_y = initial_relative_y + transformed_delta_y;
+
+    //         return;
+    //     }
+
+    //     translate (delta_x, delta_y);
+    // }
+    public virtual void move (double x, double y) {
         if (artboard != null) {
-            var transformed_delta_x = delta_x_accumulator;
-            var transformed_delta_y = delta_y_accumulator;
-
-            relative_x = initial_relative_x + transformed_delta_x;
-            relative_y = initial_relative_y + transformed_delta_y;
-
+            relative_x += x;
+            relative_y += y;
             return;
         }
 
-        translate (delta_x, delta_y);
+        translate (x, y);
     }
 
     public virtual Cairo.Matrix get_real_transform () {
@@ -222,23 +231,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         transform.translate (- (width / 2), - (height / 2));
 
         return transform;
-    }
-
-    public virtual double get_real_coord (string coord_id) {
-        var offset_x = artboard == null ? 0 : relative_x;
-        var offset_y = artboard == null ? 0 : relative_y;
-
-        var item_x = get_coords ("x") - offset_x;
-        var item_y = get_coords ("y") - offset_y;
-
-        switch (coord_id) {
-            case "x":
-                return item_x;
-            case "y":
-                return item_y;
-            default:
-                return 0.0;
-        }
     }
 
     public virtual double get_global_coord (string coord_id) {

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -127,9 +127,9 @@ public class Akira.Utils.AffineTransform : Object {
 
         var canvas = item.canvas;
 
-        // double item_width = item.get_coords ("width");
+        double item_width = item.get_coords ("width");
         double item_height = item.get_coords ("height");
-        // double item_x = item.get_global_coord ("x");
+        double item_x = item.get_global_coord ("x");
         double item_y = item.get_global_coord ("y");
 
         double new_width = 0;
@@ -196,27 +196,27 @@ public class Akira.Utils.AffineTransform : Object {
 
             case NobManager.Nob.RIGHT_CENTER:
                 new_width = delta_x;
-                // new_width = item_x - event_x;
 
-                // if (canvas.ctrl_is_pressed || item.size_locked) {
-                //     new_height = GLib.Math.round (new_width / item.size_ratio);
-                // }
+                if (canvas.ctrl_is_pressed || item.size_locked) {
+                    new_height = new_width / item.size_ratio;
+                }
                 break;
 
             case NobManager.Nob.BOTTOM_RIGHT:
                 new_width = delta_x;
                 new_height = delta_y;
-                // if (canvas.ctrl_is_pressed || item.size_locked) {
-                //     new_height = GLib.Math.round (new_width / item.size_ratio);
-                // }
+
+                if (canvas.ctrl_is_pressed || item.size_locked) {
+                    new_height = new_width / item.size_ratio;
+                }
                 break;
 
             case NobManager.Nob.BOTTOM_CENTER:
-                // new_height = initial_height + delta_y;
                 new_height = delta_y;
-                // if (canvas.ctrl_is_pressed || item.size_locked) {
-                //     new_width = GLib.Math.round (new_height * item.size_ratio);
-                // }
+
+                if (canvas.ctrl_is_pressed || item.size_locked) {
+                    new_width = new_height * item.size_ratio;
+                }
                 break;
 
             case NobManager.Nob.BOTTOM_LEFT:
@@ -244,6 +244,29 @@ public class Akira.Utils.AffineTransform : Object {
                 // if (new_width >= MIN_SIZE) {
                 //     origin_move_delta_x = item_width - new_width;
                 // }
+                new_x = delta_x;
+                new_width = -delta_x;
+
+                if (fix_size (event_x) > item_x + item_width && item_width != 1) {
+                    // If the mouse event goes beyond the available width of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_x = item_width - 1;
+                    new_width = -item_width + 1;
+                } else if (fix_size (event_x) > item_x + item_width) {
+                    // If the user keeps mouving the mouse beyond the available width of the item
+                    // prevent any size changes.
+                    new_x = 0;
+                    new_width = 0;
+                } else if (item_width == 1 && delta_x >= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving down.
+                    new_x = 0;
+                    new_width = 0;
+                }
+
+                if (canvas.ctrl_is_pressed || item.size_locked) {
+                    new_height = new_width * item.size_ratio;
+                }
                 break;
         }
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -139,21 +139,48 @@ public class Akira.Utils.AffineTransform : Object {
 
         switch (nob) {
             case NobManager.Nob.TOP_LEFT:
-                // new_height = initial_height - delta_y;
-                // new_width = initial_width - delta_x;
-                // new_height = initial_height - delta_y;
-                // new_width = initial_width - delta_x;
-                // if (canvas.ctrl_is_pressed || item.size_locked) {
-                //     new_width = GLib.Math.round (new_height * item.size_ratio);
-                // }
+                new_y = delta_y;
+                new_x = delta_x;
+                new_height = -delta_y;
+                new_width = -delta_x;
 
-                // if (item_height > MIN_SIZE) {
-                //     origin_move_delta_y = item_height - new_height;
-                // }
+                if (fix_size (event_y) > item_y + item_height && item_height != 1) {
+                    // If the mouse event goes beyond the available height of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_y = item_height - 1;
+                    new_height = -item_height + 1;
+                } else if (fix_size (event_y) > item_y + item_height) {
+                    // If the user keeps moving the mouse beyond the available height of the item
+                    // prevent any size changes.
+                    new_y = 0;
+                    new_height = 0;
+                } else if (item_height == 1 && delta_y >= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving down.
+                    new_y = 0;
+                    new_height = 0;
+                }
 
-                // if (item_width > MIN_SIZE) {
-                //     origin_move_delta_x = item_width - new_width;
-                // }
+                if (fix_size (event_x) > item_x + item_width && item_width != 1) {
+                    // If the mouse event goes beyond the available width of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_x = item_width - 1;
+                    new_width = -item_width + 1;
+                } else if (fix_size (event_x) > item_x + item_width) {
+                    // If the user keeps moving the mouse beyond the available width of the item
+                    // prevent any size changes.
+                    new_x = 0;
+                    new_width = 0;
+                } else if (item_width == 1 && delta_x >= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving right.
+                    new_x = 0;
+                    new_width = 0;
+                }
+
+                if (canvas.ctrl_is_pressed || item.size_locked) {
+                    new_width = new_height * item.size_ratio;
+                }
                 break;
 
             case NobManager.Nob.TOP_CENTER:
@@ -166,7 +193,7 @@ public class Akira.Utils.AffineTransform : Object {
                     new_y = item_height - 1;
                     new_height = -item_height + 1;
                 } else if (fix_size (event_y) > item_y + item_height) {
-                    // If the user keeps mouving the mouse beyond the available height of the item
+                    // If the user keeps moving the mouse beyond the available height of the item
                     // prevent any size changes.
                     new_y = 0;
                     new_height = 0;
@@ -183,15 +210,30 @@ public class Akira.Utils.AffineTransform : Object {
                 break;
 
             case NobManager.Nob.TOP_RIGHT:
-                // new_width = initial_width + delta_x;
-                // new_height = initial_height - delta_y;
-                // if (canvas.ctrl_is_pressed || item.size_locked) {
-                //     new_height = GLib.Math.round (new_width / item.size_ratio);
-                // }
+                new_y = delta_y;
+                new_height = -delta_y;
+                new_width = delta_x;
 
-                // if (item_height > MIN_SIZE) {
-                //     origin_move_delta_y = item_height - new_height;
-                // }
+                if (fix_size (event_y) > item_y + item_height && item_height != 1) {
+                    // If the mouse event goes beyond the available height of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_y = item_height - 1;
+                    new_height = -item_height + 1;
+                } else if (fix_size (event_y) > item_y + item_height) {
+                    // If the user keeps moving the mouse beyond the available height of the item
+                    // prevent any size changes.
+                    new_y = 0;
+                    new_height = 0;
+                } else if (item_height == 1 && delta_y >= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving down.
+                    new_y = 0;
+                    new_height = 0;
+                }
+
+                if (canvas.ctrl_is_pressed || item.size_locked) {
+                    new_height = new_width / item.size_ratio;
+                }
                 break;
 
             case NobManager.Nob.RIGHT_CENTER:
@@ -208,6 +250,9 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width / item.size_ratio;
+                    if (item.size_ratio == 1 && item_width != item_height) {
+                        new_height = item_width - item_height;
+                    }
                 }
                 break;
 
@@ -220,30 +265,33 @@ public class Akira.Utils.AffineTransform : Object {
                 break;
 
             case NobManager.Nob.BOTTOM_LEFT:
-                // new_height = initial_height + delta_y;
-                // new_width = initial_width - delta_x;
+                new_x = delta_x;
+                new_width = -delta_x;
                 new_height = delta_y;
-                // new_width = initial_width - delta_x;
-                // if (canvas.ctrl_is_pressed || item.size_locked) {
-                //     new_width = GLib.Math.round (new_height * item.size_ratio);
-                // }
 
-                // if (item_width > MIN_SIZE) {
-                //     origin_move_delta_x = item_width - new_width;
-                // }
+                if (fix_size (event_x) > item_x + item_width && item_width != 1) {
+                    // If the mouse event goes beyond the available width of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_x = item_width - 1;
+                    new_width = -item_width + 1;
+                } else if (fix_size (event_x) > item_x + item_width) {
+                    // If the user keeps moving the mouse beyond the available width of the item
+                    // prevent any size changes.
+                    new_x = 0;
+                    new_width = 0;
+                } else if (item_width == 1 && delta_x >= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving right.
+                    new_x = 0;
+                    new_width = 0;
+                }
+
+                if (canvas.ctrl_is_pressed || item.size_locked) {
+                    new_width = new_height * item.size_ratio;
+                }
                 break;
 
             case NobManager.Nob.LEFT_CENTER:
-                // debug ((initial_event_x - event_x).to_string ());
-                // origin_move_delta_x = x - delta_x;
-                // new_width = initial_width - delta_x;
-                // if (canvas.ctrl_is_pressed || item.size_locked) {
-                //     new_height = GLib.Math.round (new_width / item.size_ratio);
-                // }
-
-                // if (new_width >= MIN_SIZE) {
-                //     origin_move_delta_x = item_width - new_width;
-                // }
                 new_x = delta_x;
                 new_width = -delta_x;
 
@@ -253,13 +301,13 @@ public class Akira.Utils.AffineTransform : Object {
                     new_x = item_width - 1;
                     new_width = -item_width + 1;
                 } else if (fix_size (event_x) > item_x + item_width) {
-                    // If the user keeps mouving the mouse beyond the available width of the item
+                    // If the user keeps moving the mouse beyond the available width of the item
                     // prevent any size changes.
                     new_x = 0;
                     new_width = 0;
                 } else if (item_width == 1 && delta_x >= 0) {
                     // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving down.
+                    // meaning the user is still moving right.
                     new_x = 0;
                     new_width = 0;
                 }
@@ -270,6 +318,7 @@ public class Akira.Utils.AffineTransform : Object {
                 break;
         }
 
+        // Update the initial coordiante to keep getting the correct delta.
         initial_event_x = event_x;
         initial_event_y = event_y;
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -259,6 +259,20 @@ public class Akira.Utils.AffineTransform : Object {
             case NobManager.Nob.BOTTOM_CENTER:
                 new_height = delta_y;
 
+                if (fix_size (event_y) < item_y && item_height != 1) {
+                    // If the mouse event goes beyond the available height of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_height = -item_height + 1;
+                } else if (fix_size (event_y) < item_y) {
+                    // If the user keeps moving the mouse beyond the available height of the item
+                    // prevent any size changes.
+                    new_height = 0;
+                } else if (item_height == 1 && delta_y <= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving down.
+                    new_height = 0;
+                }
+
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
                 }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -144,6 +144,7 @@ public class Akira.Utils.AffineTransform : Object {
                 new_height = -delta_y;
                 new_width = -delta_x;
 
+                // Height size constraints.
                 if (fix_size (event_y) > item_y + item_height && item_height != 1) {
                     // If the mouse event goes beyond the available height of the item
                     // super quickly, collapse the size to 1 and maintain the position.
@@ -161,6 +162,7 @@ public class Akira.Utils.AffineTransform : Object {
                     new_height = 0;
                 }
 
+                // Width size constraints.
                 if (fix_size (event_x) > item_x + item_width && item_width != 1) {
                     // If the mouse event goes beyond the available width of the item
                     // super quickly, collapse the size to 1 and maintain the position.
@@ -187,6 +189,7 @@ public class Akira.Utils.AffineTransform : Object {
                 new_y = delta_y;
                 new_height = -delta_y;
 
+                // Height size constraints.
                 if (fix_size (event_y) > item_y + item_height && item_height != 1) {
                     // If the mouse event goes beyond the available height of the item
                     // super quickly, collapse the size to 1 and maintain the position.
@@ -214,6 +217,7 @@ public class Akira.Utils.AffineTransform : Object {
                 new_height = -delta_y;
                 new_width = delta_x;
 
+                // Height size constraints.
                 if (fix_size (event_y) > item_y + item_height && item_height != 1) {
                     // If the mouse event goes beyond the available height of the item
                     // super quickly, collapse the size to 1 and maintain the position.
@@ -231,6 +235,21 @@ public class Akira.Utils.AffineTransform : Object {
                     new_height = 0;
                 }
 
+                // Width size constraints.
+                if (fix_size (event_x) < item_x && item_width != 1) {
+                    // If the mouse event goes beyond the available width of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_width = -item_width + 1;
+                } else if (fix_size (event_x) < item_x) {
+                    // If the user keeps moving the mouse beyond the available width of the item
+                    // prevent any size changes.
+                    new_width = 0;
+                } else if (item_width == 1 && delta_x <= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving left.
+                    new_width = 0;
+                }
+
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width / item.size_ratio;
                 }
@@ -238,6 +257,21 @@ public class Akira.Utils.AffineTransform : Object {
 
             case NobManager.Nob.RIGHT_CENTER:
                 new_width = delta_x;
+
+                // Width size constraints.
+                if (fix_size (event_x) < item_x && item_width != 1) {
+                    // If the mouse event goes beyond the available width of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_width = -item_width + 1;
+                } else if (fix_size (event_x) < item_x) {
+                    // If the user keeps moving the mouse beyond the available width of the item
+                    // prevent any size changes.
+                    new_width = 0;
+                } else if (item_width == 1 && delta_x <= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving left.
+                    new_width = 0;
+                }
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width / item.size_ratio;
@@ -247,6 +281,36 @@ public class Akira.Utils.AffineTransform : Object {
             case NobManager.Nob.BOTTOM_RIGHT:
                 new_width = delta_x;
                 new_height = delta_y;
+
+                // Width size constraints.
+                if (fix_size (event_x) < item_x && item_width != 1) {
+                    // If the mouse event goes beyond the available width of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_width = -item_width + 1;
+                } else if (fix_size (event_x) < item_x) {
+                    // If the user keeps moving the mouse beyond the available width of the item
+                    // prevent any size changes.
+                    new_width = 0;
+                } else if (item_width == 1 && delta_x <= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving left.
+                    new_width = 0;
+                }
+
+                // Height size constraints.
+                if (fix_size (event_y) < item_y && item_height != 1) {
+                    // If the mouse event goes beyond the available height of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_height = -item_height + 1;
+                } else if (fix_size (event_y) < item_y) {
+                    // If the user keeps moving the mouse beyond the available height of the item
+                    // prevent any size changes.
+                    new_height = 0;
+                } else if (item_height == 1 && delta_y <= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving down.
+                    new_height = 0;
+                }
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width / item.size_ratio;
@@ -259,6 +323,7 @@ public class Akira.Utils.AffineTransform : Object {
             case NobManager.Nob.BOTTOM_CENTER:
                 new_height = delta_y;
 
+                // Height size constraints.
                 if (fix_size (event_y) < item_y && item_height != 1) {
                     // If the mouse event goes beyond the available height of the item
                     // super quickly, collapse the size to 1 and maintain the position.
@@ -283,6 +348,7 @@ public class Akira.Utils.AffineTransform : Object {
                 new_width = -delta_x;
                 new_height = delta_y;
 
+                // Width size contraints.
                 if (fix_size (event_x) > item_x + item_width && item_width != 1) {
                     // If the mouse event goes beyond the available width of the item
                     // super quickly, collapse the size to 1 and maintain the position.
@@ -300,6 +366,21 @@ public class Akira.Utils.AffineTransform : Object {
                     new_width = 0;
                 }
 
+                // Height size constraints.
+                if (fix_size (event_y) < item_y && item_height != 1) {
+                    // If the mouse event goes beyond the available height of the item
+                    // super quickly, collapse the size to 1 and maintain the position.
+                    new_height = -item_height + 1;
+                } else if (fix_size (event_y) < item_y) {
+                    // If the user keeps moving the mouse beyond the available height of the item
+                    // prevent any size changes.
+                    new_height = 0;
+                } else if (item_height == 1 && delta_y <= 0) {
+                    // Don't update the size or position if the delta keeps increasing,
+                    // meaning the user is still moving down.
+                    new_height = 0;
+                }
+
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
                 }
@@ -309,6 +390,7 @@ public class Akira.Utils.AffineTransform : Object {
                 new_x = delta_x;
                 new_width = -delta_x;
 
+                // Width size constraints.
                 if (fix_size (event_x) > item_x + item_width && item_width != 1) {
                     // If the mouse event goes beyond the available width of the item
                     // super quickly, collapse the size to 1 and maintain the position.


### PR DESCRIPTION
## Summary / How this PR fixes the problem?

Rewrite the `scale_from_event()` method in order to fix visual glitches and accidental changes to the origin points.

## Steps to Test

- Create a shape.
- Resize it from any handle.
- Be sure the shape doesn't move around unexpectedly.

## Screenshots 

**OLD METHOD**
![resize-KO](https://user-images.githubusercontent.com/2527103/87868788-a0c33080-c94e-11ea-9451-cc1bd1bdbfc9.gif)

**NEW METHOD**
![resize-ok](https://user-images.githubusercontent.com/2527103/87868790-a9b40200-c94e-11ea-9eb9-cf4837b823ff.gif)

## Known Issues / Things To Do

- Due to the way we handle rotation and coordinates for Artboard items, the same glitch of #372 is still present.
- Resizing from a Nob that modifies the origin doesn't work well if the size is locked or if holding down the <kbd>CTRL</kbd> key. I'll take care of that in a follow up patch.

## This PR fixes/implements the following **bugs/features**:

- [x] Rewrite the method to simplify how we handle the delta.
- [x] Prevent moving the origin when resizing quickly with the mouse.
- [x] Account for locked size ratio.

### Fixes

- Fixes #335
