### PR TITLE
Restore saved background colors for artboards

### DIFF
--- a/data/com.github.akiraux.akira.appdata.xml.in.in
+++ b/data/com.github.akiraux.akira.appdata.xml.in.in
@@ -32,6 +32,15 @@
 		<binary>@APP_ID@</binary>
 	</provides>
   <releases>
+    <release version="0.0.13" date="2020-08-17">
+      <description>
+        <p>Bug fixes and improvements</p>
+        <ul>
+          <li>Fix loading Artboards background color when opening a file.</li>
+          <li>General code improvements and optimization.</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.0.12" date="2020-08-12">
       <description>
         <p>Bug fixes and Artboards improvements</p>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+com.github.akiraux.akira (0.0.13) xenial; urgency=medium
+
+  * Fix loading Artboards background color when opening a file.
+  * General code improvements and optimization.
+
+ -- Alessandro Castellani <castellani.ale@gmail.com>  Sun, 17 Aug 2020 09:00:00 -0800
+
 com.github.akiraux.akira (0.0.12) xenial; urgency=medium
 
   * Control Artboards background color.

--- a/src/Dialogs/ReleaseDialog.vala
+++ b/src/Dialogs/ReleaseDialog.vala
@@ -63,7 +63,7 @@ public class Akira.Dialogs.ReleaseDialog : Gtk.Dialog {
         app_version.get_style_context ().add_class ("h2");
         app_version.selectable = true;
 
-        var version_title = new Gtk.Label ("Bug fixes and Artboards improvements");
+        var version_title = new Gtk.Label ("Bug fixes and improvements");
         version_title.get_style_context ().add_class ("h3");
 
         var version_date = new Gtk.Label ("Aug 12th, 2020");
@@ -81,7 +81,7 @@ public class Akira.Dialogs.ReleaseDialog : Gtk.Dialog {
         scrolled.expand = true;
 
         var release_info = new Gtk.TextView ();
-        release_info.buffer.text = "✓ Control Artboards background color.\n✓ Hide and Lock Artbaords from the Layers panel.\n✓ Items inside Artboards are masked when extending outside the edges of the Artboard.\n✓ Fix items reordering with the layers panel drag and drop.\n✓ Fix random segfault at startup while setting accelerators.\n✓ Updated goocanvas vapi.";
+        release_info.buffer.text = "✓ Fix loading Artboards background color when opening a file.\n✓ General code improvements and optimization.\n";
         release_info.pixels_below_lines = 3;
         release_info.border_width = 12;
         release_info.wrap_mode = Gtk.WrapMode.WORD;

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -487,20 +487,29 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 ? Goo.CanvasItemVisibility.VISIBLE
                 : Goo.CanvasItemVisibility.INVISIBLE;
 
-        // Restore fill and border.
-        if (!(item is Models.CanvasArtboard)) {
-            item.has_fill = obj.get_boolean_member ("has-fill");
-            item.hidden_fill = obj.get_boolean_member ("hidden-fill");
-            item.fill_alpha = (int) obj.get_int_member ("fill-alpha");
-            item.color_string = obj.get_string_member ("color-string");
+        // Restore the fill attributes.
+        item.has_fill = obj.get_boolean_member ("has-fill");
+        item.hidden_fill = obj.get_boolean_member ("hidden-fill");
+        item.fill_alpha = (int) obj.get_int_member ("fill-alpha");
+        // If an item doesn't have any fill color, set a default white in case
+        // this is an artboard and it needs to be rendered.
+        item.color_string =
+            obj.get_string_member ("color-string") != null
+            ? obj.get_string_member ("color-string")
+            : "#ffffff";
 
-            item.has_border = obj.get_boolean_member ("has-border");
-            item.hidden_border = obj.get_boolean_member ("hidden-border");
-            item.border_size = (int) obj.get_int_member ("border-size");
-            item.stroke_alpha = (int) obj.get_int_member ("stroke-alpha");
-            item.border_color_string = obj.get_string_member ("border-color-string");
+        // Restore the border attributes.
+        item.has_border = obj.get_boolean_member ("has-border");
+        item.hidden_border = obj.get_boolean_member ("hidden-border");
+        item.border_size = (int) obj.get_int_member ("border-size");
+        item.stroke_alpha = (int) obj.get_int_member ("stroke-alpha");
+        item.border_color_string = obj.get_string_member ("border-color-string");
 
-            item.load_colors ();
+        item.load_colors ();
+
+        // Trigger the simple_update () method for artboards.
+        if (item is Models.CanvasArtboard) {
+            (item as Models.CanvasArtboard).trigger_change ();
         }
 
         item.set ("relative-x", obj.get_double_member ("relative-x"));


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
The background color of Artboards wasn't properly loaded when opening a file.

## Steps to Test
- Create a file with multiple Artboards.
- Set some custom colors for some Artboards.
- Leave other Artboards with the default color, hidden, or no color at all.
- Save the file and close the application.
- Open the file and confirm the colors were properly restored.

## This PR fixes/implements the following **bugs/features**:
- Load the custom Artboard colors.
- Set a default white color for old files that don't have a background color set for Artboards.
