### PR TITLE
fix(build/snap): add 'home' and 'removable-media' plugs

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -23,6 +23,8 @@ apps:
       - desktop-legacy
       - opengl
       - x11
+      - home
+      - removable-media
     slots: [ dbus-akira ]
     desktop: usr/share/applications/com.github.akiraux.akira.desktop
     environment:


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?

Akira (snap version) cannot export to user home directory because it does not define the [home](https://snapcraft.io/docs/supported-interfaces) interface in the snap config file, this pull request fixed that and I also added `removable-media` interface so it can also export to USB and other drives connected to the computer.

## This PR fixes/implements the following **bugs/features**:

- Fixes #420 
