### PR TITLE
Fix free items dnd layers

### DIFF
--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -85,24 +85,23 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
 
         move_up = new Akira.Partials.HeaderBarButton (window, "selection-raise",
             _("Up"), {"<Ctrl>Up"}, "single");
-        move_up.button.clicked.connect (() => {
-            window.event_bus.change_z_selected (true, false);
-        });
+        move_up.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX
+            + Akira.Services.ActionManager.ACTION_MOVE_UP;
+
         move_down = new Akira.Partials.HeaderBarButton (window, "selection-lower",
             _("Down"), {"<Ctrl>Down"}, "single");
-        move_down.button.clicked.connect (() => {
-            window.event_bus.change_z_selected (false, false);
-        });
+        move_down.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX
+            + Akira.Services.ActionManager.ACTION_MOVE_DOWN;
+
         move_top = new Akira.Partials.HeaderBarButton (window, "selection-top",
             _("Top"), {"<Ctrl><Shift>Up"}, "single");
-        move_top.button.clicked.connect (() => {
-            window.event_bus.change_z_selected (true, true);
-        });
+        move_top.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX
+            + Akira.Services.ActionManager.ACTION_MOVE_TOP;
+
         move_bottom = new Akira.Partials.HeaderBarButton (window, "selection-bottom",
             _("Bottom"), {"<Ctrl><Shift>Down"}, "single");
-        move_bottom.button.clicked.connect (() => {
-            window.event_bus.change_z_selected (false, true);
-        });
+        move_bottom.button.action_name = Akira.Services.ActionManager.ACTION_PREFIX
+            + Akira.Services.ActionManager.ACTION_MOVE_BOTTOM;
 
         preferences = new Akira.Partials.HeaderBarButton (window, "open-menu",
             _("Settings"), {"<Ctrl>comma"});

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -364,9 +364,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         window.event_bus.file_edited.connect (on_file_edited);
         window.event_bus.file_saved.connect (on_file_saved);
         window.event_bus.selected_items_changed.connect (on_selected_items_changed);
-        window.event_bus.z_selected_changed.connect (() => {
-            update_button_sensitivity (false);
-        });
+        window.event_bus.z_selected_changed.connect (update_button_sensitivity);
         window.event_bus.set_scale.connect (on_set_scale);
         window.event_bus.update_recent_files_list.connect (fetch_recent_files);
     }
@@ -506,17 +504,17 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
     private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {
         if (selected_items.length () == 0) {
             selected_item = null;
-            update_button_sensitivity (true);
+            update_button_sensitivity ();
             return;
         }
 
         if (selected_item == null || selected_item != selected_items.nth_data (0)) {
             selected_item = selected_items.nth_data (0);
-            update_button_sensitivity (true);
+            update_button_sensitivity ();
         }
     }
 
