### PR TITLE
Fix rotation

### DIFF
--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -103,9 +103,8 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
             case Managers.NobManager.Nob.ROTATE:
                 Utils.AffineTransform.rotate_from_event (
-                    selected_item,
-                    event_x, event_y,
-                    initial_event_x, initial_event_y
+                    selected_item, event_x, event_y,
+                    ref initial_event_x, ref initial_event_y
                 );
                 break;
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -407,6 +407,7 @@ public class Akira.Utils.AffineTransform : Object {
     ) {
         var canvas = item.canvas as Akira.Lib.Canvas;
         canvas.convert_to_item_space (item, ref x, ref y);
+        canvas.convert_to_item_space (item, ref initial_x, ref initial_y);
 
         var initial_width = item.get_coords ("width");
         var initial_height = item.get_coords ("height");
@@ -417,16 +418,17 @@ public class Akira.Utils.AffineTransform : Object {
         double rotation_amount = 0;
 
         var start_radians = GLib.Math.atan2 (
-            center_y - initial_y,
-            initial_x - center_x
+            initial_x - center_x,
+            center_y - initial_y
         );
 
         double current_x, current_y, current_scale, current_rotation;
         item.get_simple_transform (out current_x, out current_y, out current_scale, out current_rotation);
-        var radians = GLib.Math.atan2 (center_y - y, x - center_x);
+        var radians = GLib.Math.atan2 (x - center_x, center_y - y);
 
         radians = start_radians - radians;
         var rotation = radians * (180 / Math.PI) + prev_rotation_difference;
+        rotation = -rotation;
 
         initial_x = x;
         initial_y = y;
@@ -466,8 +468,7 @@ public class Akira.Utils.AffineTransform : Object {
             // Round rotation in order to avoid sub degree issue
             rotation = GLib.Math.round (rotation);
             // Cap new_rotation to the [0, 360] range
-            var new_rotation = GLib.Math.fmod (item.rotation + rotation, 360);
-            set_rotation (item, new_rotation);
+            set_rotation (item, rotation);
             canvas.convert_to_item_space (item, ref initial_x, ref initial_y);
         }
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -406,8 +406,14 @@ public class Akira.Utils.AffineTransform : Object {
         ref double initial_y
     ) {
         var canvas = item.canvas as Akira.Lib.Canvas;
-        canvas.convert_to_item_space (item, ref x, ref y);
-        canvas.convert_to_item_space (item, ref initial_x, ref initial_y);
+
+        if (item.artboard != null) {
+            canvas.convert_to_item_space (item.artboard, ref x, ref y);
+            canvas.convert_to_item_space (item.artboard, ref initial_x, ref initial_y);
+        } else {
+            canvas.convert_to_item_space (item, ref x, ref y);
+            canvas.convert_to_item_space (item, ref initial_x, ref initial_y);
+        }
 
         var center_x = item.get_coords ("width") / 2;
         var center_y = item.get_coords ("height") / 2;
@@ -429,7 +435,11 @@ public class Akira.Utils.AffineTransform : Object {
         }
 
         // Revert the coordinates to the canvas and udpate their references.
-        canvas.convert_from_item_space (item, ref x, ref y);
+        if (item.artboard != null) {
+            canvas.convert_from_item_space (item.artboard, ref x, ref y);
+        } else {
+            canvas.convert_from_item_space (item, ref x, ref y);
+        }
         initial_x = x;
         initial_y = y;
 
@@ -461,7 +471,8 @@ public class Akira.Utils.AffineTransform : Object {
 
         if (do_rotation) {
             // Round rotation in order to avoid sub degree issue.
-            set_rotation (item, GLib.Math.round (rotation + item.rotation));
+            var new_rotation = GLib.Math.fmod (item.rotation + rotation, 360);
+            set_rotation (item, GLib.Math.round (new_rotation));
         }
 
         // Reset rotation to prevent infinite rotation loops.

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -405,11 +405,22 @@ public class Akira.Utils.AffineTransform : Object {
         ref double initial_x,
         ref double initial_y
     ) {
+        var diff_x = 0.0;
+        var diff_y = 0.0;
         var canvas = item.canvas as Akira.Lib.Canvas;
 
         if (item.artboard != null) {
             canvas.convert_to_item_space (item.artboard, ref x, ref y);
             canvas.convert_to_item_space (item.artboard, ref initial_x, ref initial_y);
+
+            diff_x = item.bounds_manager.bounds.x1 - item.artboard.bounds.x1;
+            diff_y = item.bounds_manager.bounds.y1 - item.artboard.bounds.y1
+                     - item.artboard.get_label_height ();
+
+            x -= diff_x;
+            y -= diff_y;
+            initial_x -= diff_x;
+            initial_y -= diff_y;
         } else {
             canvas.convert_to_item_space (item, ref x, ref y);
             canvas.convert_to_item_space (item, ref initial_x, ref initial_y);
@@ -437,6 +448,8 @@ public class Akira.Utils.AffineTransform : Object {
         // Revert the coordinates to the canvas and udpate their references.
         if (item.artboard != null) {
             canvas.convert_from_item_space (item.artboard, ref x, ref y);
+            x += diff_x;
+            y += diff_y;
         } else {
             canvas.convert_from_item_space (item, ref x, ref y);
         }
@@ -470,8 +483,9 @@ public class Akira.Utils.AffineTransform : Object {
         }
 
         if (do_rotation) {
-            // Round rotation in order to avoid sub degree issue.
+            // Cap new_rotation to the [0, 360] range.
             var new_rotation = GLib.Math.fmod (item.rotation + rotation, 360);
+            // Round rotation in order to avoid sub degree issue.
             set_rotation (item, GLib.Math.round (new_rotation));
         }
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
- correct atan parameters
- reference points to item space
- invert calculated rotation (this can be simplified in atan calculation)

## Steps to Test

Rotate now behaves correctly


## Screenshots 

![akira-rotation](https://user-images.githubusercontent.com/220968/89121410-0a9b1880-d4bf-11ea-870a-657c7bbe6dfe.gif)

## Known Issues / Things To Do

- Rotate again after mouse release does an unexpected jump (corner case I guess)
