### PR TITLE
CI: use a custom elementary image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: docker.io/bilelmoussaoui/flatpak-github-actions
+      image: bilelmoussaoui/flatpak-github-actions:elementary-juno
       options: --privileged
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The image contains the elementary base app along with the gnome sdk, this should reduce the build time a bit.
