### PR TITLE
Cleanup bounds manager

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -151,11 +151,13 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Gdk.Key.Control_L:
             case Gdk.Key.Control_R:
                 ctrl_is_pressed = true;
+                toggle_item_ghost (false);
                 break;
 
             case Gdk.Key.Alt_L:
             case Gdk.Key.Alt_R:
-                toggle_item_ghost (true);
+                // Show the ghost item only if the CTRL button is not pressed.
+                toggle_item_ghost (!ctrl_is_pressed);
                 break;
 
             case Gdk.Key.Up:

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -331,10 +331,10 @@ public class Akira.Lib.Managers.ExportManager : Object {
             item.bounds_manager.hide ();
 
             // Account for items inside or outside artboards.
-            double x1 = item.bounds_manager.bounds.x1;
-            double x2 = item.bounds_manager.bounds.x2;
-            double y1 = item.bounds_manager.bounds.y1;
-            double y2 = item.bounds_manager.bounds.y2;
+            double x1 = item.bounds_manager.x1;
+            double x2 = item.bounds_manager.x2;
+            double y1 = item.bounds_manager.y1;
+            double y2 = item.bounds_manager.y2;
 
             // Create the rendered image with Cairo.
             surface = new Cairo.ImageSurface (
@@ -402,10 +402,10 @@ public class Akira.Lib.Managers.ExportManager : Object {
         // If the item is null it mean we're dealing with a custom area and we
         // don't have the bounds manager.
         if (item != null) {
-            double x1 = item.bounds_manager.bounds.x1;
-            double x2 = item.bounds_manager.bounds.x2;
-            double y1 = item.bounds_manager.bounds.y1;
-            double y2 = item.bounds_manager.bounds.y2;
+            double x1 = item.bounds_manager.x1;
+            double x2 = item.bounds_manager.x2;
+            double y1 = item.bounds_manager.y1;
+            double y2 = item.bounds_manager.y2;
 
             width = x2 - x1;
             height = y2 - y1 - label_height;

--- a/src/Lib/Managers/GhostBoundsManager.vala
+++ b/src/Lib/Managers/GhostBoundsManager.vala
@@ -31,25 +31,38 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
 
     // Matches the original item in order to keep the translation and rotation accurate.
     private weak Models.CanvasItem original_item;
-    public weak Akira.Lib.Canvas canvas;
 
     // Matches the original item in order to keep the translation and rotation accurate.
     private Goo.CanvasRect item;
     // Bounding Box item to be generated on the fly when the user requires it.
     private Goo.CanvasRect ghost;
 
-    public Goo.CanvasBounds bounds {
+    public double x1 {
         get {
-            return item.bounds;
+            return item.bounds.x1;
+        }
+    }
+    public double x2 {
+        get {
+            return item.bounds.x2;
+        }
+    }
+    public double y1 {
+        get {
+            return item.bounds.y1;
+        }
+    }
+    public double y2 {
+        get {
+            return item.bounds.y2;
         }
     }
 
     public GhostBoundsManager (Models.CanvasItem new_item) {
         original_item = new_item;
-        canvas = original_item.canvas;
         item = new Goo.CanvasRect (null, 0, 0, 1, 1, "line-width", 0, null);
         item.visibility = Goo.CanvasItemVisibility.HIDDEN;
-        item.set ("parent", canvas.get_root_item ());
+        item.set ("parent", original_item.canvas.get_root_item ());
         item.can_focus = false;
     }
 
@@ -89,7 +102,7 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
             null,
             item.bounds.x1, item.bounds.y1,
             item.bounds.x2 - item.bounds.x1, item.bounds.y2 - item.bounds.y1,
-            "line-width", LINE_WIDTH / canvas.current_scale,
+            "line-width", LINE_WIDTH / original_item.canvas.current_scale,
             "stroke-color", STROKE_COLOR,
             null
         );

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -48,7 +48,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
 
         window.event_bus.insert_item.connect (set_item_to_insert);
         window.event_bus.request_delete_item.connect (on_request_delete_item);
-        window.event_bus.change_item_z_index.connect (on_change_item_z_index);
         window.event_bus.hold_released.connect (on_hold_released);
     }
 
@@ -369,43 +368,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             border_size = (int) settings.border_size;
             border_color.parse (settings.border_color);
         }
-    }
-
-    private void on_change_item_z_index (Lib.Models.CanvasItem item, int position) {
-        // Lower `item` behind the item at index `position` or raise
-        // it above the item at index `position - 1`
-        var root_item = item.get_canvas ().get_root_item ();
-
-        switch (position) {
-            case -1:
-                // Put the item at the top of the stack
-                item.lower (null);
-                break;
-
-            case 0:
-                // Put the item on bottom of the stack
-                var canvas_item_at_top_position = root_item.get_n_children () - 11;
-                var canvas_item_at_top = root_item.get_child (canvas_item_at_top_position);
-
-                item.raise (canvas_item_at_top);
-                break;
-
-            default:
-                Goo.CanvasItem item_at_position = null;
-
-                var current_position = root_item.find_child (item);
-
-                if (current_position > position) {
-                    item_at_position = root_item.get_child (position);
-                    item.lower (item_at_position);
-                } else {
-                    item_at_position = root_item.get_child (position - 1);
-                    item.raise (item_at_position);
-                }
-                break;
-        }
-
-        window.event_bus.z_selected_changed ();
     }
 
     /*

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -149,6 +149,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                     break;
             }
 
+            // Create the GhostBoundsManager to keep track of the global canvas bounds.
+            new_item.bounds_manager = new Managers.GhostBoundsManager (new_item);
+
             window.event_bus.item_inserted (new_item);
             window.event_bus.file_edited ();
         }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -645,8 +645,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         }
 
         // Save the coordinates before removing the item.
-        var x = item.bounds_manager.bounds.x1;
-        var y = item.bounds_manager.bounds.y1;
+        var x = item.bounds_manager.x1;
+        var y = item.bounds_manager.y1;
 
         // If the item was moved from inside an Artboard to the emtpy Canvas.
         if (item.artboard != null && new_artboard == null) {

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -131,8 +131,6 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
 
         // Init items list.
         items = new Akira.Models.ListModel<Models.CanvasItem> ();
-        // Create the GhostBoundsManager to keep track of the global canvas bounds.
-        bounds_manager = new Managers.GhostBoundsManager (this);
 
         canvas.window.event_bus.zoom.connect (trigger_change);
         canvas.window.event_bus.change_theme.connect (trigger_change);

--- a/src/Lib/Models/CanvasEllipse.vala
+++ b/src/Lib/Models/CanvasEllipse.vala
@@ -120,8 +120,5 @@ public class Akira.Lib.Models.CanvasEllipse : Goo.CanvasEllipse, Models.CanvasIt
         }
 
         reset_colors ();
-
-        // Create the GhostBoundsManager to keep track of the global canvas bounds.
-        bounds_manager = new Managers.GhostBoundsManager (this);
     }
 }

--- a/src/Lib/Models/CanvasImage.vala
+++ b/src/Lib/Models/CanvasImage.vala
@@ -116,9 +116,6 @@ public class Akira.Lib.Models.CanvasImage : Goo.CanvasImage, Models.CanvasItem {
 
         init_position (_x, _y);
 
-        // Create the GhostBoundsManager to keep track of the global canvas bounds.
-        bounds_manager = new Managers.GhostBoundsManager (this);
-
         // Save the unedited pixbuf to enable resampling and restoring.
         manager.get_pixbuf.begin (-1, -1, (obj, res) => {
             try {

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -287,9 +287,9 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
     public virtual double get_global_coord (string coord_id) {
         switch (coord_id) {
             case "x":
-                return bounds_manager.bounds.x1;
+                return bounds_manager.x1;
             case "y":
-                return bounds_manager.bounds.y1;
+                return bounds_manager.y1;
             default:
                 return 0.0;
         }

--- a/src/Lib/Models/CanvasRect.vala
+++ b/src/Lib/Models/CanvasRect.vala
@@ -134,9 +134,6 @@ public class Akira.Lib.Models.CanvasRect : Goo.CanvasRect, Models.CanvasItem {
         }
 
         reset_colors ();
-
-        // Create the GhostBoundsManager to keep track of the global canvas bounds.
-        bounds_manager = new Managers.GhostBoundsManager (this);
     }
 
     public void update_border () {

--- a/src/Lib/Models/CanvasText.vala
+++ b/src/Lib/Models/CanvasText.vala
@@ -113,8 +113,5 @@ public class Akira.Lib.Models.CanvasText : Goo.CanvasText, Models.CanvasItem {
         set_transform (Cairo.Matrix.identity ());
 
         init_position (_x, _y);
-
-        // Create the GhostBoundsManager to keep track of the global canvas bounds.
-        bounds_manager = new Managers.GhostBoundsManager (this);
     }
 }

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -69,7 +69,6 @@ public class Akira.Services.EventBus : Object {
     public signal void hover_over_layer (Lib.Models.CanvasItem? item);
     public signal void item_deleted (Lib.Models.CanvasItem item);
     public signal void item_locked (Lib.Models.CanvasItem item);
-    public signal void change_item_z_index (Lib.Models.CanvasItem item, int position);
 
     // Others.
     public signal void disconnect_typing_accel ();

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -33,8 +33,8 @@ public class Akira.Utils.AffineTransform : Object {
 
     public static HashTable<string, double?> get_position (CanvasItem item) {
         HashTable<string, double?> array = new HashTable<string, double?> (str_hash, str_equal);
-        double item_x = item.bounds_manager.bounds.x1;
-        double item_y = item.bounds_manager.bounds.y1;
+        double item_x = item.bounds_manager.x1;
+        double item_y = item.bounds_manager.y1;
 
         if (item.artboard != null) {
             item_x -= item.artboard.bounds.x1;
@@ -53,8 +53,8 @@ public class Akira.Utils.AffineTransform : Object {
         if (item.artboard != null) {
             // Account for the different between the current position and the
             // the item's bounds.
-            diff_x = item.bounds_manager.bounds.x1 - item.artboard.bounds.x1 - item.relative_x;
-            diff_y = item.bounds_manager.bounds.y1 - item.artboard.bounds.y1
+            diff_x = item.bounds_manager.x1 - item.artboard.bounds.x1 - item.relative_x;
+            diff_y = item.bounds_manager.y1 - item.artboard.bounds.y1
                      - item.artboard.get_label_height () - item.relative_y;
 
             item.relative_x = x != null ? x - diff_x : item.relative_x;
@@ -67,8 +67,8 @@ public class Akira.Utils.AffineTransform : Object {
 
         // Account for the item rotation and get the difference between
         // its bounds and matrix coordinates.
-        diff_x = item.bounds_manager.bounds.x1 - matrix.x0;
-        diff_y = item.bounds_manager.bounds.y1 - matrix.y0;
+        diff_x = item.bounds_manager.x1 - matrix.x0;
+        diff_y = item.bounds_manager.y1 - matrix.y0;
 
         matrix.x0 = (x != null) ? x - diff_x : matrix.x0;
         matrix.y0 = (y != null) ? y - diff_y : matrix.y0;
@@ -414,8 +414,8 @@ public class Akira.Utils.AffineTransform : Object {
             canvas.convert_to_item_space (item.artboard, ref x, ref y);
             canvas.convert_to_item_space (item.artboard, ref initial_x, ref initial_y);
 
-            diff_x = item.bounds_manager.bounds.x1 - item.artboard.bounds.x1;
-            diff_y = item.bounds_manager.bounds.y1 - item.artboard.bounds.y1
+            diff_x = item.bounds_manager.x1 - item.artboard.bounds.x1;
+            diff_y = item.bounds_manager.y1 - item.artboard.bounds.y1
                      - item.artboard.get_label_height ();
 
             x -= diff_x;


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Some code clean ups and improvements to the `GhostBoundsManager`.

## This PR fixes/implements the following **bugs/features**:
- [x] Create getters to better get the item bounds coordinates.
- [x] Remove a couple of unused methods.
- [x] Prevent the ghost item to be visible if CTRL is pressed.
