### PR TITLE
Fix item bounds

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -239,7 +239,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                         return true;
                     }
 
-                    // Item has been selected
+                    // Item has been selected.
                     selected_bound_manager.add_item_to_selection (clicked_item as Models.CanvasItem);
                 }
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -151,6 +151,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Gdk.Key.Control_L:
             case Gdk.Key.Control_R:
                 ctrl_is_pressed = true;
+                items_ghost (true);
                 break;
 
             case Gdk.Key.Up:
@@ -175,6 +176,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Gdk.Key.Control_L:
             case Gdk.Key.Control_R:
                 ctrl_is_pressed = false;
+                items_ghost (false);
                 break;
         }
 
@@ -385,5 +387,22 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         var cursor = new Gdk.Cursor.for_display (Gdk.Display.get_default (), cursor_type);
         get_window ().set_cursor (cursor);
+    }
+
+    private void items_ghost (bool show) {
+        // If no items is selected we can't show anything.
+        if (selected_bound_manager.selected_items.length () == 0) {
+            return;
+        }
+
+        // Temporarily get the first item until multi select is implemented.
+        var item = selected_bound_manager.selected_items.nth_data (0);
+
+        if (!show) {
+            item.bounds_manager.hide ();
+            return;
+        }
+
+        item.bounds_manager.show ();
     }
 }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -151,7 +151,11 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Gdk.Key.Control_L:
             case Gdk.Key.Control_R:
                 ctrl_is_pressed = true;
-                items_ghost (true);
+                break;
+
+            case Gdk.Key.Alt_L:
+            case Gdk.Key.Alt_R:
+                toggle_item_ghost (true);
                 break;
 
             case Gdk.Key.Up:
@@ -176,7 +180,11 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Gdk.Key.Control_L:
             case Gdk.Key.Control_R:
                 ctrl_is_pressed = false;
-                items_ghost (false);
+                break;
+
+            case Gdk.Key.Alt_L:
+            case Gdk.Key.Alt_R:
+                toggle_item_ghost (false);
                 break;
         }
 
@@ -389,7 +397,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         get_window ().set_cursor (cursor);
     }
 
