### PR TITLE
Improve artboard item selection

### DIFF
--- a/data/com.github.akiraux.akira.appdata.xml.in.in
+++ b/data/com.github.akiraux.akira.appdata.xml.in.in
@@ -32,6 +32,16 @@
 		<binary>@APP_ID@</binary>
 	</provides>
   <releases>
+    <release version="0.0.12" date="2020-08-11">
+      <description>
+        <p>Bug fixes and improvements</p>
+        <ul>
+          <li>Fix items reordering with the layers panel drag and drop</li>
+          <li>Fix random segfault at startup while setting accelerators</li>
+          <li>Updated goocanvas vapi</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.0.11" date="2020-08-04">
       <description>
         <p>🚀 Experimental Alpha Release, say Hi to Akira!</p>

--- a/data/com.github.akiraux.akira.appdata.xml.in.in
+++ b/data/com.github.akiraux.akira.appdata.xml.in.in
@@ -34,8 +34,9 @@
   <releases>
     <release version="0.0.12" date="2020-08-11">
       <description>
-        <p>Bug fixes and improvements</p>
+        <p>Bug fixes and Artboards improvements</p>
         <ul>
+          <li>Items inside Artboards are masked when extending outside the edges of the Artboard.</li>
           <li>Fix items reordering with the layers panel drag and drop</li>
           <li>Fix random segfault at startup while setting accelerators</li>
           <li>Updated goocanvas vapi</li>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 com.github.akiraux.akira (0.0.12) xenial; urgency=medium
 
+  * Items inside Artboards are masked when extending outside the edges of the Artboard.
   * Fix items reordering with the layers panel drag and drop.
   * Fix random segfault at startup while setting accelerators.
   * Updated goocanvas vapi.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+com.github.akiraux.akira (0.0.12) xenial; urgency=medium
+
+  * Fix items reordering with the layers panel drag and drop.
+  * Fix random segfault at startup while setting accelerators.
+  * Updated goocanvas vapi.
+
+ -- Alessandro Castellani <castellani.ale@gmail.com>  Sun, 11 Aug 2020 09:00:00 -0800
+
 com.github.akiraux.akira (0.0.11) xenial; urgency=medium
 
   * Experimental Alpha Release, say Hi to Akira!

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -137,7 +137,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         switch (uppercase_keyval) {
             case Gdk.Key.Escape:
-                edit_mode = Akira.Lib.Canvas.EditMode.MODE_SELECTION;
+                edit_mode = EditMode.MODE_SELECTION;
                 // Clear the selected export area to be sure to not leave anything behind.
                 export_manager.clear ();
                 break;

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -229,17 +229,19 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
                 cr.save ();
                 cr.transform (item.compute_transform (Cairo.Matrix.identity ()));
 
+                // TEMPORARILY REMOVED.
+                // This won't work until the official goocanvas PPA gets the fixed VAPI.
                 // Clip the item if it comes with a path mask.
-                if (canvas_item.simple_data.clip_path_commands != null) {
-                    Goo.Canvas.create_path (canvas_item.simple_data.clip_path_commands, cr);
-                    Cairo.FillRule fill_rule =
-                        canvas_item.simple_data.clip_fill_rule == 0
-                        ? Cairo.FillRule.EVEN_ODD
-                        : Cairo.FillRule.WINDING;
+                // if (canvas_item.simple_data.clip_path_commands != null) {
+                //     Goo.Canvas.create_path (canvas_item.simple_data.clip_path_commands, cr);
+                //     Cairo.FillRule fill_rule =
+                //         canvas_item.simple_data.clip_fill_rule == 0
+                //         ? Cairo.FillRule.EVEN_ODD
+                //         : Cairo.FillRule.WINDING;
 
-                    cr.set_fill_rule (fill_rule);
-                    cr.clip ();
-                }
+                //     cr.set_fill_rule (fill_rule);
+                //     cr.clip ();
+                // }
 
                 canvas_item.simple_paint (cr, bounds);
                 cr.restore ();

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -155,27 +155,17 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public bool is_outside (Models.CanvasItem item) {
-        var x1 = item.get_global_coord ("x");
-        var x2 = x1 + item.get_coords ("width");
-        var y1 = item.get_global_coord ("y");
-        var y2 = y1 + item.get_coords ("height");
-
-        return x1 < bounds.x1
-            || x2 > bounds.x2
-            || y1 < bounds.y1
-            || y2 > bounds.y2;
+        return item.bounds_manager.x1 < bounds.x1
+            || item.bounds_manager.x2 > bounds.x2
+            || item.bounds_manager.y1 < bounds.y1
+            || item.bounds_manager.y2 > bounds.y2;
     }
 
     public bool dropped_inside (Models.CanvasItem item) {
-        var x1 = item.get_global_coord ("x");
-        var x2 = x1 + item.get_coords ("width");
-        var y1 = item.get_global_coord ("y");
-        var y2 = y1 + item.get_coords ("height");
-
-        return x1 < bounds.x2
-            && x2 > bounds.x1
-            && y1 < bounds.y2
-            && y2 > bounds.y1;
+        return item.bounds_manager.x1 < bounds.x2
+            && item.bounds_manager.x2 > bounds.x1
+            && item.bounds_manager.y1 < bounds.y2
+            && item.bounds_manager.y2 > bounds.y1;
     }
 
     public void add_child (Goo.CanvasItem item, int position = -1) {
@@ -195,14 +185,8 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         Cairo.ImageSurface surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, 290, 256);
         Cairo.Context cr = new Cairo.Context (surface);
 
-        cr.select_font_face (
-            "Sans",
-            Cairo.FontSlant.NORMAL,
-            Cairo.FontWeight.NORMAL
-            );
-
+        cr.select_font_face ("Sans", Cairo.FontSlant.NORMAL, Cairo.FontWeight.NORMAL);
         cr.set_font_size (LABEL_FONT_SIZE / (canvas as Lib.Canvas).current_scale);
-
         cr.text_extents (id, out label_extents);
     }
 
