### PR TITLE
Fix bounds manager on load

### DIFF
--- a/src/Lib/Managers/GhostBoundsManager.vala
+++ b/src/Lib/Managers/GhostBoundsManager.vala
@@ -29,6 +29,8 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
     private const string STROKE_COLOR = "#41c9fd";
     private const double LINE_WIDTH = 1.0;
 
+    // Matches the original item in order to keep the translation and rotation accurate.
+    private weak Models.CanvasItem original_item;
     public weak Akira.Lib.Canvas canvas;
 
     // Matches the original item in order to keep the translation and rotation accurate.
@@ -42,7 +44,8 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
         }
     }
 
-    public GhostBoundsManager (Models.CanvasItem original_item) {
+    public GhostBoundsManager (Models.CanvasItem new_item) {
+        original_item = new_item;
         canvas = original_item.canvas;
         item = new Goo.CanvasRect (null, 0, 0, 1, 1, "line-width", 0, null);
         item.visibility = Goo.CanvasItemVisibility.HIDDEN;
@@ -53,7 +56,7 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
     /*
      * Update the item to match size and transform matrix of the original item.
      */
-    public void update (Models.CanvasItem original_item) {
+    public void update () {
         double width, height;
         original_item.get ("width", out width, "height", out height);
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -471,6 +471,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         }
 
         restore_attributes (item, artboard, obj);
+        item.bounds_manager.update ();
     }
 
     /*

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -251,7 +251,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
                 cr.save ();
 
                 cr.transform (item.compute_transform (Cairo.Matrix.identity ()));
-                item.bounds_manager.update (item);
+                item.bounds_manager.update ();
 
                 var canvas_item = item as Goo.CanvasItemSimple;
 

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -116,6 +116,9 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
 
         init_position (_x, _y);
 
+        // Create the GhostBoundsManager to keep track of the global canvas bounds.
+        bounds_manager = new Managers.GhostBoundsManager (this);
+
         // Save the unedited pixbuf to enable resampling and restoring.
         manager.get_pixbuf.begin (-1, -1, (obj, res) => {
             try {
@@ -128,8 +131,7 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
                 size_locked = true;
                 size_ratio = width / height;
 
-                // Create the GhostBoundsManager to keep track of the global canvas bounds.
-                bounds_manager = new Managers.GhostBoundsManager (this);
+                bounds_manager.update ();
             } catch (Error e) {
                 warning (e.message);
                 canvas.window.event_bus.canvas_notification (e.message);

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -75,7 +75,7 @@ public class Akira.Utils.AffineTransform : Object {
         matrix.y0 = (y != null) ? y - diff_y : matrix.y0;
 
         item.set_transform (matrix);
-        item.bounds_manager.update (item);
+        item.bounds_manager.update ();
     }
 
     /**
@@ -107,7 +107,7 @@ public class Akira.Utils.AffineTransform : Object {
         initial_event_x = event_x;
         initial_event_y = event_y;
 
-        item.bounds_manager.update (item);
+        item.bounds_manager.update ();
     }
 
     public static void scale_from_event (
@@ -297,7 +297,7 @@ public class Akira.Utils.AffineTransform : Object {
         item.move (new_x, new_y);
         set_size (item, new_width, new_height);
 
-        item.bounds_manager.update (item);
+        item.bounds_manager.update ();
     }
 
     // Width size constraints.
@@ -494,7 +494,7 @@ public class Akira.Utils.AffineTransform : Object {
         // meaning no Akira Models was used and we don't need the bounds.
         if (!(item is Goo.CanvasRect)) {
             var model_item = item as CanvasItem;
-            model_item.bounds_manager.update (model_item);
+            model_item.bounds_manager.update ();
         }
     }
 
@@ -506,7 +506,7 @@ public class Akira.Utils.AffineTransform : Object {
         item.rotate (actual_rotation, center_x, center_y);
         item.rotation += actual_rotation;
 
-        item.bounds_manager.update (item);
+        item.bounds_manager.update ();
     }
 
     public static void flip_item (CanvasItem item, double sx, double sy) {
@@ -523,7 +523,7 @@ public class Akira.Utils.AffineTransform : Object {
 
         item.set_transform (transform);
 
-        item.bounds_manager.update (item);
+        item.bounds_manager.update ();
     }
 
     public static double fix_size (double size) {

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -35,8 +35,6 @@ public class Akira.Utils.AffineTransform : Object {
         double item_x = item.bounds_manager.bounds.x1;
         double item_y = item.bounds_manager.bounds.y1;
 
-        // debug (@"item x: $(item_x) y: $(item_y)");
-
         if (item.artboard != null) {
             item_x -= item.artboard.bounds.x1;
             item_y -= item.artboard.bounds.y1 + item.artboard.get_label_height ();


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
The bounds manager wasn't getting properly generate nor updated when loading a file or adding an image.

## This PR fixes/implements the following **bugs/features**:
- Generate the bounds manager when an image is first created and then update it once the full size pixbuf is generated.
- Update the bounds manager after an item has been loaded.