-    private void items_ghost (bool show) {
+    /*
+     * Show or hide the ghost bounding box of the selected items
+     */
+    private void toggle_item_ghost (bool show) {
         // If no items is selected we can't show anything.
         if (selected_bound_manager.selected_items.length () == 0) {
             return;

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -327,11 +327,14 @@ public class Akira.Lib.Managers.ExportManager : Object {
                 name = artboard.name != null ? artboard.name : name;
             }
 
+            // Hide the ghost item.
+            item.bounds_manager.hide ();
+
             // Account for items inside or outside artboards.
-            double x1 = item.get_global_coord ("x");
-            double x2 = x1 + item.get_coords ("width");
-            double y1 = item.get_global_coord ("y");
-            double y2 = y1 + item.get_coords ("height");
+            double x1 = item.bounds_manager.bounds.x1;
+            double x2 = item.bounds_manager.bounds.x2;
+            double y1 = item.bounds_manager.bounds.y1;
+            double y2 = item.bounds_manager.bounds.y2;
 
             // Create the rendered image with Cairo.
             surface = new Cairo.ImageSurface (
@@ -389,19 +392,27 @@ public class Akira.Lib.Managers.ExportManager : Object {
         var label_height = 0.0;
 
         // If the item is an artboard, account for the label's height.
-        if (item != null && item is Akira.Lib.Models.CanvasArtboard) {
-            var artboard = item as Akira.Lib.Models.CanvasArtboard;
+        if (item != null && item is Lib.Models.CanvasArtboard) {
+            var artboard = item as Lib.Models.CanvasArtboard;
             label_height = artboard.get_label_height ();
         }
 
-        // Account for items inside or outside artboards.
-        double x1 = item.get_global_coord ("x");
-        double x2 = x1 + item.get_coords ("width");
-        double y1 = item.get_global_coord ("y");
-        double y2 = y1 + item.get_coords ("height");
+        double width, height;
 
-        var width = item != null ? x2 - x1 : area.width;
-        var height = item != null ? y2 - y1 - label_height : area.height;
+        // If the item is null it mean we're dealing with a custom area and we
+        // don't have the bounds manager.
+        if (item != null) {
+            double x1 = item.bounds_manager.bounds.x1;
+            double x2 = item.bounds_manager.bounds.x2;
+            double y1 = item.bounds_manager.bounds.y1;
+            double y2 = item.bounds_manager.bounds.y2;
+
+            width = x2 - x1;
+            height = y2 - y1 - label_height;
+        } else {
+            width = area.width;
+            height = area.height;
+        }
 
         switch (settings.export_scale) {
             case 0:

--- a/src/Lib/Managers/GhostBoundsManager.vala
+++ b/src/Lib/Managers/GhostBoundsManager.vala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+ */
+
+ /*
+  * This class is used to create a ghost duplicate of each item to keep attached
+  * to the main canvas. These ghost items will always be CanvasRect items, ignoring
+  * rotation and skew, in order to always return the correct bounds and enable the
+  * rulers distance overlay feature.
+  */
+public class Akira.Lib.Managers.GhostBoundsManager : Object {
+    private const string STROKE_COLOR = "#41c9fd";
+    private const double LINE_WIDTH = 1.0;
+
+    public weak Akira.Lib.Canvas canvas;
+
+    // Matches the original item in order to keep the translation and rotation accurate.
+    private Goo.CanvasRect item;
+    // Bounding Box item to be generated on the fly when the user requires it.
+    private Goo.CanvasRect ghost;
+
+    public GhostBoundsManager (Models.CanvasItem original_item) {
+        canvas = original_item.canvas;
+        item = new Goo.CanvasRect (null, 0, 0, 1, 1, "line-width", 0, null);
+        item.visibility = Goo.CanvasItemVisibility.HIDDEN;
+        item.set ("parent", canvas.get_root_item ());
+        item.can_focus = false;
+    }
+
+    public void update (Models.CanvasItem original_item) {
+        double width, height;
+        original_item.get ("width", out width, "height", out height);
+
+        item.set ("width", width);
+        item.set ("height", height);
+        item.set_transform (original_item.get_real_transform ());
+    }
+
+    public void delete () {
+        item.remove ();
+        hide ();
+    }
+
+    public Goo.CanvasBounds bounds () {
+        return item.bounds;
+    }
+
+    public void show () {
+        if (ghost != null) {
+            return;
+        }
+
+        ghost = new Goo.CanvasRect (
+            null,
+            item.bounds.x1, item.bounds.y1,
+            item.bounds.x2 - item.bounds.x1, item.bounds.y2 - item.bounds.y1,
+            "line-width", LINE_WIDTH / canvas.current_scale,
+            "stroke-color", STROKE_COLOR,
+            null
+        );
+        ghost.set ("parent", item.canvas.get_root_item ());
+        ghost.can_focus = false;
+    }
+
+    public void hide () {
+        ghost.remove ();
+        ghost = null;
+    }
+}

--- a/src/Lib/Managers/GhostBoundsManager.vala
+++ b/src/Lib/Managers/GhostBoundsManager.vala
@@ -36,6 +36,12 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
     // Bounding Box item to be generated on the fly when the user requires it.
     private Goo.CanvasRect ghost;
 
+    public Goo.CanvasBounds bounds {
+        get {
+            return item.bounds;
+        }
+    }
+
     public GhostBoundsManager (Models.CanvasItem original_item) {
         canvas = original_item.canvas;
         item = new Goo.CanvasRect (null, 0, 0, 1, 1, "line-width", 0, null);
@@ -44,6 +50,9 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
         item.can_focus = false;
     }
 
+    /*
+     * Update the item to match size and transform matrix of the original item.
+     */
     public void update (Models.CanvasItem original_item) {
         double width, height;
         original_item.get ("width", out width, "height", out height);
@@ -58,10 +67,9 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
         hide ();
     }
 
-    public Goo.CanvasBounds bounds () {
-        return item.bounds;
-    }
-
+    /*
+     * Show the ghost effect.
+     */
     public void show () {
         if (ghost != null) {
             return;
@@ -79,6 +87,9 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
         ghost.can_focus = false;
     }
 
+    /*
+     * Hide the ghost effect.
+     */
     public void hide () {
         ghost.remove ();
         ghost = null;

--- a/src/Lib/Managers/GhostBoundsManager.vala
+++ b/src/Lib/Managers/GhostBoundsManager.vala
@@ -98,6 +98,10 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
      * Hide the ghost effect.
      */
     public void hide () {
+        if (ghost == null) {
+            return;
+        }
+
         ghost.remove ();
         ghost = null;
     }

--- a/src/Lib/Managers/GhostBoundsManager.vala
+++ b/src/Lib/Managers/GhostBoundsManager.vala
@@ -60,6 +60,13 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
         item.set ("width", width);
         item.set ("height", height);
         item.set_transform (original_item.get_real_transform ());
+
+        if (ghost != null) {
+            ghost.x = item.bounds.x1;
+            ghost.y = item.bounds.y1;
+            ghost.width = item.bounds.x2 - item.bounds.x1;
+            ghost.height = item.bounds.y2 - item.bounds.y1;
+        }
     }
 
     public void delete () {
@@ -93,5 +100,12 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
     public void hide () {
         ghost.remove ();
         ghost = null;
+    }
+
+    public Cairo.Matrix get_transform () {
+        Cairo.Matrix matrix;
+        item.get_transform (out matrix);
+
+        return matrix;
     }
 }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -188,8 +188,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 break;
         }
 
-        item.delete ();
         item.bounds_manager.delete ();
+        item.delete ();
         window.event_bus.item_deleted (item);
         window.event_bus.file_edited ();
     }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -189,6 +189,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         }
 
         item.delete ();
+        item.bounds_manager.delete ();
         window.event_bus.item_deleted (item);
         window.event_bus.file_edited ();
     }
@@ -197,7 +198,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         var artboard = new Models.CanvasArtboard (
             Utils.AffineTransform.fix_size (x),
             Utils.AffineTransform.fix_size (y),
-            root);
+            root
+        );
 
         return artboard as Models.CanvasItem;
     }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -88,6 +88,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     public Akira.Models.ListModel<Models.CanvasItem> items;
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard? artboard { get; set; }
+    public Managers.GhostBoundsManager bounds_manager { get; set; }
 
     public double relative_x { get; set; }
     public double relative_y { get; set; }
@@ -101,7 +102,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         canvas = parent_item.get_canvas () as Akira.Lib.Canvas;
         parent_item.add_child (this, -1);
 
-        // Artboards can't be nested
+        // Artboards can't be nested.
         artboard = null;
 
         item_type = Models.CanvasItemType.ARTBOARD;
@@ -122,14 +123,16 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         set_transform (Cairo.Matrix.identity ());
 
         // Keep the item always in the origin
-        // move the entire coordinate system every time
+        // move the entire coordinate system every time.
         translate (_x, _y);
 
-        // Get artboard name pixel extent
+        // Get artboard name pixel extent.
         get_label_extent ();
 
-        // Init items list
+        // Init items list.
         items = new Akira.Models.ListModel<Models.CanvasItem> ();
+        // Create the GhostBoundsManager to keep track of the global canvas bounds.
+        bounds_manager = new Managers.GhostBoundsManager (this);
 
         canvas.window.event_bus.zoom.connect (trigger_change);
         canvas.window.event_bus.change_theme.connect (trigger_change);
@@ -248,6 +251,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
                 cr.save ();
 
                 cr.transform (item.compute_transform (Cairo.Matrix.identity ()));
+                item.bounds_manager.update (item);
 
                 var canvas_item = item as Goo.CanvasItemSimple;
 

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -62,6 +62,7 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
 
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard? artboard { get; set; }
+    public Managers.GhostBoundsManager bounds_manager { get; set; }
 
     public double relative_x { get; set; }
     public double relative_y { get; set; }
@@ -119,5 +120,8 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         }
 
         reset_colors ();
+
+        // Create the GhostBoundsManager to keep track of the global canvas bounds.
+        bounds_manager = new Managers.GhostBoundsManager (this);
     }
 }

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -69,6 +69,7 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
 
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard? artboard { get; set; }
+    public Managers.GhostBoundsManager bounds_manager { get; set; }
 
     public double relative_x { get; set; }
     public double relative_y { get; set; }