@@ -237,7 +221,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
 
             // Painting items in reversed order in order to
             // print last item inserted (top of the stack) on top
-            // of the items inserted before
+            // of the items inserted before.
             for (var i = 0; i < items_length; i++) {
                 var item = items[items_length - 1 - i];
 
@@ -267,8 +251,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public override bool simple_is_item_at (double x, double y, Cairo.Context cr, bool is_pointer_event) {
-        // To select an Artboard you should put the arrow
-        // over the Artboard label
+        // To select an Artboard you should put the arrow over the Artboard label.
         return y < 0
             && y > - (label_extents.height + LABEL_BOTTOM_PADDING)
             && x > 0

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -192,7 +192,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
 
     public override void simple_update (Cairo.Context cr) {
         bounds.x1 = x;
-        bounds.y1 = y - label_extents.height - LABEL_BOTTOM_PADDING;
+        bounds.y1 = y - get_label_height ();
         bounds.x2 = x + width;
         bounds.y2 = y + height;
     }
@@ -253,7 +253,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     public override bool simple_is_item_at (double x, double y, Cairo.Context cr, bool is_pointer_event) {
         // To select an Artboard you should put the arrow over the Artboard label.
         return y < 0
-            && y > - (label_extents.height + LABEL_BOTTOM_PADDING)
+            && y > - get_label_height ()
             && x > 0
             && x < (label_extents.width);
     }
@@ -280,14 +280,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         }
 
         foreach (Lib.Models.CanvasItem item in items) {
-            var item_x = x;
-            var item_y = y;
-
-            canvas.convert_to_item_space (item, ref item_x, ref item_y);
-
-            var item_is_inside = item.simple_is_item_at (x, y, cr, is_pointer_event);
-
-            if (item_is_inside) {
+            if (item.simple_is_item_at (x, y, cr, is_pointer_event)) {
                 found_items.append (item);
             }
         }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -154,13 +154,6 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
             && y <= bounds.y2;
     }
 
-    public bool is_outside (Models.CanvasItem item) {
-        return item.bounds_manager.x1 < bounds.x1
-            || item.bounds_manager.x2 > bounds.x2
-            || item.bounds_manager.y1 < bounds.y1
-            || item.bounds_manager.y2 > bounds.y2;
-    }
-
     public bool dropped_inside (Models.CanvasItem item) {
         return item.bounds_manager.x1 < bounds.x2
             && item.bounds_manager.x2 > bounds.x1
@@ -198,7 +191,6 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
     }
 
     public override void simple_paint (Cairo.Context cr, Goo.CanvasBounds bounds) {
-        bool force_redraw = false;
         cr.set_source_rgba (0, 0, 0, 0.6);
 
         if (settings.dark_theme) {
@@ -229,11 +221,6 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
             for (var i = 0; i < items_length; i++) {
                 var item = items[items_length - 1 - i];
 
-                // Check if the item is partially outside.
-                if (is_outside (item)) {
-                    force_redraw = true;
-                }
-
                 var canvas_item = item as Goo.CanvasItemSimple;
                 if (canvas_item == null || item.visibility != Goo.CanvasItemVisibility.VISIBLE) {
                     continue;
@@ -258,10 +245,6 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
                 cr.restore ();
 
                 item.bounds_manager.update ();
-            }
-
-            if (force_redraw) {
-                canvas.queue_draw ();
             }
         }
     }

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -271,6 +271,21 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         bool parent_is_visible,
         GLib.List<Goo.CanvasItem> found_items
     ) {
+        // Check if the item needs a paint update.
+        if (need_update == 1) {
+            ensure_updated ();
+        }
+
+        // Skip the item if the point isn't in the item's bounds.
+        if (bounds.x1 > x || bounds.x2 < x || bounds.y1 > y || bounds.y2 < y) {
+            return found_items;
+        }
+
+        // Skip the item if is not visible or locked.
+        if (visibility != Goo.CanvasItemVisibility.VISIBLE || locked == true) {
+            return found_items;
+        }
+
         var artboard_x = x;
         var artboard_y = y;
 

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -358,28 +358,16 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         border_color = rgba_stroke;
     }
 
+    /*
+     * TODO: This method needs to account for the actual path of the item and not
+     * just the bounding box. I don't know if this is possible directly with goocanvas
+     * or it needs some cairo trickery to make it work.
+     */
     public bool simple_is_item_at (double x, double y, Cairo.Context cr, bool is_pointer_event) {
-        var width = get_coords ("width");
-        var height = get_coords ("height");
-
-        var item_x = relative_x;
-        var item_y = relative_y;
-
-        canvas.convert_from_item_space (
-            artboard,
-            ref item_x,
-            ref item_y);
-
-        if (
-            x >= item_x
-            && x <= item_x + width
-            && y >= item_y
-            && y <= item_y + height
-        ) {
-            return true;
-        }
-
-        return false;
+        return x >= bounds_manager.x1
+            && x <= bounds_manager.x2
+            && y >= bounds_manager.y1
+            && y <= bounds_manager.y2;
     }
 
     // Update the size ratio to respect the updated size.

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -284,17 +284,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         return transform;
     }
 
