### PR TITLE
Fix segfault items move outside artboard

### DIFF
--- a/data/com.github.akiraux.akira.appdata.xml.in.in
+++ b/data/com.github.akiraux.akira.appdata.xml.in.in
@@ -39,6 +39,9 @@
           <li>Fix loading Artboards background color when opening a file.</li>
           <li>Fix numbering of newly created items.</li>
           <li>Fix Gtk-CRITICAL warning when opening the Export Dialog.</li>
+          <li>Fix flipping items inside Artbaords.</li>
+          <li>Fix crash when dropping flipped items inside Artbaords.</li>
+          <li>Zooming with mouse wheel follows the position of the cursor.</li>
           <li>General code improvements and optimization.</li>
         </ul>
       </description>

--- a/data/com.github.akiraux.akira.appdata.xml.in.in
+++ b/data/com.github.akiraux.akira.appdata.xml.in.in
@@ -39,8 +39,8 @@
           <li>Fix loading Artboards background color when opening a file.</li>
           <li>Fix numbering of newly created items.</li>
           <li>Fix Gtk-CRITICAL warning when opening the Export Dialog.</li>
-          <li>Fix flipping items inside Artbaords.</li>
-          <li>Fix crash when dropping flipped items inside Artbaords.</li>
+          <li>Fix flipping items inside Artboards.</li>
+          <li>Fix crash when dropping flipped items inside Artboards.</li>
           <li>Zooming with mouse wheel follows the position of the cursor.</li>
           <li>General code improvements and optimization.</li>
         </ul>
@@ -51,7 +51,7 @@
         <p>Bug fixes and Artboards improvements</p>
         <ul>
           <li>Control Artboards background color.</li>
-          <li>Hide and Lock Artbaords from the Layers panel.</li>
+          <li>Hide and Lock Artboards from the Layers panel.</li>
           <li>Items inside Artboards are masked when extending outside the edges of the Artboard.</li>
           <li>Fix items reordering with the layers panel drag and drop.</li>
           <li>Fix random segfault at startup while setting accelerators.</li>

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,9 @@ com.github.akiraux.akira (0.0.13) xenial; urgency=medium
   * Fix loading Artboards background color when opening a file.
   * Fix numbering of newly created items.
   * Fix Gtk-CRITICAL warning when opening the Export Dialog.
+  * Fix flipping items inside Artbaords.
+  * Fix crash when dropping flipped items inside Artbaords.
+  * Zooming with mouse wheel follows the position of the cursor.
   * General code improvements and optimization.
 
  -- Alessandro Castellani <castellani.ale@gmail.com>  Sun, 17 Aug 2020 09:00:00 -0800

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,8 +3,8 @@ com.github.akiraux.akira (0.0.13) xenial; urgency=medium
   * Fix loading Artboards background color when opening a file.
   * Fix numbering of newly created items.
   * Fix Gtk-CRITICAL warning when opening the Export Dialog.
-  * Fix flipping items inside Artbaords.
-  * Fix crash when dropping flipped items inside Artbaords.
+  * Fix flipping items inside Artboards.
+  * Fix crash when dropping flipped items inside Artboards.
   * Zooming with mouse wheel follows the position of the cursor.
   * General code improvements and optimization.
 
@@ -13,7 +13,7 @@ com.github.akiraux.akira (0.0.13) xenial; urgency=medium
 com.github.akiraux.akira (0.0.12) xenial; urgency=medium
 
   * Control Artboards background color.
-  * Hide and Lock Artbaords from the Layers panel.
+  * Hide and Lock Artboards from the Layers panel.
   * Items inside Artboards are masked when extending outside the edges of the Artboard.
   * Fix items reordering with the layers panel drag and drop.
   * Fix random segfault at startup while setting accelerators.