@@ -133,6 +134,9 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
         });
 
         reset_colors ();
+
+        // Create the GhostBoundsManager to keep track of the global canvas bounds.
+        bounds_manager = new Managers.GhostBoundsManager (this);
     }
 
     /**

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -73,7 +73,10 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
 
     public abstract Akira.Lib.Canvas canvas { get; set; }
     public abstract Models.CanvasArtboard? artboard { get; set; }
+    public abstract Managers.GhostBoundsManager bounds_manager { get; set; }
 
+    // TODO: Create a new Cairo.Matrix, apply translation and rotation after converting
+    // the current values to canvas space, then get the bounds and save them for reference.
     public abstract double relative_x { get; set; }
     public abstract double relative_y { get; set; }
 
@@ -161,7 +164,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
             relative_x = _x;
             relative_y = _y;
 
-            // debug (@"relative X: $(relative_x) - Y: $(relative_y)");
             return;
         }
 

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -75,8 +75,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public abstract Models.CanvasArtboard? artboard { get; set; }
     public abstract Managers.GhostBoundsManager bounds_manager { get; set; }
 
-    // TODO: Create a new Cairo.Matrix, apply translation and rotation after converting
-    // the current values to canvas space, then get the bounds and save them for reference.
     public abstract double relative_x { get; set; }
     public abstract double relative_y { get; set; }
 

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -214,13 +214,16 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         return transform;
     }
 
+    /*
+     * Compute the Matrix transform of an item inside an Artboard.
+     */
     public virtual Cairo.Matrix compute_transform (Cairo.Matrix transform) {
         transform.translate (relative_x, relative_y);
 
         var center_x = get_coords ("width") / 2;
         var center_y = get_coords ("height") / 2;
 
-        // Rotate around the center by the amount in item.rotation.
+        // Rotate around the center by the rotation amount.
         transform.translate (center_x, center_y);
         transform.rotate (Utils.AffineTransform.deg_to_rad (rotation));
         transform.translate (-center_x, -center_y);
@@ -231,20 +234,11 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public virtual double get_global_coord (string coord_id) {
-        var item_x =
-            artboard != null
-                ? relative_x + artboard.bounds.x1
-                : bounds.x1;
-        var item_y =
-            artboard != null
-                ? relative_y + artboard.bounds.y1 + artboard.get_label_height ()
-                : bounds.y1;
-
         switch (coord_id) {
             case "x":
-                return item_x;
+                return bounds_manager.bounds.x1;
             case "y":
-                return item_y;
+                return bounds_manager.bounds.y1;
             default:
                 return 0.0;
         }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -76,6 +76,7 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
 
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard? artboard { get; set; }
+    public Managers.GhostBoundsManager bounds_manager { get; set; }
 
     public double relative_x { get; set; }
     public double relative_y { get; set; }
@@ -133,6 +134,9 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         }
 
         reset_colors ();
+
+        // Create the GhostBoundsManager to keep track of the global canvas bounds.
+        bounds_manager = new Managers.GhostBoundsManager (this);
     }
 
     public void update_border () {

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -62,6 +62,7 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
 
     public new Akira.Lib.Canvas canvas { get; set; }
     public Models.CanvasArtboard? artboard { get; set; }
+    public Managers.GhostBoundsManager bounds_manager { get; set; }
 
     public double relative_x { get; set; }
     public double relative_y { get; set; }
@@ -112,5 +113,8 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
         set_transform (Cairo.Matrix.identity ());
 
         position_item (_x, _y);
+
+        // Create the GhostBoundsManager to keep track of the global canvas bounds.
+        bounds_manager = new Managers.GhostBoundsManager (this);
     }
 }