-    public virtual double get_global_coord (string coord_id) {
-        switch (coord_id) {
-            case "x":
-                return bounds_manager.x1;
-            case "y":
-                return bounds_manager.y1;
-            default:
-                return 0.0;
-        }
-    }
-
     public virtual void reset_colors () {
         reset_fill ();
         reset_border ();

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -128,8 +128,8 @@ public class Akira.Utils.AffineTransform : Object {
 
         double item_width = item.get_coords ("width");
         double item_height = item.get_coords ("height");
-        double item_x = item.get_global_coord ("x");
-        double item_y = item.get_global_coord ("y");
+        double item_x = item.bounds_manager.x1;
+        double item_y = item.bounds_manager.y1;
 
         double new_width = 0;
         double new_height = 0;


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Artboards are a whole new beast that need a lot of work, so let's start doing some small PRs to slowly improve them.

## Steps to Test
- Create an artboard
- Create various items inside an artboard
- Rotate/scale them and move them around.

## Screenshots
![masked-artboard](https://user-images.githubusercontent.com/2527103/89967960-89066180-dc07-11ea-8d25-04800bc4a44b.gif)

## Known Issues / Things To Do
- The `simple_is_item_at` in the current state accounts only for the item's bounding box. This is not optimal as it should only react when the pointer is inside the actual path, and ignore it when it's on the empty area.

## This PR fixes/implements the following **bugs/features**:
- Mask items outside the canvas
- Account for item's clipping mask
- Removes the necessity of constantly calling the `canvas_redraw` method 
- Some code clean up to reduce repetition