-    private void update_button_sensitivity (bool selected) {
+    private void update_button_sensitivity () {
         var z_buttons_sensitive = selected_item != null && !(selected_item is Lib.Models.CanvasArtboard);
 
         move_up.sensitive = z_buttons_sensitive;

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -387,31 +387,8 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         // Change artboard if necessary.
         window.items_manager.change_artboard (layer.model, model);
 
-        items_count = (int) model.items.get_n_items ();
-        pos_source = items_count - 1 - model.items.index (layer.model);
-
-        // Interrupt if item position doesn't exist.
-        if (pos_source == -1) {
-            return;
-        }
-
-        // z-index is the exact opposite of items placement as the last item
-        // is the topmost element. Because of this, we need some trickery to
-        // properly handle the list's order.
-        source = items_count - 1 - pos_source;
-
-        // Interrupt if the item was dropped in the same position.
-        if (source == 0) {
-            debug ("same position");
-            return;
-        }
-
-        // Remove item at source position
-        var item_to_swap = model.items.remove_at (source);
-
-        // Insert item at target position
-        model.items.insert_at (0, item_to_swap);
-        window.event_bus.z_selected_changed ();
+        // Use the existing action to push an item all the way to the top.
+        window.event_bus.change_z_selected (true, true);
 
         model.changed (true);
     }

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -435,7 +435,6 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
         // Insert item at target position
         items_source.insert_at (target, item_to_swap);
-        window.event_bus.z_selected_changed ();
 
         if (model.artboard != null) {
             model.artboard.changed (true);
@@ -448,6 +447,8 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
             target = items_count - 1 - items_source.index (item_to_swap);
             root.add_child (item_to_swap, target);
         }
+
+        window.event_bus.z_selected_changed ();
     }
 
     /**

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -241,12 +241,13 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
 
         // Insert item at target position.
         window.items_manager.free_items.insert_at (items_count - 1, item_to_swap);
-        window.event_bus.z_selected_changed ();
 
         var root = window.main_window.main_canvas.canvas.get_root_item ();
         // Fetch the new correct position.
         var target = items_count - 1 - window.items_manager.free_items.index (item_to_swap);
         root.add_child (item_to_swap, target);
+
+        window.event_bus.z_selected_changed ();
     }
 
     private void check_scroll (int y) {

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -216,38 +216,8 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
             return;
         }
 
-        items_count = (int) window.items_manager.free_items.get_n_items ();
-        pos_source = items_count - 1 - window.items_manager.free_items.index (layer.model);
-
-        // Interrupt if item position doesn't exist.
-        if (pos_source == -1) {
-            return;
-        }
-
-        // z-index is the exact opposite of items placement as the last item
-        // is the topmost element. Because of this, we need some trickery to
-        // properly handle the list's order.
-        source = items_count - 1 - pos_source;
-
-        // Interrupt if the item was dropped in the same position.
-        if (source == items_count - 1) {
-            debug ("same position");
-            return;
-        }
-
-        // Remove item at source position.
-        var item_to_swap = window.items_manager.free_items.remove_at (source);
-        item_to_swap.parent.remove_child (item_to_swap.parent.find_child (item_to_swap));
-
-        // Insert item at target position.
-        window.items_manager.free_items.insert_at (items_count - 1, item_to_swap);
-
-        var root = window.main_window.main_canvas.canvas.get_root_item ();
-        // Fetch the new correct position.
-        var target = items_count - 1 - window.items_manager.free_items.index (item_to_swap);
-        root.add_child (item_to_swap, target);
-
-        window.event_bus.z_selected_changed ();
+        // Use the existing action to push an item all the way to the bottom.
+        window.event_bus.change_z_selected (false, true);
     }
 
     private void check_scroll (int y) {

--- a/src/Layouts/RightSideBar.vala
+++ b/src/Layouts/RightSideBar.vala
@@ -203,38 +203,8 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
             return;
         }
 
-        items_count = (int) window.items_manager.free_items.get_n_items ();
-        pos_source = items_count - 1 - window.items_manager.free_items.index (layer.model);
-
-        // Interrupt if item position doesn't exist.
-        if (pos_source == -1) {
-            return;
-        }
-
-        // z-index is the exact opposite of items placement as the last item
-        // is the topmost element. Because of this, we need some trickery to
-        // properly handle the list's order.
-        source = items_count - 1 - pos_source;
-
-        // Interrupt if the item was dropped in the same position.
-        if (source == 0) {
-            debug ("same position");
-            return;
-        }
-
-        // Remove item at source position.
-        var item_to_swap = window.items_manager.free_items.remove_at (source);
-        item_to_swap.parent.remove_child (item_to_swap.parent.find_child (item_to_swap));
-
-        // Insert item at target position.
-        window.items_manager.free_items.insert_at (0, item_to_swap);
-
-        var root = window.main_window.main_canvas.canvas.get_root_item ();
-        // Fetch the new correct position.
-        var target = items_count - 1 - window.items_manager.free_items.index (item_to_swap);
-        root.add_child (item_to_swap, target);
-
-        window.event_bus.z_selected_changed ();
+        // Use the existing action to push an item all the way to the top.
+        window.event_bus.change_z_selected (true, true);
     }
 
     private bool handle_focus_in (Gdk.EventFocus event) {

--- a/src/Layouts/RightSideBar.vala
+++ b/src/Layouts/RightSideBar.vala
@@ -228,12 +228,13 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
 
         // Insert item at target position.
         window.items_manager.free_items.insert_at (0, item_to_swap);
-        window.event_bus.z_selected_changed ();
 
         var root = window.main_window.main_canvas.canvas.get_root_item ();
         // Fetch the new correct position.
         var target = items_count - 1 - window.items_manager.free_items.index (item_to_swap);
         root.add_child (item_to_swap, target);
+
+        window.event_bus.z_selected_changed ();
     }
 
     private bool handle_focus_in (Gdk.EventFocus event) {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -241,8 +241,8 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         if (selected_item.artboard != null) {
             selected_item.artboard.items.swap_items (source, target);
 
-            canvas.window.event_bus.z_selected_changed ();
             selected_item.artboard.changed (true);
+            canvas.window.event_bus.z_selected_changed ();
 
             // There is no need to raise or lower the selection
             // since the z stacking is done inside the paint method


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
During the Alpha release live streaming I stumbled upon a strange inconsistent bug while using the layers drag and drop feature.

## Steps to Test
Bug:
- Create 4 items in the empty canvas.
- Drag the bottom layer and drop it on top of the search bar.
- The layer doesn't reorder properly in the canvas but is correct in the layers panel.

## This PR fixes/implements the following **bugs/features**:
I was doing a wrong items calculation for free items.
I fixed by using the already available actions that perfectly work.