--- a/src/Dialogs/ReleaseDialog.vala
+++ b/src/Dialogs/ReleaseDialog.vala
@@ -81,7 +81,7 @@ public class Akira.Dialogs.ReleaseDialog : Gtk.Dialog {
         scrolled.expand = true;
 
         var release_info = new Gtk.TextView ();
-        release_info.buffer.text = "✓ Fix loading Artboards background color when opening a file.\n✓ General code improvements and optimization.\n✓ Fix numbering of newly created items.\n✓ Fix Gtk-CRITICAL warning when opening the Export Dialog.\n";
+        release_info.buffer.text = "✓ Fix loading Artboards background color when opening a file.\n✓ General code improvements and optimization.\n✓ Fix numbering of newly created items.\n✓ Fix Gtk-CRITICAL warning when opening the Export Dialog.\n✓ Fix flipping items inside Artbaords.\n✓ Fix crash when dropping flipped items inside Artbaords.\n✓ Zooming with mouse wheel follows the position of the cursor.\n";
         release_info.pixels_below_lines = 3;
         release_info.border_width = 12;
         release_info.wrap_mode = Gtk.WrapMode.WORD;

--- a/src/Dialogs/ReleaseDialog.vala
+++ b/src/Dialogs/ReleaseDialog.vala
@@ -81,7 +81,7 @@ public class Akira.Dialogs.ReleaseDialog : Gtk.Dialog {
         scrolled.expand = true;
 
         var release_info = new Gtk.TextView ();
-        release_info.buffer.text = "✓ Fix loading Artboards background color when opening a file.\n✓ General code improvements and optimization.\n✓ Fix numbering of newly created items.\n✓ Fix Gtk-CRITICAL warning when opening the Export Dialog.\n✓ Fix flipping items inside Artbaords.\n✓ Fix crash when dropping flipped items inside Artbaords.\n✓ Zooming with mouse wheel follows the position of the cursor.\n";
+        release_info.buffer.text = "✓ Fix loading Artboards background color when opening a file.\n✓ General code improvements and optimization.\n✓ Fix numbering of newly created items.\n✓ Fix Gtk-CRITICAL warning when opening the Export Dialog.\n✓ Fix flipping items inside Artboards.\n✓ Fix crash when dropping flipped items inside Artboards.\n✓ Zooming with mouse wheel follows the position of the cursor.\n";
         release_info.pixels_below_lines = 3;
         release_info.border_width = 12;
         release_info.wrap_mode = Gtk.WrapMode.WORD;

--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -112,71 +112,29 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         double delta_x, delta_y;
         event.get_scroll_deltas (out delta_x, out delta_y);
 
-        int width, height;
-        width = main_scroll.get_allocated_width ();
-        height = main_scroll.get_allocated_height ();
-
         if (delta_y < -SCROLL_DISTANCE) {
-            // Scroll UP
+            // Scroll UP.
             if (is_ctrl) {
+                // Get the current zoom before zooming.
                 double old_zoom = canvas.get_scale ();
-                //The regular zoom mode shifts the visible viewing area
-                //to center itself (it already has one translation applied)
-                //so you cannot just move the viewing area by the distance
-                //of the current mouse location and the new mouse location
-
-                //If you want to zoom to your mouse you need to find the
-                //difference between the distances of the current mouse location
-                //in the current view scale to the left view border and the new
-                //mouse location that has the new canvas scale applied to the
-                //new left view border and shift the view by that difference
-
-                // Zoom in
+                // Zoom in.
                 window.headerbar.zoom.zoom_in ();
-
-                var center_x = main_scroll.hadjustment.value + (width / 2);
-                var center_y = main_scroll.vadjustment.value + (height / 2);
-
-                var old_center_x = (center_x / canvas.get_scale ()) * old_zoom;
-                var old_center_y = (center_y / canvas.get_scale ()) * old_zoom;
-
-                var new_event_x = (event.x / old_zoom) * canvas.get_scale ();
-                var new_event_y = (event.y / old_zoom) * canvas.get_scale ();
-
-                var old_hadjustment = old_center_x - (width / 2);
-                var old_vadjustment = old_center_y - (height / 2);
-
-                main_scroll.hadjustment.value += (new_event_x - main_scroll.hadjustment.value) - (event.x - old_hadjustment);
-                main_scroll.vadjustment.value += (new_event_y - main_scroll.vadjustment.value) - (event.y - old_vadjustment);
-
+                // Adjust zoom based on cursor position.
+                zoom_on_cursor (event, old_zoom);
             } else if (is_shift) {
                 main_scroll.hadjustment.value += delta_y * 10;
             } else {
                 main_scroll.vadjustment.value += delta_y * 10;
             }
         } else if (delta_y > SCROLL_DISTANCE) {
-            // Scroll DOWN
+            // Scroll DOWN.
             if (is_ctrl) {
+                // Get the current zoom before zooming.
                 double old_zoom = canvas.get_scale ();
-
-                // Zoom out
+                // Zoom out.
                 window.headerbar.zoom.zoom_out ();
-
-                var center_x = main_scroll.hadjustment.value + (width / 2);
-                var center_y = main_scroll.vadjustment.value + (height / 2);
-
-                var old_center_x = (center_x / canvas.get_scale ()) * old_zoom;
-                var old_center_y = (center_y / canvas.get_scale ()) * old_zoom;
-
-                var new_event_x = (event.x / old_zoom) * canvas.get_scale ();
-                var new_event_y = (event.y / old_zoom) * canvas.get_scale ();
-
-                var old_hadjustment = old_center_x - (width / 2);
-                var old_vadjustment = old_center_y - (height / 2);
-
-                main_scroll.hadjustment.value += (new_event_x - main_scroll.hadjustment.value) - (event.x - old_hadjustment);
-                main_scroll.vadjustment.value += (new_event_y - main_scroll.vadjustment.value) - (event.y - old_vadjustment);
-
+                // Adjust zoom based on cursor position.
+                zoom_on_cursor (event, old_zoom);
             } else if (is_shift) {
                 main_scroll.hadjustment.value += delta_y * 10;
             } else {
@@ -191,6 +149,38 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         }
 
         return true;
+    }
+
+    private void zoom_on_cursor (Gdk.EventScroll event, double old_zoom) {
+        // The regular zoom mode shifts the visible viewing area
+        // to center itself (it already has one translation applied)
+        // so you cannot just move the viewing area by the distance
+        // of the current mouse location and the new mouse location.
+
+        // If you want to zoom to your mouse you need to find the
+        // difference between the distances of the current mouse location
+        // in the current view scale to the left view border and the new
+        // mouse location that has the new canvas scale applied to the
+        // new left view border and shift the view by that difference.
+        int width = main_scroll.get_allocated_width ();
+        int height = main_scroll.get_allocated_height ();
+
+        var center_x = main_scroll.hadjustment.value + (width / 2);
+        var center_y = main_scroll.vadjustment.value + (height / 2);
+
+        var old_center_x = (center_x / canvas.get_scale ()) * old_zoom;
+        var old_center_y = (center_y / canvas.get_scale ()) * old_zoom;
+
+        var new_event_x = (event.x / old_zoom) * canvas.get_scale ();
+        var new_event_y = (event.y / old_zoom) * canvas.get_scale ();
+
+        var old_hadjustment = old_center_x - (width / 2);
+        var old_vadjustment = old_center_y - (height / 2);
+
+        main_scroll.hadjustment.value +=
+            (new_event_x - main_scroll.hadjustment.value) - (event.x - old_hadjustment);
+        main_scroll.vadjustment.value +=
+            (new_event_y - main_scroll.vadjustment.value) - (event.y - old_vadjustment);
     }
 
     private async void on_exporting (string message) {

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -652,6 +652,10 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         // If the item was moved from the empty Canvas to an Artboard.
         if (item.artboard == null && new_artboard != null) {
             debug ("Free Item => Artboard");
+
+            // Apply the matrix transform before removing the item from the artboard.
+            item.set_transform (item.get_real_transform ());
+
             // Remove the item from the free items.
             free_items.remove_item.begin (item);
             item.parent.remove_child (item.parent.find_child (item));

--- a/src/Lib/Models/CanvasItem.vala
+++ b/src/Lib/Models/CanvasItem.vala
@@ -194,39 +194,6 @@ public interface Akira.Lib.Models.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasI
             // Add item to the parent Artboard.
             artboard.add_child (this, -1);
 
-            // If the item is rotated we need to reset it to get the correct
-            // relative position based on the original matrix transform.
-            if (rotation != 0) {
-                Cairo.Matrix transform;
-                get_transform (out transform);
-
-                var center_x = get_coords ("width") / 2;
-                var center_y = get_coords ("height") / 2;
-
-                // Reset the rotation.
-                transform.translate (center_x, center_y);
-                transform.rotate (Utils.AffineTransform.deg_to_rad (-rotation));
-                transform.translate (-center_x, -center_y);
-
-                _x = transform.x0;
-                _y = transform.y0;
-            }
-
-            // Account for mirrored items.
-            if (flipped_h || flipped_v) {
-                var center_x = get_coords ("width") / 2;
-                var center_y = get_coords ("height") / 2;
-                var radians = Utils.AffineTransform.deg_to_rad (rotation);
-
-                var sx = flipped_h ? -1 : 1;
-                var sy = flipped_v ? -1 : 1;
-                transform.translate (center_x, center_y);
-                transform.rotate (-radians);
-                transform.scale (sx, sy);
-                transform.rotate (radians);
-                transform.translate (-center_x, -center_y);
-            }
-
             // Convert the coordinates for the artboard space.
             canvas.convert_to_item_space (artboard, ref _x, ref _y);
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
This PR fixes the segfault when a flipped item is dragged and dropped from the free canvas to inside an Artboard.
We were reapplying the Cairo matrix transform which is not necessary as that's done when an item is computed by the `simple_paint` method of the Artboard.
