### PR TITLE
Fix gtk warnings export dialog

### DIFF
--- a/data/com.github.akiraux.akira.appdata.xml.in.in
+++ b/data/com.github.akiraux.akira.appdata.xml.in.in
@@ -38,6 +38,7 @@
         <ul>
           <li>Fix loading Artboards background color when opening a file.</li>
           <li>Fix numbering of newly created items.</li>
+          <li>Fix Gtk-CRITICAL warning when opening the Export Dialog.</li>
           <li>General code improvements and optimization.</li>
         </ul>
       </description>

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ com.github.akiraux.akira (0.0.13) xenial; urgency=medium
 
   * Fix loading Artboards background color when opening a file.
   * Fix numbering of newly created items.
+  * Fix Gtk-CRITICAL warning when opening the Export Dialog.
   * General code improvements and optimization.
 
  -- Alessandro Castellani <castellani.ale@gmail.com>  Sun, 17 Aug 2020 09:00:00 -0800

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -31,7 +31,6 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     public Gtk.FileChooserButton folder_button;
     public Gtk.Adjustment quality_adj;
     public Gtk.Scale quality_scale;
-    public Akira.Partials.InputField quality_entry;
     public Gtk.Adjustment compression_adj;
     public Gtk.Scale compression_scale;
     public Gtk.ComboBoxText file_format;
@@ -138,6 +137,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         });
 
         settings.bind ("export-paned", pane, "position", SettingsBindFlags.DEFAULT);
+        settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
     }
 
     private void build_export_sidebar () {
@@ -171,7 +171,6 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         file_format.append ("jpg", "JPG");
         file_format.changed.connect (update_format_ui);
         grid.attach (file_format, 1, 2, 1, 1);
-        settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
         settings.changed["export-format"].connect (() => {
             manager.regenerate_pixbuf (export_type);
         });
@@ -262,7 +261,6 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     public void update_format_ui () {
         jpg_title.visible = (file_format.active_id == "jpg");
         quality_scale.visible = (file_format.active_id == "jpg");
-        quality_entry.visible = (file_format.active_id == "jpg");
 
         png_title.visible = (file_format.active_id == "png");
         compression_scale.visible = (file_format.active_id == "png");

--- a/src/Dialogs/ReleaseDialog.vala
+++ b/src/Dialogs/ReleaseDialog.vala
@@ -81,7 +81,7 @@ public class Akira.Dialogs.ReleaseDialog : Gtk.Dialog {
         scrolled.expand = true;
 
         var release_info = new Gtk.TextView ();
-        release_info.buffer.text = "✓ Fix loading Artboards background color when opening a file.\n✓ General code improvements and optimization.\n✓ Fix numbering of newly created items.\n";
+        release_info.buffer.text = "✓ Fix loading Artboards background color when opening a file.\n✓ General code improvements and optimization.\n✓ Fix numbering of newly created items.\n✓ Fix Gtk-CRITICAL warning when opening the Export Dialog.\n";
         release_info.pixels_below_lines = 3;
         release_info.border_width = 12;
         release_info.wrap_mode = Gtk.WrapMode.WORD;


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Multiple `Gtk-CRITICAL` warnings when opening the Export Dialog due to an early settings bind and a leftover from a previously deleted widget.
