### PR TITLE
Add elementary-theme and elementary-icon-theme as additional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can install Akira by compiling it from the source
  - `cairo`
  - `meson`
 
-> _**Note:** For non-elementary distros, (such as Arch, Debian etc) you are required to install "vala" as additional dependency._
+> _**Note:** For non-elementary distros, (such as Arch, Debian etc) you are required to install "vala", "elementary-theme" and "elementary-icon-theme" as additional dependencies._
 
 ### Compile &amp; Run
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
It makes it clear that  `elementary-theme` and `elementary-icon-theme` are additional dependencies for those who are using non-elementary distros by stating it on the `README.md` file.

## Steps to Test
N/A

## Screenshots 
N/A

## Known Issues / Things To Do
N/A

## This PR fixes/implements the following **bugs/features**:
- Fixes #444 
- Fixes #429 