--- a/src/Partials/InputField.vala
+++ b/src/Partials/InputField.vala
@@ -53,7 +53,6 @@ public class Akira.Partials.InputField : Gtk.EventBox {
     }
 
     construct {
-        //  window = get_toplevel () as Akira.Window;
         valign = Gtk.Align.CENTER;
 
         entry = new Gtk.SpinButton.with_range (0, 100, step);

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -48,23 +48,22 @@ public class Akira.Utils.AffineTransform : Object {
     }
 
     public static void set_position (CanvasItem item, double? x = null, double? y = null) {
-        Cairo.Matrix matrix;
         var diff_x = 0.0;
         var diff_y = 0.0;
 
         if (item.artboard != null) {
-            // Account for the item rotation and get the difference between
-            // its bounds and matrix coordinates.
+            // Account for the different between the current position and the
+            // the item's bounds.
             diff_x = item.bounds_manager.bounds.x1 - item.artboard.bounds.x1 - item.relative_x;
-            diff_y =
-                item.bounds_manager.bounds.y1 - item.artboard.bounds.y1
-                - item.artboard.get_label_height () - item.relative_y;
+            diff_y = item.bounds_manager.bounds.y1 - item.artboard.bounds.y1
+                     - item.artboard.get_label_height () - item.relative_y;
 
             item.relative_x = x != null ? x - diff_x : item.relative_x;
             item.relative_y = y != null ? y - diff_y : item.relative_y;
             return;
         }
 
+        Cairo.Matrix matrix;
         item.get_transform (out matrix);
 
         // Account for the item rotation and get the difference between
@@ -491,8 +490,12 @@ public class Akira.Utils.AffineTransform : Object {
             item.set ("height", fix_size (height + y));
         }
 
-        var model_item = item as CanvasItem;
-        model_item.bounds_manager.update (model_item);
+        // Don't update the bounds manager if a native goocanvas_rect was used,
+        // meaning no Akira Models was used and we don't need the bounds.
+        if (!(item is Goo.CanvasRect)) {
+            var model_item = item as CanvasItem;
+            model_item.bounds_manager.update (model_item);
+        }
     }
 
     public static void set_rotation (CanvasItem item, double rotation) {

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -32,21 +32,18 @@ public class Akira.Utils.AffineTransform : Object {
 
     public static HashTable<string, double?> get_position (CanvasItem item) {
         HashTable<string, double?> array = new HashTable<string, double?> (str_hash, str_equal);
-        double item_x = item.bounds.x1;
-        double item_y = item.bounds.y1;
+        double item_x = item.bounds_manager.bounds.x1;
+        double item_y = item.bounds_manager.bounds.y1;
 
         // debug (@"item x: $(item_x) y: $(item_y)");
-        // debug (@"item x: $(item.bounds.x1) y: $(item.bounds.y1)");
-        // debug (@"Item has artboard: $(item.artboard != null)");
 
         if (item.artboard != null) {
-            item_x = item.relative_x;
-            item_y = item.relative_y;
+            item_x -= item.artboard.bounds.x1;
+            item_y -= item.artboard.bounds.y1 + item.artboard.get_label_height ();
         }
 
         array.insert ("x", item_x);
         array.insert ("y", item_y);
-
         return array;
     }
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -48,19 +48,29 @@ public class Akira.Utils.AffineTransform : Object {
     }
 
     public static void set_position (CanvasItem item, double? x = null, double? y = null) {
+        Cairo.Matrix matrix;
+        var diff_x = 0.0;
+        var diff_y = 0.0;
+
         if (item.artboard != null) {
-            item.relative_x = x != null ? x : item.relative_x;
-            item.relative_y = y != null ? y : item.relative_y;
+            // Account for the item rotation and get the difference between
+            // its bounds and matrix coordinates.
+            diff_x = item.bounds_manager.bounds.x1 - item.artboard.bounds.x1 - item.relative_x;
+            diff_y =
+                item.bounds_manager.bounds.y1 - item.artboard.bounds.y1
+                - item.artboard.get_label_height () - item.relative_y;
+
+            item.relative_x = x != null ? x - diff_x : item.relative_x;
+            item.relative_y = y != null ? y - diff_y : item.relative_y;
             return;
         }
 
-        Cairo.Matrix matrix;
         item.get_transform (out matrix);
 
         // Account for the item rotation and get the difference between
         // its bounds and matrix coordinates.
-        var diff_x = item.bounds.x1 - matrix.x0;
-        var diff_y = item.bounds.y1 - matrix.y0;
+        diff_x = item.bounds_manager.bounds.x1 - matrix.x0;
+        diff_y = item.bounds_manager.bounds.y1 - matrix.y0;
 
         matrix.x0 = (x != null) ? x - diff_x : matrix.x0;
         matrix.y0 = (y != null) ? y - diff_y : matrix.y0;

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -69,6 +69,7 @@ public class Akira.Utils.AffineTransform : Object {
         matrix.y0 = (y != null) ? y - diff_y : matrix.y0;
 
         item.set_transform (matrix);
+        item.bounds_manager.update (item);
     }
 
     /**
@@ -81,7 +82,6 @@ public class Akira.Utils.AffineTransform : Object {
         ref double initial_event_x,
         ref double initial_event_y
     ) {
-
         var delta_x = event_x - initial_event_x;
         var delta_y = event_y - initial_event_y;
 
@@ -100,6 +100,8 @@ public class Akira.Utils.AffineTransform : Object {
 
         initial_event_x = event_x;
         initial_event_y = event_y;
+
+        item.bounds_manager.update (item);
     }
 
     public static void scale_from_event (
@@ -288,6 +290,8 @@ public class Akira.Utils.AffineTransform : Object {
 
         item.move (new_x, new_y);
         set_size (item, new_width, new_height);
+
+        item.bounds_manager.update (item);
     }
 
     // Width size constraints.
@@ -479,6 +483,9 @@ public class Akira.Utils.AffineTransform : Object {
         if (height + y > 0) {
             item.set ("height", fix_size (height + y));
         }
+
+        var model_item = item as CanvasItem;
+        model_item.bounds_manager.update (model_item);
     }
 
     public static void set_rotation (CanvasItem item, double rotation) {
@@ -488,6 +495,8 @@ public class Akira.Utils.AffineTransform : Object {
 
         item.rotate (actual_rotation, center_x, center_y);
         item.rotation += actual_rotation;
+
+        item.bounds_manager.update (item);
     }
 
     public static void flip_item (CanvasItem item, double sx, double sy) {
@@ -505,6 +514,8 @@ public class Akira.Utils.AffineTransform : Object {
         transform.rotate (radians);
         transform.translate (-center_x, -center_y);
         item.set_transform (transform);
+
+        item.bounds_manager.update (item);
     }
 
     public static double fix_size (double size) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -79,11 +79,12 @@ sources = files(
     'Lib/Canvas.vala',
 
     'Lib/Managers/ExportManager.vala',
+    'Lib/Managers/GhostBoundsManager.vala',
     'Lib/Managers/HoverManager.vala',
-    'Lib/Managers/SelectedBoundManager.vala',
-    'Lib/Managers/ItemsManager.vala',
     'Lib/Managers/ImageManager.vala',
+    'Lib/Managers/ItemsManager.vala',
     'Lib/Managers/NobManager.vala',
+    'Lib/Managers/SelectedBoundManager.vala',
 
     'Lib/Models/CanvasItem.vala',
     'Lib/Models/CanvasRect.vala',


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implement a new `GhostBoundsManager` object to keep track of global coordinates, no matter if the item is inside or outside an artboard, or if it's part of a group.
This also allows us to use this "ghost" item for future rulers overlay.

## Steps to Test
- Create an item inside an artboard.
- Rotate the item and see the X & Y coordinates updating properly.
- Hold <kbd>ALT</kbd> when an item is selected to reveal its ghost.

## Screenshots 
![item-bounds](https://user-images.githubusercontent.com/2527103/89095018-a96c2b80-d37e-11ea-9dbe-02473a7fd419.gif)

## This PR fixes/implements the following **bugs/features**:

- [x] Create a ghost item to keep track of real world item position.
- [x] Use the relative coordinates only to translate items inside artboards.
- [x] Improve the `get_position` and `set_position` of the `AffineTransform` object.
~Properly position rotated items when dragged inside and outside artboards.~

### Fixes

- Fixes #372 
