### PR TITLE
Fix position item when dropped inside or outside artboards

### DIFF
--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -471,7 +471,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         }
 
         restore_attributes (item, artboard, obj);
-        restore_selection (obj.get_boolean_member ("selected"), item);
     }
 
     /*
@@ -576,18 +575,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     }
 
     /**
-     * Restore the selected status of an object.
-     *
-     * @param bool selected - If the object is selected.
-     * @param Models.CanvasItem item - The newly created item.
-     */
-    private void restore_selection (bool selected, Models.CanvasItem item) {
-        if (selected) {
-            window.main_window.main_canvas.canvas.selected_bound_manager.add_item_to_selection (item);
-        }
-    }
-
-    /**
      * Handle the aftermath of an item transformation, like size changes or movement.
      */
     private void on_hold_released () {
@@ -657,8 +644,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         }
 
         // Save the coordinates before removing the item.
-        var x = item.get_global_coord ("x");
-        var y = item.get_global_coord ("y");
+        var x = item.bounds_manager.bounds.x1;
+        var y = item.bounds_manager.bounds.y1;
 
         // If the item was moved from inside an Artboard to the emtpy Canvas.
         if (item.artboard != null && new_artboard == null) {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -293,27 +293,15 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
             switch (event.keyval) {
                 case Gdk.Key.Up:
-                    if (item is Models.CanvasEllipse && item.artboard == null) {
-                        amount--;
-                    }
                     Utils.AffineTransform.set_position (item, null, position["y"] - amount);
                     break;
                 case Gdk.Key.Down:
-                    if (item is Models.CanvasEllipse && item.artboard == null) {
-                        amount++;
-                    }
                     Utils.AffineTransform.set_position (item, null, position["y"] + amount);
                     break;
                 case Gdk.Key.Right:
-                    if (item is Models.CanvasEllipse && item.artboard == null) {
-                        amount++;
-                    }
                     Utils.AffineTransform.set_position (item, position["x"] + amount);
                     break;
                 case Gdk.Key.Left:
-                    if (item is Models.CanvasEllipse && item.artboard == null) {
-                        amount--;
-                    }
                     Utils.AffineTransform.set_position (item, position["x"] - amount);
                     break;
             }

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -109,7 +109,7 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
 
         set_transform (Cairo.Matrix.identity ());
 
-        position_item (_center_x, _center_y);
+        init_position (_center_x, _center_y);
 
         color = _fill_color;
         has_border = settings.set_border;

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -127,6 +127,9 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
                 // Imported images should have their size ratio locked by default.
                 size_locked = true;
                 size_ratio = width / height;
+
+                // Create the GhostBoundsManager to keep track of the global canvas bounds.
+                bounds_manager = new Managers.GhostBoundsManager (this);
             } catch (Error e) {
                 warning (e.message);
                 canvas.window.event_bus.canvas_notification (e.message);
@@ -134,9 +137,6 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
         });
 
         reset_colors ();
-
-        // Create the GhostBoundsManager to keep track of the global canvas bounds.
-        bounds_manager = new Managers.GhostBoundsManager (this);
     }
 
     /**

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -114,7 +114,7 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
 
         set_transform (Cairo.Matrix.identity ());
 
-        position_item (_x, _y);
+        init_position (_x, _y);
 
         // Save the unedited pixbuf to enable resampling and restoring.
         manager.get_pixbuf.begin (-1, -1, (obj, res) => {

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -123,7 +123,7 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         is_radius_uniform = true;
         is_radius_autoscale = false;
 
-        position_item (_x, _y);
+        init_position (_x, _y);
 
         color = _fill_color;
         has_border = settings.set_border;

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -112,7 +112,7 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
 
         set_transform (Cairo.Matrix.identity ());
 
-        position_item (_x, _y);
+        init_position (_x, _y);
 
         // Create the GhostBoundsManager to keep track of the global canvas bounds.
         bounds_manager = new Managers.GhostBoundsManager (this);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
If an item is rotate and it gets dropped inside or outside an artboard, the position is not correct and doesn't reflect the real coordinates due to its rotation.

## This PR fixes/implements the following **bugs/features**:
- Simplify the positioning code to let the built-in compute transform deal with it.
- Account for the item's rotation when dropping inside an artboard.
