### PR TITLE
Improve artboard interactions

### DIFF
--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -401,7 +401,7 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         var layer = (Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
 
         // Change artboard if necessary.
-        window.items_manager.change_artboard (layer.model, model);
+        window.items_manager.change_artboard.begin (layer.model, model);
 
         // Use the existing action to push an item all the way to the top.
         window.event_bus.change_z_selected (true, true);

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -388,7 +388,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         var layer = (Layer) ((Gtk.Widget[]) selection_data.get_data ())[0];
 
         // Change artboard if necessary.
-        window.items_manager.change_artboard (layer.model, model.artboard);
+        window.items_manager.change_artboard.begin (layer.model, model.artboard);
 
         // Store the source of our items.
         var items_source = model.artboard == null

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -209,7 +209,7 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
         var layer_artboard = layer.model.artboard;
 
         // Change artboard if necessary.
-        window.items_manager.change_artboard (layer.model, null);
+        window.items_manager.change_artboard.begin (layer.model, null);
 
         // If the moved layer had an artboard, no need to do anything else.
         if (layer_artboard != null) {

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -189,7 +189,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         }
 
         selected_item = selected_items.nth_data (0);
-
     }
 
     private void disconnect_previous_item () {

--- a/src/Layouts/RightSideBar.vala
+++ b/src/Layouts/RightSideBar.vala
@@ -196,7 +196,7 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         var layer_artboard = layer.model.artboard;
 
         // Change artboard if necessary.
-        window.items_manager.change_artboard (layer.model, null);
+        window.items_manager.change_artboard.begin (layer.model, null);
 
         // If the moved layer had an artboard, no need to do anything else.
         if (layer_artboard != null) {

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -157,6 +157,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Gdk.Key.Right:
             case Gdk.Key.Left:
                 window.event_bus.move_item_from_canvas (event);
+                window.event_bus.detect_artboard_change ();
                 break;
         }
 
@@ -283,9 +284,12 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 edit_mode = EditMode.MODE_SELECTION;
                 break;
 
+            case EditMode.MODE_SELECTION:
+                window.event_bus.detect_artboard_change ();
+                break;
+
             default:
                 edit_mode = EditMode.MODE_SELECTION;
-                window.event_bus.hold_released ();
                 break;
         }
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -557,7 +557,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
      * Handle the aftermath of an item transformation, like size changes or movement
      * to see if we need to add or remove an item to an Artboard.
      */
-    private void on_detect_artboard_change () {
+    private async void on_detect_artboard_change () {
         // Interrupt if no artboard is currently present.
         if (artboards.get_n_items () == 0) {
             return;
@@ -617,7 +617,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 }
             }
 
-            change_artboard (item, new_artboard);
+            yield change_artboard (item, new_artboard);
         }
 
         is_changing = false;
@@ -626,7 +626,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     /**
      * Add or remove an item from an artboard.
      */
-    public void change_artboard (Models.CanvasItem item, Models.CanvasArtboard? new_artboard) {
+    public async void change_artboard (Models.CanvasItem item, Models.CanvasArtboard? new_artboard) {
         // Interrupt if the item was moved within its original artboard.
         if (item.artboard == new_artboard) {
             debug ("Same parent");

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -32,6 +32,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     private Gdk.RGBA border_color;
     private Gdk.RGBA fill_color;
 
+    // Keep track of the expensive Artboard change method.
+    private bool is_changing = false;
+
     public ItemsManager (Akira.Window window) {
         Object (
             window: window
@@ -48,7 +51,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
 
         window.event_bus.insert_item.connect (set_item_to_insert);
         window.event_bus.request_delete_item.connect (on_request_delete_item);
-        window.event_bus.hold_released.connect (on_hold_released);
+        window.event_bus.detect_artboard_change.connect (on_detect_artboard_change);
     }
 
     public void insert_image (Lib.Managers.ImageManager manager) {
@@ -551,16 +554,30 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     }
 
     /**
-     * Handle the aftermath of an item transformation, like size changes or movement.
+     * Handle the aftermath of an item transformation, like size changes or movement
+     * to see if we need to add or remove an item to an Artboard.
      */
-    private void on_hold_released () {
+    private void on_detect_artboard_change () {
+        // Interrupt if no artboard is currently present.
+        if (artboards.get_n_items () == 0) {
+            return;
+        }
+
+        // Interrupt if this is already running.
+        if (is_changing) {
+            return;
+        }
+
+        // Interrupt if no item is selected.
+        if (window.main_window.main_canvas.canvas.selected_bound_manager.selected_items.length () == 0) {
+            return;
+        }
+
+        is_changing = true;
+
         // We need to copy the array of selected items as we need to remove and add items once
         // moved to force the natural redraw of the canvas.
         var items = window.main_window.main_canvas.canvas.selected_bound_manager.selected_items.copy ();
-
-        if (items.length () == 0) {
-            return;
-        }
 
         // If we have images in the canvas, check if they're part of the selection to recalculate the size.
         if (images.get_n_items () > 0) {
@@ -577,11 +594,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 continue;
             }
             item.update_size_ratio ();
-        }
-
-        // Interrupt if no artboard is currently present.
-        if (artboards.get_n_items () == 0) {
-            return;
         }
 
         // Check if any of the currently moved items was dropped inside or outside any artboard.
@@ -607,6 +619,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
 
             change_artboard (item, new_artboard);
         }
+
+        is_changing = false;
     }
 
     /**

--- a/src/Lib/Models/CanvasArtboard.vala
+++ b/src/Lib/Models/CanvasArtboard.vala
@@ -162,7 +162,7 @@ public class Akira.Lib.Models.CanvasArtboard : Goo.CanvasItemSimple, Goo.CanvasI
         return item.bounds_manager.x1 < bounds.x2
             && item.bounds_manager.x2 > bounds.x1
             && item.bounds_manager.y1 < bounds.y2
-            && item.bounds_manager.y2 > bounds.y1;
+            && item.bounds_manager.y2 > bounds.y1 + get_label_height ();
     }
 
     public void add_child (Goo.CanvasItem item, int position = -1) {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -62,7 +62,7 @@ public class Akira.Services.EventBus : Object {
     public signal void request_delete_item (Lib.Models.CanvasItem item);
     public signal void selected_items_changed (List<Lib.Models.CanvasItem> selected_items);
     public signal void z_selected_changed ();
-    public signal void hold_released ();
+    public signal void detect_artboard_change ();
 
     // Layers panel signals.
     public signal void hover_over_item (Lib.Models.CanvasItem? item);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Adding some code improvements and clean up to the artboard changing method.

## Steps to Test
- Create a file with multiple artboards and multiple objects.
- Move the objects between artboards and the emtpy canvas.
- Use the arrow keys to move objects around.
- Move the layers between artboards in the layers panel.

## This PR fixes/implements the following **bugs/features**:
- Converts the artboard changing method to async.
- Prevents running the method multiple times if already running (this will probably need some reworking after the multi selection is implemented).
- Change artboard when the item is moved outside with the arrow keys.
- Exclude the artboard label from the artboard's dropping area.
