### PR TITLE
Fix items coordinates

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -297,7 +297,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             "active", selected_item, "flipped-h", BindingFlags.BIDIRECTIONAL,
             (binding, val, ref res) => {
                 res = val.get_boolean ();
-                window.event_bus.flip_item (true);
+                window.event_bus.flip_item ();
                 on_item_coord_changed ();
                 return true;
             });
@@ -306,7 +306,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             "active", selected_item, "flipped-v", BindingFlags.BIDIRECTIONAL,
             (binding, val, ref res) => {
                 res = val.get_boolean ();
-                window.event_bus.flip_item (true, true);
+                window.event_bus.flip_item (true);
                 on_item_coord_changed ();
                 return true;
             });

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -285,7 +285,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             (binding, srcval, ref targetval) => {
                 double src = (double) srcval;
                 targetval.set_double (src);
-                Utils.AffineTransform.set_rotation (src, selected_item);
+                Utils.AffineTransform.set_rotation (selected_item, src);
                 return true;
             });
 

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -103,13 +103,10 @@ public class Akira.Lib.Managers.NobManager : Object {
         double bb_left = 1e6, bb_top = 1e6, bb_right = 0, bb_bottom = 0;
 
         foreach (var item in selected_items) {
-            Goo.CanvasBounds item_bounds;
-            item.get_bounds (out item_bounds);
-
-            bb_left = double.min (bb_left, item_bounds.x1);
-            bb_top = double.min (bb_top, item_bounds.y1);
-            bb_right = double.max (bb_right, item_bounds.x2);
-            bb_bottom = double.max (bb_bottom, item_bounds.y2);
+            bb_left = double.min (bb_left, item.bounds.x1);
+            bb_top = double.min (bb_top, item.bounds.y1);
+            bb_right = double.max (bb_right, item.bounds.x2);
+            bb_bottom = double.max (bb_bottom, item.bounds.y2);
         }
 
         select_bb = Goo.CanvasBounds () {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -66,8 +66,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         if (selected_items.length () == 1) {
             var selected_item = selected_items.nth_data (0);
 
-            selected_item.store_relative_position ();
-
             delta_x_accumulator = 0.0;
             delta_y_accumulator = 0.0;
 
@@ -265,7 +263,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         canvas.window.event_bus.z_selected_changed ();
     }
 
-    private void on_flip_item (bool clicked, bool vertical) {
+    private void on_flip_item (bool vertical) {
         if (selected_items.length () == 0 || selected_items.nth_data (0) is Lib.Models.CanvasArtboard) {
             return;
         }
@@ -273,12 +271,12 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         selected_items.foreach ((item) => {
             if (vertical) {
                 item.flipped_v = !item.flipped_v;
-                Utils.AffineTransform.flip_item (clicked, item, 1, -1);
+                Utils.AffineTransform.flip_item (item, 1, -1);
                 update_selected_items ();
                 return;
             }
             item.flipped_h = !item.flipped_h;
-            Utils.AffineTransform.flip_item (clicked, item, -1, 1);
+            Utils.AffineTransform.flip_item (item, -1, 1);
             update_selected_items ();
         });
     }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -240,7 +240,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
             for (var i = 0; i < items_length; i++) {
                 var item = items[items_length - 1 - i];
 
-                // Force the redraw of the canvas if an item is partially outside.
+                // Check if the item is partially outside.
                 if (is_outside (item)) {
                     force_redraw = true;
                 }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -92,9 +92,6 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 
-    public double initial_relative_x { get; set; }
-    public double initial_relative_y { get; set; }
-
     // Knows if an item was created or loaded for ordering purpose.
     public bool loaded { get; set; default = false; }
 
@@ -156,6 +153,18 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
             && y <= bounds.y2;
     }
 
+    public bool is_outside (Models.CanvasItem item) {
+        var x1 = item.get_global_coord ("x");
+        var x2 = x1 + item.get_coords ("width");
+        var y1 = item.get_global_coord ("y");
+        var y2 = y1 + item.get_coords ("height");
+
+        return x1 < bounds.x1
+            || x2 > bounds.x2
+            || y1 < bounds.y1
+            || y2 > bounds.y2;
+    }
+
     public bool dropped_inside (Models.CanvasItem item) {
         var x1 = item.get_global_coord ("x");
         var x2 = x1 + item.get_coords ("width");
@@ -204,6 +213,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public override void simple_paint (Cairo.Context cr, Goo.CanvasBounds bounds) {
+        bool force_redraw = false;
         cr.set_source_rgba (0, 0, 0, 0.6);
 
         if (settings.dark_theme) {
@@ -224,14 +234,16 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         if (items.get_n_items () > 0) {
             var items_length = items.get_n_items ();
 
-            // Force the redraw of the canvas in case an item is partially outside.
-            canvas.queue_draw ();
-
             // Painting items in reversed order in order to
             // print last item inserted (top of the stack) on top
             // of the items inserted before
             for (var i = 0; i < items_length; i++) {
                 var item = items[items_length - 1 - i];
+
+                // Force the redraw of the canvas if an item is partially outside.
+                if (is_outside (item)) {
+                    force_redraw = true;
+                }
 
                 cr.save ();
 
@@ -244,6 +256,10 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
                 }
 
                 cr.restore ();
+            }
+
+            if (force_redraw) {
+                canvas.queue_draw ();
             }
         }
     }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -66,9 +66,6 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 
-    public double initial_relative_x { get; set; }
-    public double initial_relative_y { get; set; }
-
     // Knows if an item was created or loaded for ordering purpose.
     public bool loaded { get; set; default = false; }
 

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -73,9 +73,6 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 
-    public double initial_relative_x { get; set; }
-    public double initial_relative_y { get; set; }
-
     // Knows if an item was created or loaded for ordering purpose.
     public bool loaded { get; set; default = false; }
 

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -217,9 +217,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public virtual double get_global_coord (string coord_id) {
-        Goo.CanvasBounds bounds;
-        get_bounds (out bounds);
-
         var item_x =
             artboard != null
                 ? relative_x + artboard.bounds.x1

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -162,13 +162,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         set_transform (transform);
 
         if (artboard != null) {
-            debug ("get_position");
             artboard.add_child (this, -1);
-
-            // canvas.convert_to_item_space (artboard, ref transform.x0, ref transform.y0);
-
-            // relative_x = transform.x0;
-            // relative_y = transform.y0;
 
             double item_x_from_artboard = transform.x0;
             double item_y_from_artboard = transform.y0;
@@ -209,17 +203,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public virtual Cairo.Matrix compute_transform (Cairo.Matrix transform) {
-        // transform.translate (relative_x, relative_y);
-
-        // var matrix = Cairo.Matrix.identity ();
-        double x = relative_x;
-        double y = relative_y;
-        // debug (@"relative X: $(x) - Y: $(y)");
-
-        canvas.convert_from_item_space (artboard, ref x, ref y);
-        transform.translate (x, y);
-
-        // debug (@"initial X: $(matrix.x0) - Y: $(matrix.y0)");
+        transform.translate (relative_x, relative_y);
 
         var center_x = get_coords ("width") / 2;
         var center_y = get_coords ("height") / 2;
@@ -228,28 +212,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         transform.translate (center_x, center_y);
         transform.rotate (Utils.AffineTransform.deg_to_rad (rotation));
         transform.translate (-center_x, -center_y);
-
-        // var item_x = get_coords ("width") / 2;
-        // var item_y = get_coords ("height") / 2;
-
-        // matrix.translate (item_x, item_y);
-        // matrix.rotate (Utils.AffineTransform.deg_to_rad (rotation));
-        // matrix.translate (-item_x, -item_y);
-
-        // debug (@"rotated X: $(matrix.x0) - Y: $(matrix.y0)");
-
-        // double new_x = matrix.x0;
-        // double new_y = matrix.y0;
-
-        canvas.convert_to_item_space (artboard, ref transform.x0, ref transform.y0);
-        // debug (@"rotated X: $(transform.x0) - Y: $(transform.y0)");
-
-        // set_transform (transform);
-
-        // transform.translate (new_x, new_y);
-
-        // relative_x = transform.x0;
-        // relative_y = transform.y0;
 
         return transform;
     }

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -139,30 +139,36 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public virtual void position_item (double _x, double _y) {
-        //  debug (@"item x: $(_x) - y: $(_y)");
+        // debug (@"item x: $(_x) - y: $(_y)");
 
-        // Always reset the translation matrix when position an item
+        // Always reset the translation matrix when positioning an item
         // in the "free canvas" space. This is to avoid previous coordinate
-        // space translations to be applied twice
+        // space translations to be applied twice.
         var transform = Cairo.Matrix.identity ();
 
-        // Keep the item always in the origin
-        // move the entire coordinate system every time
+        // Keep the item always in the origin and move the entire coordinate
+        // system every time.
         transform.translate (_x, _y);
 
         // We only need to take into account the rotation relative
         // to the center of the item.
-        var width = get_coords ("width");
-        var height = get_coords ("height");
+        var center_x = get_coords ("width") / 2;
+        var center_y = get_coords ("height") / 2;
 
-        transform.translate (width / 2, height / 2);
+        transform.translate (center_x, center_y);
         transform.rotate (Utils.AffineTransform.deg_to_rad (rotation));
-        transform.translate (- (width / 2), - (height / 2));
+        transform.translate (-center_x, -center_y);
 
         set_transform (transform);
 
         if (artboard != null) {
+            debug ("get_position");
             artboard.add_child (this, -1);
+
+            // canvas.convert_to_item_space (artboard, ref transform.x0, ref transform.y0);
+
+            // relative_x = transform.x0;
+            // relative_y = transform.y0;
 
             double item_x_from_artboard = transform.x0;
             double item_y_from_artboard = transform.y0;
@@ -172,7 +178,7 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
             relative_x = item_x_from_artboard;
             relative_y = item_y_from_artboard;
 
-            debug (@"relative X: $(relative_x) - Y: $(relative_y)");
+            // debug (@"relative X: $(relative_x) - Y: $(relative_y)");
             return;
         }
 
@@ -203,26 +209,47 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public virtual Cairo.Matrix compute_transform (Cairo.Matrix transform) {
-        debug ("here");
-        transform.translate (relative_x, relative_y);
+        // transform.translate (relative_x, relative_y);
 
-        var width = get_coords ("width");
-        var height = get_coords ("height");
+        // var matrix = Cairo.Matrix.identity ();
+        double x = relative_x;
+        double y = relative_y;
+        // debug (@"relative X: $(x) - Y: $(y)");
+
+        canvas.convert_from_item_space (artboard, ref x, ref y);
+        transform.translate (x, y);
+
+        // debug (@"initial X: $(matrix.x0) - Y: $(matrix.y0)");
+
+        var center_x = get_coords ("width") / 2;
+        var center_y = get_coords ("height") / 2;
 
         // Rotate around the center by the amount in item.rotation.
-        transform.translate (width / 2, height / 2);
+        transform.translate (center_x, center_y);
         transform.rotate (Utils.AffineTransform.deg_to_rad (rotation));
-        transform.translate (- (width / 2), - (height / 2));
+        transform.translate (-center_x, -center_y);
 
-        //  if (artboard != null) {
-        //      double item_x_from_artboard = transform.x0;
-        //      double item_y_from_artboard = transform.y0;
+        // var item_x = get_coords ("width") / 2;
+        // var item_y = get_coords ("height") / 2;
 
-        //      canvas.convert_to_item_space (artboard, ref item_x_from_artboard, ref item_y_from_artboard);
+        // matrix.translate (item_x, item_y);
+        // matrix.rotate (Utils.AffineTransform.deg_to_rad (rotation));
+        // matrix.translate (-item_x, -item_y);
 
-        //      relative_x = item_x_from_artboard;
-        //      relative_y = item_y_from_artboard;
-        //  }
+        // debug (@"rotated X: $(matrix.x0) - Y: $(matrix.y0)");
+
+        // double new_x = matrix.x0;
+        // double new_y = matrix.y0;
+
+        canvas.convert_to_item_space (artboard, ref transform.x0, ref transform.y0);
+        // debug (@"rotated X: $(transform.x0) - Y: $(transform.y0)");
+
+        // set_transform (transform);
+
+        // transform.translate (new_x, new_y);
+
+        // relative_x = transform.x0;
+        // relative_y = transform.y0;
 
         return transform;
     }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -80,9 +80,6 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 
-    public double initial_relative_x { get; set; }
-    public double initial_relative_y { get; set; }
-
     // Knows if an item was created or loaded for ordering purpose.
     public bool loaded { get; set; default = false; }
 

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -66,9 +66,6 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
     public double relative_x { get; set; }
     public double relative_y { get; set; }
 
-    public double initial_relative_x { get; set; }
-    public double initial_relative_y { get; set; }
-
     // Knows if an item was created or loaded for ordering purpose.
     public bool loaded { get; set; default = false; }
 

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -340,11 +340,11 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_flip_h () {
-        window.event_bus.flip_item (true);
+        window.event_bus.flip_item ();
     }
 
     private void action_flip_v () {
-        window.event_bus.flip_item (true, true);
+        window.event_bus.flip_item (true);
     }
 
     private void action_ellipse_tool () {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -57,7 +57,7 @@ public class Akira.Services.EventBus : Object {
 
     // Item signals.
     public signal void change_z_selected (bool raise, bool total);
-    public signal void flip_item (bool clicked, bool vertical = false);
+    public signal void flip_item (bool vertical = false);
     public signal void request_add_item_to_selection (Lib.Models.CanvasItem item);
     public signal void request_delete_item (Lib.Models.CanvasItem item);
     public signal void selected_items_changed (List<Lib.Models.CanvasItem> selected_items);

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -60,8 +60,13 @@ public class Akira.Utils.AffineTransform : Object {
         Cairo.Matrix matrix;
         item.get_transform (out matrix);
 
-        matrix.x0 = (x != null) ? x : matrix.x0;
-        matrix.y0 = (y != null) ? y : matrix.y0;
+        // Account for the item rotation and get the difference between
+        // its bounds and matrix coordinates.
+        var diff_x = item.bounds.x1 - matrix.x0;
+        var diff_y = item.bounds.y1 - matrix.y0;
+
+        matrix.x0 = (x != null) ? x - diff_x : matrix.x0;
+        matrix.y0 = (y != null) ? y - diff_y : matrix.y0;
 
         item.set_transform (matrix);
     }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -187,7 +187,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
-                    new_x = -(new_width / 2);
+                    new_x = - (new_width / 2);
                 }
                 break;
 
@@ -220,7 +220,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width / item.size_ratio;
-                    new_y = -(new_height / 2);
+                    new_y = - (new_height / 2);
                 }
                 break;
 
@@ -247,7 +247,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
-                    new_x = -(new_width / 2);
+                    new_x = - (new_width / 2);
                 }
                 break;
 
@@ -288,7 +288,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width * item.size_ratio;
-                    new_y = -(new_height / 2);
+                    new_y = - (new_height / 2);
                 }
                 break;
         }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -167,6 +167,8 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
+                    new_x = -new_width;
+                    new_y = -new_height;
                 }
                 break;
 
@@ -185,6 +187,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
+                    new_x = -(new_width / 2);
                 }
                 break;
 
@@ -206,6 +209,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width / item.size_ratio;
+                    new_y = -new_height;
                 }
                 break;
 
@@ -216,6 +220,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width / item.size_ratio;
+                    new_y = -(new_height / 2);
                 }
                 break;
 
