### PR TITLE
Remove support for Vala version < 0.42

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,14 +6,6 @@ akira_datadir = join_paths(akira_prefix, get_option('datadir'))
 akira_pkgdatadir = join_paths(akira_datadir, meson.project_name())
 install_tests = get_option('install-tests')
 
-vala_version = meson.get_compiler('vala').version()
-if vala_version.version_compare('<=0.43.90')
-    add_project_arguments(
-        ['--vapidir', join_paths(meson.current_source_dir(), 'vapi')],
-        language: 'vala'
-    )
-endif
-
 # Include the translations module
 i18n = import('i18n')
 # Dependencies

--- a/src/FileFormat/ZipArchiveHandler.vala
+++ b/src/FileFormat/ZipArchiveHandler.vala
@@ -341,7 +341,7 @@ public class Akira.FileFormat.ZipArchiveHandler : GLib.Object {
                         if (bytes_read <= 0) {
                             break;
                         }
-                        
+
                         archive.write_data (buffer[0:bytes_read]);
                     }
                 }

--- a/src/FileFormat/ZipArchiveHandler.vala
+++ b/src/FileFormat/ZipArchiveHandler.vala
@@ -267,16 +267,9 @@ public class Akira.FileFormat.ZipArchiveHandler : GLib.Object {
             }
 
             Posix.off_t offset;
-#if VALA_0_42
             uint8[] buffer;
             while (archive.read_data_block (out buffer, out offset) == Archive.Result.OK) {
                 if (extractor.write_data_block (buffer, offset) != Archive.Result.OK) {
-#else
-            void* buffer = null;
-            size_t buffer_length;
-            while (archive.read_data_block (out buffer, out buffer_length, out offset) == Archive.Result.OK) {
-                if (extractor.write_data_block (buffer, buffer_length, offset) != Archive.Result.OK) {
-#endif
                     break;
                 }
             }
@@ -327,13 +320,8 @@ public class Akira.FileFormat.ZipArchiveHandler : GLib.Object {
                     // Add an entry to the archive
                     Archive.Entry entry = new Archive.Entry ();
                     entry.set_pathname (initial_folder.get_relative_path (current_file));
-#if VALA_0_42
                     entry.set_size ((Archive.int64_t) file_info.get_size ());
                     entry.set_filetype (Archive.FileType.IFREG);
-#else
-                    entry.set_size (file_info.get_size ());
-                    entry.set_filetype ((uint) Posix.S_IFREG);
-#endif
                     entry.set_perm (0644);
 
                     if (archive.write_header (entry) != Archive.Result.OK) {
@@ -353,12 +341,8 @@ public class Akira.FileFormat.ZipArchiveHandler : GLib.Object {
                         if (bytes_read <= 0) {
                             break;
                         }
-
-#if VALA_0_42
+                        
                         archive.write_data (buffer[0:bytes_read]);
-#else
-                        archive.write_data (buffer, bytes_read);
-#endif
                     }
                 }
             }


### PR DESCRIPTION
Very simple PR to remove the support for Vala code prior to v0.42.

Please, be sure to test that the saving and opening of `.akira` files works.