### PR TITLE
Fix the numbering of newly created items

### DIFF
--- a/data/com.github.akiraux.akira.appdata.xml.in.in
+++ b/data/com.github.akiraux.akira.appdata.xml.in.in
@@ -37,6 +37,7 @@
         <p>Bug fixes and improvements</p>
         <ul>
           <li>Fix loading Artboards background color when opening a file.</li>
+          <li>Fix numbering of newly created items.</li>
           <li>General code improvements and optimization.</li>
         </ul>
       </description>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 com.github.akiraux.akira (0.0.13) xenial; urgency=medium
 
   * Fix loading Artboards background color when opening a file.
+  * Fix numbering of newly created items.
   * General code improvements and optimization.
 
  -- Alessandro Castellani <castellani.ale@gmail.com>  Sun, 17 Aug 2020 09:00:00 -0800

--- a/src/Dialogs/ReleaseDialog.vala
+++ b/src/Dialogs/ReleaseDialog.vala
@@ -81,7 +81,7 @@ public class Akira.Dialogs.ReleaseDialog : Gtk.Dialog {
         scrolled.expand = true;
 
         var release_info = new Gtk.TextView ();
-        release_info.buffer.text = "✓ Fix loading Artboards background color when opening a file.\n✓ General code improvements and optimization.\n";
+        release_info.buffer.text = "✓ Fix loading Artboards background color when opening a file.\n✓ General code improvements and optimization.\n✓ Fix numbering of newly created items.\n";
         release_info.pixels_below_lines = 3;
         release_info.border_width = 12;
         release_info.wrap_mode = Gtk.WrapMode.WORD;

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -30,7 +30,6 @@ public enum Akira.Lib.Models.CanvasItemType {
 
 public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasItem {
     // Identifiers.
-    public static int global_id = 0;
     public abstract Models.CanvasItemType item_type { get; set; }
     public abstract string id { get; set; }
     public abstract string name { get; set; }
@@ -102,7 +101,21 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
         string[] type_slug_tokens = item.item_type.to_string ().split ("_");
         string type_slug = type_slug_tokens[type_slug_tokens.length - 1];
 
-        return "%s %d".printf (capitalize (type_slug.down ()), global_id++);
+        // Make sure the initial ID is the current count of the total amount
+        // of items with the same item type in the same artboard.
+        int count = 0;
+        var items = item.artboard != null ? item.artboard.items : item.canvas.window.items_manager.free_items;
+        if (item is Models.CanvasArtboard) {
+            items = item.canvas.window.items_manager.artboards;
+        }
+
+        foreach (var _item in items) {
+            if (_item.item_type == item.item_type) {
+                count++;
+            }
+        }
+
+        return "%s %d".printf (capitalize (type_slug.down ()), count);
     }
 
     public static string capitalize (string s) {


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Since IDs are not used for any reference, we don't really need a unique identifier for items and the initial name should have an accurate count of the current available items from the same type. 

## This PR fixes/implements the following **bugs/features**:
- Count the same items type on creation to return the correct local ID of the item.

### Fixes
- Fixes #343
- Fixes #344