@@ -242,6 +247,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
+                    new_x = -(new_width / 2);
                 }
                 break;
 
@@ -263,6 +269,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
+                    new_x = -new_width;
                 }
                 break;
 
@@ -281,6 +288,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width * item.size_ratio;
+                    new_y = -(new_height / 2);
                 }
                 break;
         }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -32,13 +32,16 @@ public class Akira.Utils.AffineTransform : Object {
 
     public static HashTable<string, double?> get_position (CanvasItem item) {
         HashTable<string, double?> array = new HashTable<string, double?> (str_hash, str_equal);
-        double item_x = item.get_coords ("x");
-        double item_y = item.get_coords ("y");
+        //  double item_x = item.get_coords ("x");
+        //  double item_y = item.get_coords ("y");
+        double item_x = item.bounds.x1;
+        double item_y = item.bounds.y1;
 
-        // debug (@"item x: $(item_x) y: $(item_y)");
+        //  debug (@"item x: $(item_x) y: $(item_y)");
+        //  debug (@"item x: $(item.bounds.x1) y: $(item.bounds.y1)");
         // debug (@"Item has artboard: $(item.artboard != null)");
 
-        item.canvas.convert_from_item_space (item, ref item_x, ref item_y);
+        //  item.canvas.convert_from_item_space (item, ref item_x, ref item_y);
 
         if (item.artboard != null) {
             item_x = item.relative_x;
@@ -516,36 +519,26 @@ public class Akira.Utils.AffineTransform : Object {
     public static void set_rotation (double rotation, CanvasItem item) {
         var center_x = item.get_coords ("width") / 2;
         var center_y = item.get_coords ("height") / 2;
-
         var actual_rotation = rotation - item.rotation;
 
         item.rotate (actual_rotation, center_x, center_y);
-
         item.rotation += actual_rotation;
     }
 
-    public static void flip_item (bool clicked, CanvasItem item, double sx, double sy) {
-        if (clicked) {
-            double x, y, width, height;
-            item.get ("x", out x, "y", out y, "width", out width, "height", out height);
-            var center_x = x + width / 2;
-            var center_y = y + height / 2;
-
-            var transform = Cairo.Matrix.identity ();
-            item.get_transform (out transform);
-            double radians = item.rotation * (Math.PI / 180);
-            transform.translate (center_x, center_y);
-            transform.rotate (-radians);
-            transform.scale (sx, sy);
-            transform.rotate (radians);
-            transform.translate (-center_x, -center_y);
-            item.set_transform (transform);
-            return;
-        }
+    public static void flip_item (CanvasItem item, double sx, double sy) {
+        double x, y, width, height;
+        item.get ("x", out x, "y", out y, "width", out width, "height", out height);
+        var center_x = x + width / 2;
+        var center_y = y + height / 2;
 
         var transform = Cairo.Matrix.identity ();
         item.get_transform (out transform);
+        double radians = item.rotation * (Math.PI / 180);
+        transform.translate (center_x, center_y);
+        transform.rotate (-radians);
         transform.scale (sx, sy);
+        transform.rotate (radians);
+        transform.translate (-center_x, -center_y);
         item.set_transform (transform);
     }
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -147,41 +147,23 @@ public class Akira.Utils.AffineTransform : Object {
                 new_height = -delta_y;
                 new_width = -delta_x;
 
-                // Height size constraints.
-                if (fix_size (event_y) > item_y + item_height && item_height != 1) {
-                    // If the mouse event goes beyond the available height of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_y = item_height - 1;
-                    new_height = -item_height + 1;
-                } else if (fix_size (event_y) > item_y + item_height) {
-                    // If the user keeps moving the mouse beyond the available height of the item
-                    // prevent any size changes.
-                    new_y = 0;
-                    new_height = 0;
-                } else if (item_height == 1 && delta_y >= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving down.
-                    new_y = 0;
-                    new_height = 0;
-                }
+                fix_height_origin (
+                    ref delta_y,
+                    ref event_y,
+                    ref item_y,
+                    ref item_height,
+                    ref new_y,
+                    ref new_height
+                );
 
-                // Width size constraints.
-                if (fix_size (event_x) > item_x + item_width && item_width != 1) {
-                    // If the mouse event goes beyond the available width of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_x = item_width - 1;
-                    new_width = -item_width + 1;
-                } else if (fix_size (event_x) > item_x + item_width) {
-                    // If the user keeps moving the mouse beyond the available width of the item
-                    // prevent any size changes.
-                    new_x = 0;
-                    new_width = 0;
-                } else if (item_width == 1 && delta_x >= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving right.
-                    new_x = 0;
-                    new_width = 0;
-                }
+                fix_width_origin (
+                    ref delta_x,
+                    ref event_x,
+                    ref item_x,
+                    ref item_width,
+                    ref new_x,
+                    ref new_width
+                );
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
@@ -192,23 +174,14 @@ public class Akira.Utils.AffineTransform : Object {
                 new_y = delta_y;
                 new_height = -delta_y;
 
-                // Height size constraints.
-                if (fix_size (event_y) > item_y + item_height && item_height != 1) {
-                    // If the mouse event goes beyond the available height of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_y = item_height - 1;
-                    new_height = -item_height + 1;
-                } else if (fix_size (event_y) > item_y + item_height) {
-                    // If the user keeps moving the mouse beyond the available height of the item
-                    // prevent any size changes.
-                    new_y = 0;
-                    new_height = 0;
-                } else if (item_height == 1 && delta_y >= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving down.
-                    new_y = 0;
-                    new_height = 0;
-                }
+                fix_height_origin (
+                    ref delta_y,
+                    ref event_y,
+                    ref item_y,
+                    ref item_height,
+                    ref new_y,
+                    ref new_height
+                );
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
@@ -220,38 +193,16 @@ public class Akira.Utils.AffineTransform : Object {
                 new_height = -delta_y;
                 new_width = delta_x;
 
-                // Height size constraints.
-                if (fix_size (event_y) > item_y + item_height && item_height != 1) {
-                    // If the mouse event goes beyond the available height of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_y = item_height - 1;
-                    new_height = -item_height + 1;
-                } else if (fix_size (event_y) > item_y + item_height) {
-                    // If the user keeps moving the mouse beyond the available height of the item
-                    // prevent any size changes.
-                    new_y = 0;
-                    new_height = 0;
-                } else if (item_height == 1 && delta_y >= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving down.
-                    new_y = 0;
-                    new_height = 0;
-                }
+                fix_height_origin (
+                    ref delta_y,
+                    ref event_y,
+                    ref item_y,
+                    ref item_height,
+                    ref new_y,
+                    ref new_height
+                );
 
-                // Width size constraints.
-                if (fix_size (event_x) < item_x && item_width != 1) {
-                    // If the mouse event goes beyond the available width of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_width = -item_width + 1;
-                } else if (fix_size (event_x) < item_x) {
-                    // If the user keeps moving the mouse beyond the available width of the item
-                    // prevent any size changes.
-                    new_width = 0;
-                } else if (item_width == 1 && delta_x <= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving left.
-                    new_width = 0;
-                }
+                fix_width (ref delta_x, ref event_x, ref item_x, ref item_width, ref new_width);
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width / item.size_ratio;
@@ -261,20 +212,7 @@ public class Akira.Utils.AffineTransform : Object {
             case NobManager.Nob.RIGHT_CENTER:
                 new_width = delta_x;
 
-                // Width size constraints.
-                if (fix_size (event_x) < item_x && item_width != 1) {
-                    // If the mouse event goes beyond the available width of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_width = -item_width + 1;
-                } else if (fix_size (event_x) < item_x) {
-                    // If the user keeps moving the mouse beyond the available width of the item
-                    // prevent any size changes.
-                    new_width = 0;
-                } else if (item_width == 1 && delta_x <= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving left.
-                    new_width = 0;
-                }
+                fix_width (ref delta_x, ref event_x, ref item_x, ref item_width, ref new_width);
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width / item.size_ratio;
@@ -285,35 +223,9 @@ public class Akira.Utils.AffineTransform : Object {
                 new_width = delta_x;
                 new_height = delta_y;
 
-                // Width size constraints.
-                if (fix_size (event_x) < item_x && item_width != 1) {
-                    // If the mouse event goes beyond the available width of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_width = -item_width + 1;
-                } else if (fix_size (event_x) < item_x) {
-                    // If the user keeps moving the mouse beyond the available width of the item
-                    // prevent any size changes.
-                    new_width = 0;
-                } else if (item_width == 1 && delta_x <= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving left.
-                    new_width = 0;
-                }
+                fix_width (ref delta_x, ref event_x, ref item_x, ref item_width, ref new_width);
 
-                // Height size constraints.
-                if (fix_size (event_y) < item_y && item_height != 1) {
-                    // If the mouse event goes beyond the available height of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_height = -item_height + 1;
-                } else if (fix_size (event_y) < item_y) {
-                    // If the user keeps moving the mouse beyond the available height of the item
-                    // prevent any size changes.
-                    new_height = 0;
-                } else if (item_height == 1 && delta_y <= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving down.
-                    new_height = 0;
-                }
+                fix_height (ref delta_y, ref event_y, ref item_y, ref item_height, ref new_height);
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width / item.size_ratio;
@@ -326,20 +238,7 @@ public class Akira.Utils.AffineTransform : Object {
             case NobManager.Nob.BOTTOM_CENTER:
                 new_height = delta_y;
 
-                // Height size constraints.
-                if (fix_size (event_y) < item_y && item_height != 1) {
-                    // If the mouse event goes beyond the available height of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_height = -item_height + 1;
-                } else if (fix_size (event_y) < item_y) {
-                    // If the user keeps moving the mouse beyond the available height of the item
-                    // prevent any size changes.
-                    new_height = 0;
-                } else if (item_height == 1 && delta_y <= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving down.
-                    new_height = 0;
-                }
+                fix_height (ref delta_y, ref event_y, ref item_y, ref item_height, ref new_height);
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
@@ -351,38 +250,16 @@ public class Akira.Utils.AffineTransform : Object {
                 new_width = -delta_x;
                 new_height = delta_y;
 
-                // Width size contraints.
-                if (fix_size (event_x) > item_x + item_width && item_width != 1) {
-                    // If the mouse event goes beyond the available width of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_x = item_width - 1;
-                    new_width = -item_width + 1;
-                } else if (fix_size (event_x) > item_x + item_width) {
-                    // If the user keeps moving the mouse beyond the available width of the item
-                    // prevent any size changes.
-                    new_x = 0;
-                    new_width = 0;
-                } else if (item_width == 1 && delta_x >= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving right.
-                    new_x = 0;
-                    new_width = 0;
-                }
+                fix_width_origin (
+                    ref delta_x,
+                    ref event_x,
+                    ref item_x,
+                    ref item_width,
+                    ref new_x,
+                    ref new_width
+                );
 
-                // Height size constraints.
-                if (fix_size (event_y) < item_y && item_height != 1) {
-                    // If the mouse event goes beyond the available height of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_height = -item_height + 1;
-                } else if (fix_size (event_y) < item_y) {
-                    // If the user keeps moving the mouse beyond the available height of the item
-                    // prevent any size changes.
-                    new_height = 0;
-                } else if (item_height == 1 && delta_y <= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving down.
-                    new_height = 0;
-                }
+                fix_height (ref delta_y, ref event_y, ref item_y, ref item_height, ref new_height);
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_width = new_height * item.size_ratio;
@@ -393,23 +270,14 @@ public class Akira.Utils.AffineTransform : Object {
                 new_x = delta_x;
                 new_width = -delta_x;
 
-                // Width size constraints.
-                if (fix_size (event_x) > item_x + item_width && item_width != 1) {
-                    // If the mouse event goes beyond the available width of the item
-                    // super quickly, collapse the size to 1 and maintain the position.
-                    new_x = item_width - 1;
-                    new_width = -item_width + 1;
-                } else if (fix_size (event_x) > item_x + item_width) {
-                    // If the user keeps moving the mouse beyond the available width of the item
-                    // prevent any size changes.
-                    new_x = 0;
-                    new_width = 0;
-                } else if (item_width == 1 && delta_x >= 0) {
-                    // Don't update the size or position if the delta keeps increasing,
-                    // meaning the user is still moving right.
-                    new_x = 0;
-                    new_width = 0;
-                }
+                fix_width_origin (
+                    ref delta_x,
+                    ref event_x,
+                    ref item_x,
+                    ref item_width,
+                    ref new_x,
+                    ref new_width
+                );
 
                 if (canvas.ctrl_is_pressed || item.size_locked) {
                     new_height = new_width * item.size_ratio;
@@ -423,6 +291,106 @@ public class Akira.Utils.AffineTransform : Object {
 
         item.move (new_x, new_y);
         set_size (item, new_width, new_height);
+    }
+
+    // Width size constraints.
+    private static void fix_width (
+        ref double delta_x,
+        ref double event_x,
+        ref double item_x,
+        ref double item_width,
+        ref double new_width
+    ) {
+        if (fix_size (event_x) < item_x && item_width != 1) {
+            // If the mouse event goes beyond the available width of the item
+            // super quickly, collapse the size to 1 and maintain the position.
+            new_width = -item_width + 1;
+        } else if (fix_size (event_x) < item_x) {
+            // If the user keeps moving the mouse beyond the available width of the item
+            // prevent any size changes.
+            new_width = 0;
+        } else if (item_width == 1 && delta_x <= 0) {
+            // Don't update the size or position if the delta keeps increasing,
+            // meaning the user is still moving left.
+            new_width = 0;
+        }
+    }
+
+    // Width size constraints and origin point.
+    private static void fix_width_origin (
+        ref double delta_x,
+        ref double event_x,
+        ref double item_x,
+        ref double item_width,
+        ref double new_x,
+        ref double new_width
+    ) {
+        if (fix_size (event_x) > item_x + item_width && item_width != 1) {
+            // If the mouse event goes beyond the available width of the item
+            // super quickly, collapse the size to 1 and maintain the position.
+            new_x = item_width - 1;
+            new_width = -item_width + 1;
+        } else if (fix_size (event_x) > item_x + item_width) {
+            // If the user keeps moving the mouse beyond the available width of the item
+            // prevent any size changes.
+            new_x = 0;
+            new_width = 0;
+        } else if (item_width == 1 && delta_x >= 0) {
+            // Don't update the size or position if the delta keeps increasing,
+            // meaning the user is still moving right.
+            new_x = 0;
+            new_width = 0;
+        }
+    }
+
+    // Height size constraints.
+    private static void fix_height (
+        ref double delta_y,
+        ref double event_y,
+        ref double item_y,
+        ref double item_height,
+        ref double new_height
+    ) {
+        if (fix_size (event_y) < item_y && item_height != 1) {
+            // If the mouse event goes beyond the available height of the item
+            // super quickly, collapse the size to 1 and maintain the position.
+            new_height = -item_height + 1;
+        } else if (fix_size (event_y) < item_y) {
+            // If the user keeps moving the mouse beyond the available height of the item
+            // prevent any size changes.
+            new_height = 0;
+        } else if (item_height == 1 && delta_y <= 0) {
+            // Don't update the size or position if the delta keeps increasing,
+            // meaning the user is still moving down.
+            new_height = 0;
+        }
+    }
+
+    // Height size constraints and origin point.
+    private static void fix_height_origin (
+        ref double delta_y,
+        ref double event_y,
+        ref double item_y,
+        ref double item_height,
+        ref double new_y,
+        ref double new_height
+    ) {
+        if (fix_size (event_y) > item_y + item_height && item_height != 1) {
+            // If the mouse event goes beyond the available height of the item
+            // super quickly, collapse the size to 1 and maintain the position.
+            new_y = item_height - 1;
+            new_height = -item_height + 1;
+        } else if (fix_size (event_y) > item_y + item_height) {
+            // If the user keeps moving the mouse beyond the available height of the item
+            // prevent any size changes.
+            new_y = 0;
+            new_height = 0;
+        } else if (item_height == 1 && delta_y >= 0) {
+            // Don't update the size or position if the delta keeps increasing,
+            // meaning the user is still moving down.
+            new_y = 0;
+            new_height = 0;
+        }
     }
 
     public static void rotate_from_event (


### PR DESCRIPTION
## Summary / How this PR fixes the problem?

This PR takes care of improving the ongoing rewrite of the Affine Transform, focusing mostly on scale events and accurate coordinates.

## Screenshots 

TBD

## This PR fixes/implements the following bugs/features

- [x] Implement private methods for coordinate constraints during scale event.
- [x] Make the item properly scale if the size ratio is locked.
