### PR TITLE
Fix LibArchive permission for vala 40. Regressed by #445

### DIFF
--- a/src/FileFormat/ZipArchiveHandler.vala
+++ b/src/FileFormat/ZipArchiveHandler.vala
@@ -259,11 +259,7 @@ public class Akira.FileFormat.ZipArchiveHandler : GLib.Object {
         Archive.Result last_result;
 
         while ((last_result = archive.next_header (out entry)) == Archive.Result.OK) {
-#if VALA_0_46
             entry.set_perm (0644);
-#else
-            entry.set_perm (Archive.FileType.IFREG);
-#endif
             entry.set_pathname (Path.build_filename (location.get_path (), entry.pathname ()));
 
             if (extractor.write_header (entry) != Archive.Result.OK) {
@@ -338,12 +334,7 @@ public class Akira.FileFormat.ZipArchiveHandler : GLib.Object {
                     entry.set_size (file_info.get_size ());
                     entry.set_filetype ((uint) Posix.S_IFREG);
 #endif
-
-#if VALA_0_46
                     entry.set_perm (0644);
-#else
-                    entry.set_perm (Archive.FileType.IFREG);
-#endif
 
                     if (archive.write_header (entry) != Archive.Result.OK) {
                         critical (


### PR DESCRIPTION
PR #445 introduced a regression for elementary OS 5 users, or distribution with Vala v40.
`Archive.FileType.IFREG` doesn't exist in that version, and if we restrict the `entry.set_perm (0644);` to v46+, we prevent opening previously saved files in v40.

Let me know if this breaks anything for newer versions of Vala.