### PR TITLE
Use perfect pixel values on canvas iterations

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -190,8 +190,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         holding = true;
 
-        event.x /= current_scale;
-        event.y /= current_scale;
+        event.x = Math.round(event.x / current_scale);
+        event.y = Math.round(event.y / current_scale);
 
         hover_manager.remove_hover_effect ();
 
@@ -293,8 +293,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     public override bool motion_notify_event (Gdk.EventMotion event) {
-        event.x /= current_scale;
-        event.y /= current_scale;
+        event.x = Math.round(event.x / current_scale);
+        event.y = Math.round(event.y / current_scale);
 
         window.event_bus.coordinate_change (event.x, event.y);
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -190,8 +190,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         holding = true;
 
-        event.x = Math.round(event.x / current_scale);
-        event.y = Math.round(event.y / current_scale);
+        event.x = Math.round (event.x / current_scale);
+        event.y = Math.round (event.y / current_scale);
 
         hover_manager.remove_hover_effect ();
 
@@ -293,8 +293,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     public override bool motion_notify_event (Gdk.EventMotion event) {
-        event.x = Math.round(event.x / current_scale);
-        event.y = Math.round(event.y / current_scale);
+        event.x = Math.round (event.x / current_scale);
+        event.y = Math.round (event.y / current_scale);
 
         window.event_bus.coordinate_change (event.x, event.y);
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
It ensures that all the canvas iterations use perfect pixel values (integers and not fractional) as the transform panel does by rounding x and y properties of the canvas event.

## Steps to Test
1. Open the application
2. Draw a square
3. Move, Resize, Pan and Zoom it slowly to see that it steps pixel by pixel.

## Screenshots 
<!--- Share a screenshot with us if it was a visual change, -->
![Screen record from 2020-08-26 11 18 29](https://user-images.githubusercontent.com/8999039/91286058-40fe4780-e78e-11ea-97d0-689a5bbcb526.gif)


## Known Issues / Things To Do
<!--- If your PR is in progress or you know something is wrong with the code -->
<!--- write it here so we can help/discuss it -->
<!--- This is also a good place for a checklist with things left to fix in the PR -->
- ~~When rotating using the knobs it steps two (2) degrees at a time instead of one.~~

## This PR fixes/implements the following **bugs/features**:
<!--- If there was an issue that this PR targets, adding it here will auto close it --> 

- Fixes #424 
