### PR TITLE
Fix mirror items inside artboards

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -298,7 +298,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             (binding, val, ref res) => {
                 res = val.get_boolean ();
                 window.event_bus.flip_item ();
-                on_item_coord_changed ();
                 return true;
             });
 
@@ -307,7 +306,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             (binding, val, ref res) => {
                 res = val.get_boolean ();
                 window.event_bus.flip_item (true);
-                on_item_coord_changed ();
                 return true;
             });
 

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -199,6 +199,21 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
                 _y = transform.y0;
             }
 
+            // Account for mirrored items.
+            if (flipped_h || flipped_v) {
+                var center_x = get_coords ("width") / 2;
+                var center_y = get_coords ("height") / 2;
+                var radians = Utils.AffineTransform.deg_to_rad (rotation);
+
+                var sx = flipped_v ? 1 : -1;
+                var sy = flipped_h ? 1 : -1;
+                transform.translate (center_x, center_y);
+                transform.rotate (-radians);
+                transform.scale (sx, sy);
+                transform.rotate (radians);
+                transform.translate (-center_x, -center_y);
+            }
+
             // Convert the coordinates for the artboard space.
             canvas.convert_to_item_space (artboard, ref _x, ref _y);
 
@@ -246,11 +261,23 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
 
         var center_x = get_coords ("width") / 2;
         var center_y = get_coords ("height") / 2;
+        var radians = Utils.AffineTransform.deg_to_rad (rotation);
 
         // Rotate around the center by the rotation amount.
         transform.translate (center_x, center_y);
-        transform.rotate (Utils.AffineTransform.deg_to_rad (rotation));
+        transform.rotate (radians);
         transform.translate (-center_x, -center_y);
+
+        // Account for mirrored items.
+        if (flipped_h || flipped_v) {
+            var sx = flipped_v ? 1 : -1;
+            var sy = flipped_h ? 1 : -1;
+            transform.translate (center_x, center_y);
+            transform.rotate (-radians);
+            transform.scale (sx, sy);
+            transform.rotate (radians);
+            transform.translate (-center_x, -center_y);
+        }
 
         set_transform (transform);
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -510,19 +510,17 @@ public class Akira.Utils.AffineTransform : Object {
     }
 
     public static void flip_item (CanvasItem item, double sx, double sy) {
-        double x, y, width, height;
-        item.get ("x", out x, "y", out y, "width", out width, "height", out height);
-        var center_x = x + width / 2;
-        var center_y = y + height / 2;
+        var center_x = item.get_coords ("width") / 2;
+        var center_y = item.get_coords ("height") / 2;
+        var transform = item.get_real_transform ();
+        double radians = deg_to_rad (item.rotation);
 
-        var transform = Cairo.Matrix.identity ();
-        item.get_transform (out transform);
-        double radians = item.rotation * (Math.PI / 180);
         transform.translate (center_x, center_y);
         transform.rotate (-radians);
         transform.scale (sx, sy);
         transform.rotate (radians);
         transform.translate (-center_x, -center_y);
+
         item.set_transform (transform);
 
         item.bounds_manager.update (item);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Since items inside an artboard rely on the `compute_transform()` method to properly render them, we need to maintain all the matrix transforms we edited.

## This PR fixes/implements the following **bugs/features**:
- Account for flipped items inside artboards.
- Account for flipped items when dropped inside artboards.

- Fixes #373
