### PR TITLE
Implement State Managers to handle coordinates

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -179,7 +179,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         attach (opacity_grid, 0, 10, 3);
 
         window.event_bus.selected_items_changed.connect (on_selected_items_changed);
-        //  window.event_bus.item_coord_changed.connect (on_item_coord_changed);
     }
 
     private void on_selected_items_changed (List<Lib.Models.CanvasItem> selected_items) {

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -291,7 +291,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
                 Utils.AffineTransform.set_rotation (selected_item, src);
                 // Update the X & Y values in the state manager.
                 canvas.window.event_bus.reset_state_coords (selected_item);
-                warning ("here");
                 return true;
             });
 

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -229,8 +229,14 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     private void enable () {
         canvas = selected_item.canvas as Akira.Lib.Canvas;
 
-        x.value = selected_item.artboard != null ? selected_item.relative_x : selected_item.bounds.x1;
-        y.value = selected_item.artboard != null ? selected_item.relative_y : selected_item.bounds.y1;
+        x.value = selected_item.bounds.x1;
+        y.value = selected_item.bounds.y1;
+
+        if (selected_item.artboard != null) {
+            x.value -= selected_item.artboard.bounds.x1;
+            y.value -= selected_item.artboard.bounds.y1 + selected_item.artboard.get_label_height ();
+        }
+
         width.value = selected_item.get_coords ("width");
         height.value = selected_item.get_coords ("height");
         rotation.value = selected_item.rotation;
@@ -288,13 +294,11 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             "value", selected_item, "rotation",
             BindingFlags.BIDIRECTIONAL,
             (binding, srcval, ref targetval) => {
-                double moved_x = 0.0;
-                double moved_y = 0.0;
                 double src = (double) srcval;
                 targetval.set_double (src);
-                Utils.AffineTransform.set_rotation (selected_item, src, ref moved_x, ref moved_y);
-                // Notify the X & Y values in the transform panel.
-                canvas.window.event_bus.update_state_coords (moved_x, moved_y, false);
+                Utils.AffineTransform.set_rotation (selected_item, src);
+                // Update the X & Y values in the state manager.
+                canvas.window.event_bus.reset_state_coords (selected_item);
                 return true;
             });
 

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -229,8 +229,8 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     private void enable () {
         canvas = selected_item.canvas as Akira.Lib.Canvas;
 
-        x.value = selected_item.bounds.x1;
-        y.value = selected_item.bounds.y1;
+        x.value = selected_item.artboard != null ? selected_item.relative_x : selected_item.bounds.x1;
+        y.value = selected_item.artboard != null ? selected_item.relative_y : selected_item.bounds.y1;
         width.value = selected_item.get_coords ("width");
         height.value = selected_item.get_coords ("height");
         rotation.value = selected_item.rotation;

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -286,11 +286,15 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
 
         rotation_bind = rotation.bind_property (
             "value", selected_item, "rotation",
-            BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL,
+            BindingFlags.BIDIRECTIONAL,
             (binding, srcval, ref targetval) => {
+                double moved_x = 0.0;
+                double moved_y = 0.0;
                 double src = (double) srcval;
                 targetval.set_double (src);
-                Utils.AffineTransform.set_rotation (selected_item, src);
+                Utils.AffineTransform.set_rotation (selected_item, src, ref moved_x, ref moved_y);
+                // Notify the X & Y values in the transform panel.
+                canvas.window.event_bus.update_state_coords (moved_x, moved_y, false);
                 return true;
             });
 

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -229,14 +229,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     private void enable () {
         canvas = selected_item.canvas as Akira.Lib.Canvas;
 
-        x.value = selected_item.bounds.x1;
-        y.value = selected_item.bounds.y1;
-
-        if (selected_item.artboard != null) {
-            x.value -= selected_item.artboard.bounds.x1;
-            y.value -= selected_item.artboard.bounds.y1 + selected_item.artboard.get_label_height ();
-        }
-
         width.value = selected_item.get_coords ("width");
         height.value = selected_item.get_coords ("height");
         rotation.value = selected_item.rotation;
@@ -245,12 +237,12 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         hflip_button.active = selected_item.flipped_h;
         vflip_button.active = selected_item.flipped_v;
 
-        x_bind = x.bind_property (
-            "value", window.coords_manager, "x", BindingFlags.BIDIRECTIONAL
+        x_bind = window.coords_manager.bind_property (
+            "x", x, "value", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL
         );
 
-        y_bind = y.bind_property (
-            "value", window.coords_manager, "y", BindingFlags.BIDIRECTIONAL
+        y_bind = window.coords_manager.bind_property (
+            "y", y, "value", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL
         );
 
         ratio_bind = lock_changes.bind_property (
@@ -299,6 +291,7 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
                 Utils.AffineTransform.set_rotation (selected_item, src);
                 // Update the X & Y values in the state manager.
                 canvas.window.event_bus.reset_state_coords (selected_item);
+                warning ("here");
                 return true;
             });
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -236,14 +236,16 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 nob_manager.selected_nob = clicked_nob_name;
 
                 if (clicked_item is Models.CanvasItem) {
-                    if (((Models.CanvasItem) clicked_item).locked) {
+                    Models.CanvasItem item = clicked_item as Models.CanvasItem;
+
+                    if (item.locked) {
                         selected_bound_manager.reset_selection ();
                         holding = false;
                         return true;
                     }
 
                     // Item has been selected.
-                    selected_bound_manager.add_item_to_selection (clicked_item as Models.CanvasItem);
+                    selected_bound_manager.add_item_to_selection (item);
                 }
 
                 selected_bound_manager.set_initial_coordinates (event.x, event.y);

--- a/src/Lib/Managers/GhostBoundsManager.vala
+++ b/src/Lib/Managers/GhostBoundsManager.vala
@@ -129,11 +129,4 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
         ghost.remove ();
         ghost = null;
     }
-
-    public Cairo.Matrix get_transform () {
-        Cairo.Matrix matrix;
-        item.get_transform (out matrix);
-
-        return matrix;
-    }
 }

--- a/src/Lib/Managers/GhostBoundsManager.vala
+++ b/src/Lib/Managers/GhostBoundsManager.vala
@@ -60,10 +60,18 @@ public class Akira.Lib.Managers.GhostBoundsManager : Object {
 
     public GhostBoundsManager (Models.CanvasItem new_item) {
         original_item = new_item;
+
         item = new Goo.CanvasRect (null, 0, 0, 1, 1, "line-width", 0, null);
         item.visibility = Goo.CanvasItemVisibility.HIDDEN;
         item.set ("parent", original_item.canvas.get_root_item ());
         item.can_focus = false;
+
+        // Update the ghost item to get the proper initial coordinates.
+        update ();
+
+        // Fetch the CanvasBounds to get the proper corodiantes for the Transform Panel.
+        Goo.CanvasBounds bounds;
+        item.get_bounds (out bounds);
     }
 
     /*

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -160,8 +160,11 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         }
 
         // We need to force the new item to generate proper bounds before being able to use its coordinates.
-        Goo.CanvasBounds bounds;
-        new_item.get_bounds (out bounds);
+        // But only if it doesn't belong to an artboard.
+        if (new_item.artboard == null) {
+            Goo.CanvasBounds bounds;
+            new_item.get_bounds (out bounds);
+        }
 
         // Create the GhostBoundsManager to keep track of the global canvas bounds.
         new_item.bounds_manager = new Managers.GhostBoundsManager (new_item);

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -159,6 +159,10 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 break;
         }
 
+        // We need to force the new item to generate proper bounds before being able to use its coordinates.
+        Goo.CanvasBounds bounds;
+        new_item.get_bounds (out bounds);
+
         // Create the GhostBoundsManager to keep track of the global canvas bounds.
         new_item.bounds_manager = new Managers.GhostBoundsManager (new_item);
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -159,13 +159,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 break;
         }
 
-        // We need to force the new item to generate proper bounds before being able to use its coordinates.
-        // But only if it doesn't belong to an artboard.
-        if (new_item.artboard == null) {
-            Goo.CanvasBounds bounds;
-            new_item.get_bounds (out bounds);
-        }
-
         // Create the GhostBoundsManager to keep track of the global canvas bounds.
         new_item.bounds_manager = new Managers.GhostBoundsManager (new_item);
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -80,8 +80,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         set_item_to_insert ("image");
         var new_item = insert_item (start_x, start_y, manager);
 
-        selected_bound_manager.add_item_to_selection (new_item);
         selected_bound_manager.set_initial_coordinates (start_x, start_y);
+        selected_bound_manager.add_item_to_selection (new_item);
     }
 
     public Models.CanvasItem? insert_item (

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -139,11 +139,14 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         item.selected = true;
         item.update_size_ratio ();
+
+        // Initialize the state manager coordinates before adding the item to the selection.
+        canvas.window.event_bus.init_state_coords (item);
+
         selected_items.append (item);
 
         // Move focus back to the canvas.
         canvas.window.event_bus.set_focus_on_canvas ();
-        canvas.window.event_bus.init_state_coords (item);
     }
 
     public void delete_selection () {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -104,6 +104,9 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
                 break;
 
             case Managers.NobManager.Nob.ROTATE:
+                moved_y = selected_item.bounds_manager.x1;
+                moved_x = selected_item.bounds_manager.y1;
+
                 Utils.AffineTransform.rotate_from_event (
                     selected_item, event_x, event_y,
                     ref initial_event_x, ref initial_event_y,

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -125,7 +125,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         }
 
         // Notify the X & Y values in the transform panel.
-        canvas.window.event_bus.update_state_coords (moved_x, moved_y);
+        canvas.window.event_bus.update_state_coords (moved_x, moved_y, false);
 
         // Let the UI know that a redraw is necessary.
         canvas.window.event_bus.item_value_changed ();
@@ -294,28 +294,24 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         }
 
         var amount = (event.state & Gdk.ModifierType.SHIFT_MASK) > 0 ? 10 : 1;
+        double x = 0.0, y = 0.0;
 
-        selected_items.foreach ((item) => {
-            var position = Akira.Utils.AffineTransform.get_position (item);
+        switch (event.keyval) {
+            case Gdk.Key.Up:
+                y -= amount;
+                break;
+            case Gdk.Key.Down:
+                y += amount;
+                break;
+            case Gdk.Key.Right:
+                x += amount;
+                break;
+            case Gdk.Key.Left:
+                x -= amount;
+                break;
+        }
 
-            switch (event.keyval) {
-                case Gdk.Key.Up:
-                    Utils.AffineTransform.set_position (item, null, position["y"] - amount);
-                    break;
-                case Gdk.Key.Down:
-                    Utils.AffineTransform.set_position (item, null, position["y"] + amount);
-                    break;
-                case Gdk.Key.Right:
-                    Utils.AffineTransform.set_position (item, position["x"] + amount);
-                    break;
-                case Gdk.Key.Left:
-                    Utils.AffineTransform.set_position (item, position["x"] - amount);
-                    break;
-            }
-
-            canvas.window.event_bus.item_coord_changed ();
-            update_selected_items ();
-        });
+        window.event_bus.update_state_coords (x, y, true);
     }
 
     private void remove_item_from_selection (Lib.Models.CanvasItem item) {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -36,8 +36,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     }
 
     private Goo.CanvasBounds select_bb;
-    private double moved_x;
-    private double moved_y;
     private double initial_event_x;
     private double initial_event_y;
     private double delta_x_accumulator;
@@ -65,9 +63,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     }
 
     public void set_initial_coordinates (double event_x, double event_y) {
-        moved_y = 0;
-        moved_x = 0;
-
         initial_event_x = event_x;
         initial_event_y = event_y;
 
@@ -98,19 +93,14 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
             case Managers.NobManager.Nob.NONE:
                 Utils.AffineTransform.move_from_event (
                     selected_item, event_x, event_y,
-                    ref initial_event_x, ref initial_event_y,
-                    ref moved_x, ref moved_y
+                    ref initial_event_x, ref initial_event_y
                 );
                 break;
 
             case Managers.NobManager.Nob.ROTATE:
-                moved_y = selected_item.bounds_manager.x1;
-                moved_x = selected_item.bounds_manager.y1;
-
                 Utils.AffineTransform.rotate_from_event (
                     selected_item, event_x, event_y,
-                    ref initial_event_x, ref initial_event_y,
-                    ref moved_x, ref moved_y
+                    ref initial_event_x, ref initial_event_y
                 );
                 break;
 
@@ -121,14 +111,13 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
                     event_x, event_y,
                     ref initial_event_x, ref initial_event_y,
                     ref delta_x_accumulator, ref delta_y_accumulator,
-                    initial_width, initial_height,
-                    ref moved_x, ref moved_y
+                    initial_width, initial_height
                 );
                 break;
         }
 
-        // Notify the X & Y values in the transform panel.
-        canvas.window.event_bus.update_state_coords (moved_x, moved_y, false);
+        // Notify the X & Y values in the state manager.
+        canvas.window.event_bus.reset_state_coords (selected_item);
 
         // Let the UI know that a redraw is necessary.
         canvas.window.event_bus.item_value_changed ();
@@ -314,7 +303,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
                 break;
         }
 
-        window.event_bus.update_state_coords (x, y, true);
+        window.event_bus.update_state_coords (x, y);
     }
 
     private void remove_item_from_selection (Lib.Models.CanvasItem item) {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -53,6 +53,8 @@ public class Akira.Services.EventBus : Object {
     public signal void border_deleted ();
     public signal void fill_deleted ();
     public signal void item_coord_changed ();
+    public signal void init_state_coords (Lib.Models.CanvasItem item);
+    public signal void update_state_coords (double moved_x, double moved_y);
     public signal void item_value_changed ();
 
     // Item signals.

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -53,7 +53,8 @@ public class Akira.Services.EventBus : Object {
     public signal void border_deleted ();
     public signal void fill_deleted ();
     public signal void init_state_coords (Lib.Models.CanvasItem item);
-    public signal void update_state_coords (double moved_x, double moved_y, bool update);
+    public signal void reset_state_coords (Lib.Models.CanvasItem item);
+    public signal void update_state_coords (double moved_x, double moved_y);
     public signal void item_value_changed ();
 
     // Item signals.

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -52,9 +52,8 @@ public class Akira.Services.EventBus : Object {
     public signal void align_items (string align_action);
     public signal void border_deleted ();
     public signal void fill_deleted ();
-    public signal void item_coord_changed ();
     public signal void init_state_coords (Lib.Models.CanvasItem item);
-    public signal void update_state_coords (double moved_x, double moved_y);
+    public signal void update_state_coords (double moved_x, double moved_y, bool update);
     public signal void item_value_changed ();
 
     // Item signals.

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -77,8 +77,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
 
     private void on_init_state_coords (Lib.Models.CanvasItem? item) {
         // Get the items X & Y coordinates.
-        double item_x = item.bounds.x1;
-        double item_y = item.bounds.y1;
+        double item_x = item.bounds_manager.x1;
+        double item_y = item.bounds_manager.y1;
 
         // Update the coordiantes if the items is inside an Artboard.
         if (item.artboard != null) {
@@ -119,7 +119,6 @@ public class Akira.StateManagers.CoordinatesManager : Object {
 
         foreach (Lib.Models.CanvasItem item in canvas.selected_bound_manager.selected_items) {
             if (!do_update) {
-                item.bounds_manager.update ();
                 continue;
             }
 

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -98,9 +98,14 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         _y = item_y;
     }
 
-    private void on_update_state_coords (double moved_x, double moved_y) {
-        // Prevent updating the item since the coordiantes change came from it.
-        do_update = false;
+    /**
+     * Update the coordinates to reflect the new position in the transform panel.
+     * If the update attribute is FALSE, it means updating the selected items Ciaro.Matrix
+     * is not necessary as the coordinates change came from a canvas action that already
+     * moved the item.
+     */
+    private void on_update_state_coords (double moved_x, double moved_y, bool update) {
+        do_update = update;
 
         x += moved_x;
         y += moved_y;

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -79,9 +79,12 @@ public class Akira.StateManagers.CoordinatesManager : Object {
      * Initialize the manager coordinates with the newly created or selected item.
      */
     private void on_init_state_coords (Lib.Models.CanvasItem item) {
+        // Get the half border size.
+        double half_border = get_border(item.border_size);
+
         // Get the item X & Y coordinates bounds in order to account for the item's rotation.
-        double item_x = item.bounds.x1;
-        double item_y = item.bounds.y1;
+        double item_x = item.bounds.x1 + half_border;
+        double item_y = item.bounds.y1 + half_border;
 
         // Update the coordinates if the item is inside an Artboard.
         if (item.artboard != null) {
@@ -106,6 +109,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
     private void on_update_state_coords (double moved_x, double moved_y) {
         x += moved_x;
         y += moved_y;
+
+        window.event_bus.file_edited ();
     }
 
     /**
@@ -117,9 +122,12 @@ public class Akira.StateManagers.CoordinatesManager : Object {
     private void on_reset_state_coords (Lib.Models.CanvasItem item) {
         do_update = false;
 
+        // Get the half border size.
+        double half_border = get_border(item.border_size);
+
         // Get the item X & Y coordinates bounds in order to account for the item's rotation.
-        double item_x = item.bounds.x1;
-        double item_y = item.bounds.y1;
+        double item_x = item.bounds.x1 + half_border;
+        double item_y = item.bounds.y1 + half_border;
 
         if (item.artboard != null) {
             item_x -= item.artboard.bounds.x1;
@@ -136,6 +144,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         y = item_y;
 
         do_update = true;
+
+        window.event_bus.file_edited ();
     }
 
     /**
@@ -172,12 +182,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             // If the item is rotated, we need to calculate the delta between the
             // new coordinates and item's bounds coordinates.
             if (item.rotation != 0) {
-                // The item's bounds account also for the border width, but we shouldn't,
-                // so we need to account for half the border width since we're only dealing
-                // with a centered border. In the future, once borders can be inside or outside,
-                // we will need to update this condition.
-                double half_border = item.border_size > 0 ? item.border_size / 2 : 0;
-
+                double half_border = get_border(item.border_size);
                 double diff_x = item.bounds.x1 - half_border;
                 double diff_y = item.bounds.y1 - half_border;
 
@@ -198,5 +203,15 @@ public class Akira.StateManagers.CoordinatesManager : Object {
 
         // Notify the rest of the UI that a value of the select items has changed.
         window.event_bus.item_value_changed ();
+    }
+
+    /**
+     * The item's bounds account also for the border width, but we shouldn't,
+     * so we need to account for half the border width since we're only dealing
+     * with a centered border. In the future, once borders can be inside or outside,
+     * we will need to update this condition.
+     */
+    private double get_border (double size) {
+        return size > 0 ? size / 2 : 0;
     }
 }

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -110,11 +110,16 @@ public class Akira.StateManagers.CoordinatesManager : Object {
     }
 
     private void update_items_coordinates () {
-        if (!do_update || _x == null || _y == null) {
+        if (_x == null || _y == null) {
             return;
         }
 
         foreach (Lib.Models.CanvasItem item in canvas.selected_bound_manager.selected_items) {
+            if (!do_update) {
+                item.bounds_manager.update ();
+                continue;
+            }
+
             item.get_simple_transform (out old_x, out old_y, out old_scale, out old_rotation);
 
             // Calculate the values which the item should be translated.

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -88,8 +88,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
 
         // Update the coordinates if the item is inside an Artboard.
         if (item.artboard != null) {
-            item_x -= item.artboard.bounds.x1;
-            item_y -= item.artboard.bounds.y1 + item.artboard.get_label_height ();
+            item_x = item.relative_x;
+            item_y = item.relative_y;
         }
 
         // Interrupt if no value has changed.
@@ -130,8 +130,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         double item_y = item.bounds.y1 + half_border;
 
         if (item.artboard != null) {
-            item_x -= item.artboard.bounds.x1;
-            item_y -= item.artboard.bounds.y1 + item.artboard.get_label_height ();
+            item_x = item.relative_x;
+            item_y = item.relative_y;
         }
 
         // Interrupt if no value has changed.

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -88,7 +88,6 @@ public class Akira.StateManagers.CoordinatesManager : Object {
 
         // Interrupt if no value has changed.
         if (item_x == x && item_y == y) {
-            //  warning ("SAME");
             return;
         }
 

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -72,18 +72,19 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         canvas = window.main_window.main_canvas.canvas;
 
         window.event_bus.init_state_coords.connect (on_init_state_coords);
+        window.event_bus.reset_state_coords.connect (on_reset_state_coords);
         window.event_bus.update_state_coords.connect (on_update_state_coords);
     }
 
-    private void on_init_state_coords (Lib.Models.CanvasItem? item) {
+    private void on_init_state_coords (Lib.Models.CanvasItem item) {
         // Get the items X & Y coordinates.
         double item_x = item.bounds_manager.x1;
         double item_y = item.bounds_manager.y1;
 
         // Update the coordiantes if the items is inside an Artboard.
         if (item.artboard != null) {
-            item_x = item.relative_x;
-            item_y = item.relative_y;
+            item_x -= item.artboard.bounds.x1;
+            item_y -= item.artboard.bounds.y1 + item.artboard.get_label_height ();
         }
 
         // Interrupt if no value has changed.
@@ -98,16 +99,32 @@ public class Akira.StateManagers.CoordinatesManager : Object {
     }
 
     /**
-     * Update the coordinates to reflect the new position in the transform panel.
-     * If the update attribute is FALSE, it means updating the selected items Ciaro.Matrix
-     * is not necessary as the coordinates change came from a canvas action that already
-     * moved the item.
+     * Update the coordinates to trigger the shapes transformation.
      */
-    private void on_update_state_coords (double moved_x, double moved_y, bool update) {
-        do_update = update;
-
+    private void on_update_state_coords (double moved_x, double moved_y) {
         x += moved_x;
         y += moved_y;
+    }
+
+    /**
+     * Reset the coordinates to get the newly updated coordinates from the item.
+     * The coordinates change came from a canvas action that already moved the items
+     * therefore we set the d_update to false to prevent updating  the selected
+     * items Cairo transform.
+     */
+    private void on_reset_state_coords (Lib.Models.CanvasItem item) {
+        do_update = false;
+
+        double item_x = item.bounds_manager.x1;
+        double item_y = item.bounds_manager.y1;
+
+        if (item.artboard != null) {
+            item_x -= item.artboard.bounds.x1;
+            item_y -= item.artboard.bounds.y1 + item.artboard.get_label_height ();
+        }
+
+        x = item_x;
+        y = item_y;
 
         do_update = true;
     }

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -1,0 +1,150 @@
+/*
+* Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+*
+* This file is part of Akira.
+*
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
+*
+* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+*/
+
+public class Akira.StateManagers.CoordinatesManager : Object {
+    public weak Akira.Window window { get; construct; }
+    private weak Akira.Lib.Canvas canvas;
+
+    // These attributes represent only the primary X & Y coordiantes of the selected shapes.
+    // These are not the origin points of each selected shape, but only the TOP-LEFT values
+    // of the selection bounding box.
+    private double? _x = null;
+    public double x {
+        get {
+            return _x != null ? _x : 0;
+        }
+        set {
+            if (value == _x) {
+                return;
+            }
+
+            _x = Utils.AffineTransform.fix_size (value);
+            update_items_coordinates ();
+        }
+    }
+
+    private double? _y = null;
+    public double y {
+        get {
+            return _y != null ? _y : 0;
+        }
+        set {
+            if (value == _y) {
+                return;
+            }
+
+            _y = Utils.AffineTransform.fix_size (value);
+            update_items_coordinates ();
+        }
+    }
+
+    // Private attributes to store simple transformation.
+    private double old_x;
+    private double old_y;
+    private double old_scale;
+    private double old_rotation;
+
+    private bool do_update = true;
+
+    public CoordinatesManager (Akira.Window window) {
+        Object (
+            window: window
+        );
+    }
+
+    construct {
+        canvas = window.main_window.main_canvas.canvas;
+
+        window.event_bus.init_state_coords.connect (on_init_state_coords);
+        window.event_bus.update_state_coords.connect (on_update_state_coords);
+    }
+
+    private void on_init_state_coords (Lib.Models.CanvasItem? item) {
+        // Get the items X & Y coordinates.
+        double item_x = item.bounds.x1;
+        double item_y = item.bounds.y1;
+
+        // Update the coordiantes if the items is inside an Artboard.
+        if (item.artboard != null) {
+            item_x -= item.artboard.bounds.x1;
+            item_y -= item.artboard.bounds.y1 + item.artboard.get_label_height ();
+        }
+
+        // Interrupt if no value has changed.
+        if (item_x == x && item_y == y) {
+            //  warning ("SAME");
+            return;
+        }
+
+        // Update the private attributes and not the public as we don't want to trigger the
+        // update_items_coordiantes () when a new item is created.
+        _x = item_x;
+        _y = item_y;
+    }
+
+    private void on_update_state_coords (double moved_x, double moved_y) {
+        do_update = false;
+
+        x += moved_x;
+        y += moved_y;
+
+        do_update = true;
+    }
+
+    private void update_items_coordinates () {
+        if (!do_update || _x == null || _y == null) {
+            return;
+        }
+
+        foreach (Lib.Models.CanvasItem item in canvas.selected_bound_manager.selected_items) {
+            item.get_simple_transform (out old_x, out old_y, out old_scale, out old_rotation);
+
+            // Calculate the values which the item should be translated.
+            var new_x = x - item.bounds.x1;
+            var new_y = y - item.bounds.y1;
+
+            // No need to call the translate method if nothing changed.
+            if (new_x == 0 && new_y == 0) {
+                continue;
+            }
+
+            // Store the border value since it makes a difference
+            // between the item's bounds and the matrix transform.
+            var border = (double) item.border_size / 2;
+
+            // Account for the item rotation and get the difference between
+            // its bounds and matrix coordinates.
+            var diff_x = item.bounds.x1 - old_x + border;
+            var diff_y = item.bounds.y1 - old_y + border;
+
+            // Update the matrix coordinates.
+            old_x += new_x + diff_x;
+            old_y += new_y + diff_y;
+
+            //  warning ("UPDATED X: %f - Y: %f", transform.x0, transform.y0);
+
+            item.set_simple_transform (old_x, old_y, old_scale, old_rotation);
+            item.bounds_manager.update ();
+        }
+
+        window.event_bus.item_value_changed ();
+    }
+}

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -80,7 +80,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
      */
     private void on_init_state_coords (Lib.Models.CanvasItem item) {
         // Get the half border size.
-        double half_border = get_border(item.border_size);
+        double half_border = get_border (item.border_size);
 
         // Get the item X & Y coordinates bounds in order to account for the item's rotation.
         double item_x = item.bounds.x1 + half_border;
@@ -123,7 +123,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         do_update = false;
 
         // Get the half border size.
-        double half_border = get_border(item.border_size);
+        double half_border = get_border (item.border_size);
 
         // Get the item X & Y coordinates bounds in order to account for the item's rotation.
         double item_x = item.bounds.x1 + half_border;
@@ -182,7 +182,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             // If the item is rotated, we need to calculate the delta between the
             // new coordinates and item's bounds coordinates.
             if (item.rotation != 0) {
-                double half_border = get_border(item.border_size);
+                double half_border = get_border (item.border_size);
                 double diff_x = item.bounds.x1 - half_border;
                 double diff_y = item.bounds.y1 - half_border;
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -460,16 +460,8 @@ public class Akira.Utils.AffineTransform : Object {
             // Cap new_rotation to the [0, 360] range.
             var new_rotation = GLib.Math.fmod (item.rotation + rotation, 360);
 
-            // Store the current X & Y coordinates of the item's bounding box.
-            var old_x = item.bounds.x1;
-            var old_y = item.bounds.y1;
-
             // Round rotation in order to avoid sub degree issue.
-            set_rotation (item, fix_size (new_rotation));
-
-            // Pass the delta of the item's bounding box coordinates after the rotation.
-            moved_x = old_x - item.bounds.x1;
-            moved_y = old_y - item.bounds.y1;
+            set_rotation (item, fix_size (new_rotation), ref moved_x, ref moved_y);
         }
 
         // Reset rotation to prevent infinite rotation loops.
@@ -497,7 +489,9 @@ public class Akira.Utils.AffineTransform : Object {
         }
     }
 
-    public static void set_rotation (CanvasItem item, double rotation) {
+    public static void set_rotation (CanvasItem item, double rotation, ref double moved_x, ref double moved_y) {
+        warning ("OLD X: %f - Y: %f", moved_x, moved_y);
+
         var center_x = item.get_coords ("width") / 2;
         var center_y = item.get_coords ("height") / 2;
         var actual_rotation = rotation - item.rotation;
@@ -508,6 +502,12 @@ public class Akira.Utils.AffineTransform : Object {
         if (item.artboard == null) {
             item.bounds_manager.update ();
         }
+
+        // Pass the delta of the item's bounding box coordinates after the rotation.
+        moved_x -= item.bounds_manager.x1;
+        moved_y -= item.bounds_manager.y1;
+
+        warning ("NEW X: %f - Y: %f", moved_x, moved_y);
     }
 
     public static void flip_item (CanvasItem item, double sx, double sy) {

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -31,8 +31,6 @@ public class Akira.Utils.AffineTransform : Object {
     private static double temp_rotation = 0.0;
     private static double prev_rotation_difference = 0.0;
 
-    private static Goo.CanvasBounds bounds;
-
     /**
      * Move the item based on the mouse click and drag event.
      */
@@ -508,7 +506,6 @@ public class Akira.Utils.AffineTransform : Object {
         item.rotation += actual_rotation;
 
         if (item.artboard == null) {
-            item.get_bounds (out bounds);
             item.bounds_manager.update ();
         }
     }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -39,23 +39,21 @@ public class Akira.Utils.AffineTransform : Object {
         double event_x,
         double event_y,
         ref double initial_event_x,
-        ref double initial_event_y,
-        ref double moved_x,
-        ref double moved_y
+        ref double initial_event_y
     ) {
         // Calculate the delta between the initial point and new mouse location.
-        moved_x = event_x - initial_event_x;
-        moved_y = event_y - initial_event_y;
+        var delta_x = event_x - initial_event_x;
+        var delta_y = event_y - initial_event_y;
 
         if (item.artboard != null) {
-            item.relative_x += moved_x;
-            item.relative_y += moved_y;
+            item.relative_x += delta_x;
+            item.relative_y += delta_y;
         } else {
             Cairo.Matrix matrix;
             item.get_transform (out matrix);
 
-            matrix.x0 += moved_x;
-            matrix.y0 += moved_y;
+            matrix.x0 += delta_x;
+            matrix.y0 += delta_y;
 
             item.set_transform (matrix);
             item.bounds_manager.update ();
@@ -75,9 +73,7 @@ public class Akira.Utils.AffineTransform : Object {
         ref double delta_x_accumulator,
         ref double delta_y_accumulator,
         double initial_width,
-        double initial_height,
-        ref double moved_x,
-        ref double moved_y
+        double initial_height
     ) {
         double delta_x = fix_size (event_x - initial_event_x);
         double delta_y = fix_size (event_y - initial_event_y);
@@ -256,10 +252,6 @@ public class Akira.Utils.AffineTransform : Object {
         item.move (new_x, new_y);
         // Update the item size.
         set_size (item, new_width, new_height);
-
-        // Send the coordiantes variations back to the caller method.
-        moved_x = new_x;
-        moved_y = new_y;
     }
 
     // Width size constraints.
@@ -367,9 +359,7 @@ public class Akira.Utils.AffineTransform : Object {
         double x,
         double y,
         ref double initial_x,
-        ref double initial_y,
-        ref double moved_x,
-        ref double moved_y
+        ref double initial_y
     ) {
         var diff_x = 0.0;
         var diff_y = 0.0;
@@ -461,7 +451,7 @@ public class Akira.Utils.AffineTransform : Object {
             var new_rotation = GLib.Math.fmod (item.rotation + rotation, 360);
 
             // Round rotation in order to avoid sub degree issue.
-            set_rotation (item, fix_size (new_rotation), ref moved_x, ref moved_y);
+            set_rotation (item, fix_size (new_rotation));
         }
 
         // Reset rotation to prevent infinite rotation loops.
@@ -489,9 +479,7 @@ public class Akira.Utils.AffineTransform : Object {
         }
     }
 
-    public static void set_rotation (CanvasItem item, double rotation, ref double moved_x, ref double moved_y) {
-        warning ("OLD X: %f - Y: %f", moved_x, moved_y);
-
+    public static void set_rotation (CanvasItem item, double rotation) {
         var center_x = item.get_coords ("width") / 2;
         var center_y = item.get_coords ("height") / 2;
         var actual_rotation = rotation - item.rotation;
@@ -502,12 +490,6 @@ public class Akira.Utils.AffineTransform : Object {
         if (item.artboard == null) {
             item.bounds_manager.update ();
         }
-
-        // Pass the delta of the item's bounding box coordinates after the rotation.
-        moved_x -= item.bounds_manager.x1;
-        moved_y -= item.bounds_manager.y1;
-
-        warning ("NEW X: %f - Y: %f", moved_x, moved_y);
     }
 
     public static void flip_item (CanvasItem item, double sx, double sy) {

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -299,7 +299,7 @@ public class Akira.Utils.AffineTransform : Object {
 
         // Always translate the item by its axis in order to properly resize it
         // even when rotated.
-        item.translate (new_x, new_y);
+        item.move (new_x, new_y);
         // Update the item size.
         set_size (item, new_width, new_height);
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -31,12 +31,6 @@ public class Akira.Utils.AffineTransform : Object {
     private static double temp_rotation = 0.0;
     private static double prev_rotation_difference = 0.0;
 
-    // Private attributes for item Cairo.Matrix.
-    private static double old_x;
-    private static double old_y;
-    private static double old_scale;
-    private static double old_rotation;
-
     private static Goo.CanvasBounds bounds;
 
     public static HashTable<string, double?> get_position (CanvasItem item) {
@@ -101,12 +95,20 @@ public class Akira.Utils.AffineTransform : Object {
         moved_x = event_x - initial_event_x;
         moved_y = event_y - initial_event_y;
 
-        // Fetch the current Cairo.Matrix attributes of the item.
-        item.get_simple_transform (out old_x, out old_y, out old_scale, out old_rotation);
-        // Update the Cairo.Matrix location based on the delta.
-        item.set_simple_transform (old_x + moved_x, old_y + moved_y, old_scale, old_rotation);
+        if (item.artboard != null) {
+            item.relative_x += moved_x;
+            item.relative_y += moved_y;
+        } else {
+            Cairo.Matrix matrix;
+            item.get_transform (out matrix);
 
-        // Reset the initial mouse pointer so we can recalculate the delta on next call.
+            matrix.x0 += moved_x;
+            matrix.y0 += moved_y;
+
+            item.set_transform (matrix);
+            item.bounds_manager.update ();
+        }
+
         initial_event_x = event_x;
         initial_event_y = event_y;
     }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -33,52 +33,6 @@ public class Akira.Utils.AffineTransform : Object {
 
     private static Goo.CanvasBounds bounds;
 
-    public static HashTable<string, double?> get_position (CanvasItem item) {
-        HashTable<string, double?> array = new HashTable<string, double?> (str_hash, str_equal);
-        double item_x = item.bounds_manager.x1;
-        double item_y = item.bounds_manager.y1;
-
-        if (item.artboard != null) {
-            item_x -= item.artboard.bounds.x1;
-            item_y -= item.artboard.bounds.y1 + item.artboard.get_label_height ();
-        }
-
-        array.insert ("x", item_x);
-        array.insert ("y", item_y);
-        return array;
-    }
-
-    public static void set_position (CanvasItem item, double? x = null, double? y = null) {
-        var diff_x = 0.0;
-        var diff_y = 0.0;
-
-        if (item.artboard != null) {
-            // Account for the different between the current position and the
-            // the item's bounds.
-            diff_x = item.bounds_manager.x1 - item.artboard.bounds.x1 - item.relative_x;
-            diff_y = item.bounds_manager.y1 - item.artboard.bounds.y1
-                     - item.artboard.get_label_height () - item.relative_y;
-
-            item.relative_x = x != null ? x - diff_x : item.relative_x;
-            item.relative_y = y != null ? y - diff_y : item.relative_y;
-            return;
-        }
-
-        Cairo.Matrix matrix;
-        item.get_transform (out matrix);
-
-        // Account for the item rotation and get the difference between
-        // its bounds and matrix coordinates.
-        diff_x = item.bounds_manager.x1 - matrix.x0;
-        diff_y = item.bounds_manager.y1 - matrix.y0;
-
-        matrix.x0 = x != null ? x - diff_x : matrix.x0;
-        matrix.y0 = y != null ? y - diff_y : matrix.y0;
-
-        item.set_transform (matrix);
-        item.bounds_manager.update ();
-    }
-
     /**
      * Move the item based on the mouse click and drag event.
      */

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -76,7 +76,7 @@ public class Akira.Utils.AffineTransform : Object {
         double initial_height
     ) {
         var canvas = item.canvas;
-        // Convert the coordiantes from the canvas to the item so we know the real
+        // Convert the coordinates from the canvas to the item so we know the real
         // values even if the item is rotated.
         canvas.convert_to_item_space (item, ref event_x, ref event_y);
         canvas.convert_to_item_space (item, ref initial_event_x, ref initial_event_y);
@@ -248,7 +248,7 @@ public class Akira.Utils.AffineTransform : Object {
                 break;
         }
 
-        // Update the initial coordiante to keep getting the correct delta.
+        // Update the initial coordinates to keep getting the correct delta.
         canvas.convert_from_item_space (item, ref event_x, ref event_y);
         initial_event_x = event_x;
         initial_event_y = event_y;
@@ -407,7 +407,7 @@ public class Akira.Utils.AffineTransform : Object {
             do_rotation = false;
         }
 
-        // Revert the coordinates to the canvas and udpate their references.
+        // Revert the coordinates to the canvas and update their references.
         if (item.artboard != null) {
             canvas.convert_from_item_space (item.artboard, ref x, ref y);
             x += diff_x;

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -410,27 +410,6 @@ public class Akira.Utils.AffineTransform : Object {
         }
     }
 
-    public static void set_size (Goo.CanvasItem item, double x, double y) {
-        double width, height;
-        item.get ("width", out width, "height", out height);
-
-        // Prevent accidental negative values.
-        if (width + x > 0) {
-            item.set ("width", fix_size (width + x));
-        }
-
-        if (height + y > 0) {
-            item.set ("height", fix_size (height + y));
-        }
-
-        // Don't update the bounds manager if a native goocanvas_rect was used,
-        // meaning no Akira Models was used and we don't need the bounds.
-        if (!(item is Goo.CanvasRect)) {
-            var model_item = item as CanvasItem;
-            model_item.bounds_manager.update ();
-        }
-    }
-
     public static void rotate_from_event (
         CanvasItem item,
         double x,
@@ -543,6 +522,27 @@ public class Akira.Utils.AffineTransform : Object {
 
         // Reset rotation to prevent infinite rotation loops.
         prev_rotation_difference = 0.0;
+    }
+
+    public static void set_size (Goo.CanvasItem item, double x, double y) {
+        double width, height;
+        item.get ("width", out width, "height", out height);
+
+        // Prevent accidental negative values.
+        if (width + x > 0) {
+            item.set ("width", fix_size (width + x));
+        }
+
+        if (height + y > 0) {
+            item.set ("height", fix_size (height + y));
+        }
+
+        // Don't update the bounds manager if a native goocanvas_rect was used,
+        // meaning no Akira Models was used and we don't need the bounds.
+        if (!(item is Goo.CanvasRect)) {
+            var model_item = item as CanvasItem;
+            model_item.bounds_manager.update ();
+        }
     }
 
     public static void set_rotation (CanvasItem item, double rotation) {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -32,6 +32,8 @@ public class Akira.Window : Gtk.ApplicationWindow {
     public Akira.Layouts.MainWindow main_window;
     public Akira.Utils.Dialogs dialogs;
 
+    public Akira.StateManagers.CoordinatesManager coords_manager;
+
     public SimpleActionGroup actions { get; construct; }
     public Gtk.AccelGroup accel_group { get; construct; }
 
@@ -55,6 +57,7 @@ public class Akira.Window : Gtk.ApplicationWindow {
         file_manager = new Akira.FileFormat.FileManager (this);
         headerbar = new Akira.Layouts.HeaderBar (this);
         main_window = new Akira.Layouts.MainWindow (this);
+        coords_manager = new Akira.StateManagers.CoordinatesManager (this);
         dialogs = new Akira.Utils.Dialogs (this);
 
         build_ui ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -95,6 +95,8 @@ sources = files(
     'Lib/Models/CanvasArtboard.vala',
 
     'Lib/Selection/Nob.vala',
+
+    'StateManagers/CoordinatesManager.vala',
 )
 
 deps = [


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implement a State Manager to keep track of the item coordinates.
This approach is to solve the problems caused by the 2-way-binding approach explained here: https://github.com/akiraux/Akira/discussions/470

This is only necessary for the X and Y values since `GooCanvas` doesn't offer those attributes to be directly accessible like it does for the others. E.g.: for the width we can simply do a `selected_item.notify["width"]` and the 2 way binding works in a bidirectional way out of the box.

## Steps to Test
- Create multiple items
- Move the items from the canvas
- Move the items from the transform panel

## What issue does this solve
- Items have the proper coordinates upon creation, as before they all started with 0 or negative coordinates for items inside artboards.
- Properly handles the difference between updating an item from the transform panel or from the canvas.
- Reduces the infinite loop of events when the coordinates change.

## Things to do
This is the first of many PRs that aim to rebuild and simplify our architecture to remove all those unnecessary Caitro.Matrix calls and start using built in GooCanvas methods.
It's gonna take us a while, but this is the first step to simplify things.
