### PR TITLE
Add images via click and drag

### DIFF
--- a/src/FileFormat/JsonLoader.vala
+++ b/src/FileFormat/JsonLoader.vala
@@ -35,6 +35,10 @@ public class Akira.FileFormat.JsonLoader : Object {
     }
 
     public void load_content () {
+        // Se the canvas to simulate a click + holding state to avoid triggering
+        // redrawing methods connected to that state.
+        window.main_window.main_canvas.canvas.holding = true;
+
         // Load saved Artboards.
         if (obj.get_member ("artboards") != null) {
             Json.Array artboards = obj.get_member ("artboards").get_array ();
@@ -54,6 +58,9 @@ public class Akira.FileFormat.JsonLoader : Object {
         window.event_bus.set_scale (obj.get_double_member ("scale"));
         window.main_window.main_canvas.main_scroll.hadjustment.value = obj.get_double_member ("hadjustment");
         window.main_window.main_canvas.main_scroll.vadjustment.value = obj.get_double_member ("vadjustment");
+
+        // Reset the holding state at the end of it.
+        window.main_window.main_canvas.canvas.holding = false;
     }
 
     private void load_item (Json.Object obj, string type) {

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -253,18 +253,38 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
         width_bind = selected_item.size.bind_property (
             "width", width, "value",
             BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL,
+            // size component => input field.
             (binding, srcval, ref targetval) => {
                 double src = (double) srcval;
                 targetval.set_double (src);
+                return true;
+            },
+            // input field => size component.
+            (binding, srcval, ref targetval) => {
+                double src = (double) srcval;
+                targetval.set_double (src);
+                // Check if an image is currently selected and needs a recalculation
+                // of the Pixbuf quality if it was resized from the Transform Panel.
+                window.event_bus.detect_image_size_change ();
                 return true;
             });
 
         height_bind = selected_item.size.bind_property (
             "height", height, "value",
             BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL,
+            // size component => input field.
             (binding, srcval, ref targetval) => {
                 double src = (double) srcval;
                 targetval.set_double (src);
+                return true;
+            },
+            // input field => size component.
+            (binding, srcval, ref targetval) => {
+                double src = (double) srcval;
+                targetval.set_double (src);
+                // Check if an image is currently selected and needs a recalculation
+                // of the Pixbuf quality if it was resized from the Transform Panel.
+                window.event_bus.detect_image_size_change ();
                 return true;
             });
 

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -256,9 +256,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             (binding, srcval, ref targetval) => {
                 double src = (double) srcval;
                 targetval.set_double (src);
-                if (selected_item.size.locked) {
-                    height.value = Utils.AffineTransform.fix_size (src / selected_item.size.ratio);
-                }
                 return true;
             });
 
@@ -268,9 +265,6 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             (binding, srcval, ref targetval) => {
                 double src = (double) srcval;
                 targetval.set_double (src);
-                if (selected_item.size.locked) {
-                    width.value = Utils.AffineTransform.fix_size (src * selected_item.size.ratio);
-                }
                 return true;
             });
 

--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -252,41 +252,11 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
 
         width_bind = selected_item.size.bind_property (
             "width", width, "value",
-            BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL,
-            // size component => input field.
-            (binding, srcval, ref targetval) => {
-                double src = (double) srcval;
-                targetval.set_double (src);
-                return true;
-            },
-            // input field => size component.
-            (binding, srcval, ref targetval) => {
-                double src = (double) srcval;
-                targetval.set_double (src);
-                // Check if an image is currently selected and needs a recalculation
-                // of the Pixbuf quality if it was resized from the Transform Panel.
-                window.event_bus.detect_image_size_change ();
-                return true;
-            });
+            BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
         height_bind = selected_item.size.bind_property (
             "height", height, "value",
-            BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL,
-            // size component => input field.
-            (binding, srcval, ref targetval) => {
-                double src = (double) srcval;
-                targetval.set_double (src);
-                return true;
-            },
-            // input field => size component.
-            (binding, srcval, ref targetval) => {
-                double src = (double) srcval;
-                targetval.set_double (src);
-                // Check if an image is currently selected and needs a recalculation
-                // of the Pixbuf quality if it was resized from the Transform Panel.
-                window.event_bus.detect_image_size_change ();
-                return true;
-            });
+            BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
         // Some items like Artboards don't implement every component.
         if (selected_item.rotation != null) {

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -311,6 +311,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
             case EditMode.MODE_SELECTION:
                 window.event_bus.detect_artboard_change ();
+                window.event_bus.detect_image_size_change ();
                 break;
 
             default:

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -58,7 +58,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     private Managers.HoverManager hover_manager;
 
     public bool ctrl_is_pressed = false;
-    private bool holding;
+    public bool holding;
     public double current_scale = 1.0;
     private Gdk.CursorType current_cursor = Gdk.CursorType.ARROW;
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -135,6 +135,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 edit_mode = EditMode.MODE_SELECTION;
                 // Clear the selected export area to be sure to not leave anything behind.
                 export_manager.clear ();
+                // Clear the image manager in case the user was adding an image.
+                window.items_manager.image_manager = null;
                 break;
 
             case Gdk.Key.space:

--- a/src/Lib/Components/Size.vala
+++ b/src/Lib/Components/Size.vala
@@ -23,6 +23,9 @@
  * Size component to keep track of the item's size ratio attributes.
  */
 public class Akira.Lib.Components.Size : Component {
+    // Keep track of the size changed internally based on the size ratio.
+    private bool ratio_resized = false;
+
     public bool locked { get; set; }
     public double ratio { get; set; }
 
@@ -35,6 +38,13 @@ public class Akira.Lib.Components.Size : Component {
         }
         set {
             item.set ("width", value);
+
+            if (locked && !ratio_resized) {
+                ratio_resized = true;
+                height = Utils.AffineTransform.fix_size (value / ratio);
+                ratio_resized = false;
+            }
+
             ((Lib.Canvas) item.canvas).window.event_bus.item_value_changed ();
         }
     }
@@ -48,6 +58,13 @@ public class Akira.Lib.Components.Size : Component {
         }
         set {
             item.set ("height", value);
+
+            if (locked && !ratio_resized) {
+                ratio_resized = true;
+                width = Utils.AffineTransform.fix_size (value * ratio);
+                ratio_resized = false;
+            }
+
             ((Lib.Canvas) item.canvas).window.event_bus.item_value_changed ();
         }
     }

--- a/src/Lib/Components/Size.vala
+++ b/src/Lib/Components/Size.vala
@@ -24,7 +24,7 @@
  */
 public class Akira.Lib.Components.Size : Component {
     // Keep track of the size changed internally based on the size ratio.
-    private bool ratio_resized = false;
+    private bool auto_resize = false;
 
     public bool locked { get; set; }
     public double ratio { get; set; }
@@ -39,13 +39,22 @@ public class Akira.Lib.Components.Size : Component {
         set {
             item.set ("width", value);
 
-            if (locked && !ratio_resized) {
-                ratio_resized = true;
+            if (locked && !auto_resize) {
+                auto_resize = true;
                 height = Utils.AffineTransform.fix_size (value / ratio);
-                ratio_resized = false;
+                auto_resize = false;
             }
 
-            ((Lib.Canvas) item.canvas).window.event_bus.item_value_changed ();
+            if (!auto_resize) {
+                Lib.Canvas canvas = item.canvas as Lib.Canvas;
+                canvas.window.event_bus.item_value_changed ();
+
+                // If the value wasn't changed automatically by the auto resize,
+                // and the image is selected and not loaded, recalculate the pixbuf quality.
+                if (item is Items.CanvasImage && item.layer.selected && !canvas.holding && !item.is_loaded) {
+                    canvas.window.event_bus.detect_image_size_change ();
+                }
+            }
         }
     }
 
@@ -59,13 +68,22 @@ public class Akira.Lib.Components.Size : Component {
         set {
             item.set ("height", value);
 
-            if (locked && !ratio_resized) {
-                ratio_resized = true;
+            if (locked && !auto_resize) {
+                auto_resize = true;
                 width = Utils.AffineTransform.fix_size (value * ratio);
-                ratio_resized = false;
+                auto_resize = false;
             }
 
-            ((Lib.Canvas) item.canvas).window.event_bus.item_value_changed ();
+            if (!auto_resize) {
+                Lib.Canvas canvas = item.canvas as Lib.Canvas;
+                canvas.window.event_bus.item_value_changed ();
+
+                // If the value wasn't changed automatically by the auto resize,
+                // and the image is selected and not loaded, recalculate the pixbuf quality.
+                if (item is Items.CanvasImage && item.layer.selected && !canvas.holding && !item.is_loaded) {
+                    canvas.window.event_bus.detect_image_size_change ();
+                }
+            }
         }
     }
 

--- a/src/Lib/Items/CanvasImage.vala
+++ b/src/Lib/Items/CanvasImage.vala
@@ -79,6 +79,8 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
         components.add (new Layer ());
 
         check_add_to_artboard (this);
+
+        ((Lib.Canvas) canvas).window.event_bus.detect_image_size_change.connect (check_resize_pixbuf);
     }
 
     private void init_pixbuf () {
@@ -92,6 +94,8 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
                 size.width = original_pixbuf.width;
                 size.height = original_pixbuf.height;
                 // Imported images should have their size ratio locked by default.
+                // Change the locked attribute after the size has been defined to let
+                // the Size component properly calculate the correct size ratio.
                 size.locked = true;
 
                 // Reset the size to the 1px initial value after the size ratio was properly defined
@@ -105,9 +109,15 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
     }
 
     /**
-     * Trigger the pixbuf resampling only if the image size changed.
+     * Trigger the pixbuf resampling.
      */
-     public void check_resize_pixbuf () {
+    public void check_resize_pixbuf () {
+        // Interrupt if this image isn't part of the selection.
+        if (!layer.selected) {
+            return;
+        }
+
+        // Interrupt if the size of the image didn't change.
         if (width == manager.pixbuf.get_width () && height == manager.pixbuf.get_height ()) {
             return;
         }

--- a/src/Lib/Items/CanvasImage.vala
+++ b/src/Lib/Items/CanvasImage.vala
@@ -98,9 +98,10 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
                 // the Size component properly calculate the correct size ratio.
                 size.locked = true;
 
-                // Reset the size to the 1px initial value after the size ratio was properly defined
-                // in order to allow the user to decide the initial image size.
-                size.width = 1;
+                // Reset the size to a 2px initial value after the size ratio was properly defined
+                // in order to allow the user to decide the initial image size. We use 2px in order
+                // to avoid issues when dividing by the ratio in case of narrow images.
+                size.width = 2;
             } catch (Error e) {
                 warning (e.message);
                 ((Lib.Canvas) canvas).window.event_bus.canvas_notification (e.message);

--- a/src/Lib/Items/CanvasImage.vala
+++ b/src/Lib/Items/CanvasImage.vala
@@ -82,17 +82,21 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
     }
 
     private void init_pixbuf () {
-        // Save the unedited pixbuf to enable resampling and restoring.
+        // Load the pixbuf at full resolution to properly define the size ratio of the item.
         manager.get_pixbuf.begin (-1, -1, (obj, res) => {
             try {
                 original_pixbuf = manager.get_pixbuf.end (res);
                 pixbuf = original_pixbuf;
-                width = size.width = original_pixbuf.get_width ();
-                height = size.height = original_pixbuf.get_height ();
 
+                // Define the item's size based on the images size.
+                size.width = original_pixbuf.width;
+                size.height = original_pixbuf.height;
                 // Imported images should have their size ratio locked by default.
                 size.locked = true;
-                size.ratio = width / height;
+
+                // Reset the size to the 1px initial value after the size ratio was properly defined
+                // in order to allow the user to decide the initial image size.
+                size.width = 1;
             } catch (Error e) {
                 warning (e.message);
                 ((Lib.Canvas) canvas).window.event_bus.canvas_notification (e.message);

--- a/src/Lib/Items/CanvasImage.vala
+++ b/src/Lib/Items/CanvasImage.vala
@@ -119,11 +119,11 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
         }
 
         // Interrupt if the size of the image didn't change.
-        if (width == manager.pixbuf.get_width () && height == manager.pixbuf.get_height ()) {
+        if (size.width == manager.pixbuf.get_width () && size.height == manager.pixbuf.get_height ()) {
             return;
         }
 
-        resize_pixbuf ((int) width, (int) height);
+        resize_pixbuf ((int) size.width, (int) size.height);
     }
 
     /**

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -35,6 +35,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     // Keep track of the expensive Artboard change method.
     private bool is_changing = false;
 
+    // Keep track of newly imported images before creation.
+    private Lib.Managers.ImageManager? image_manager;
+
     public ItemsManager (Akira.Window window) {
         Object (
             window: window
@@ -55,31 +58,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     }
 
     public void insert_image (Lib.Managers.ImageManager manager) {
-        var selected_bound_manager = window.main_window.main_canvas.canvas.selected_bound_manager;
-
-        double start_x, start_y, scale, rotation;
-        start_x = 0;
-        start_y = 0;
-
-        if (selected_bound_manager.selected_items.length () > 0) {
-            var item = selected_bound_manager.selected_items.nth_data (0);
-
-            if (item.artboard == null) {
-                item.get_simple_transform (
-                    out start_x, out start_y, out scale, out rotation
-                );
-            } else {
-                item.artboard.get_simple_transform (
-                    out start_x, out start_y, out scale, out rotation
-                );
-            }
-        }
-
-        set_item_to_insert ("image");
-        var new_item = insert_item (start_x, start_y, manager);
-
-        selected_bound_manager.set_initial_coordinates (start_x, start_y);
-        selected_bound_manager.add_item_to_selection (new_item);
+        image_manager = manager;
+        window.event_bus.insert_item ("image");
     }
 
     public Items.CanvasItem? insert_item (
@@ -127,7 +107,15 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         }
 
         if (item_type == typeof (Items.CanvasImage)) {
+            // If we don't have a manager passed to this method but a general image manager
+            // is available in the class, it means the user is importing a new image.
+            if (manager == null && image_manager != null) {
+                manager = image_manager;
+            }
             new_item = add_image (x, y, manager, root, artboard, loaded);
+
+            // Empty the image manager since we used it.
+            image_manager = null;
         }
 
         if (new_item == null) {
@@ -420,7 +408,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                         filename
                     )
                 );
-                var manager = new Akira.Lib.Managers.ImageManager.from_archive (file, filename);
+                var manager = new Lib.Managers.ImageManager.from_archive (file, filename);
                 item = insert_item (pos_x, pos_y, manager, true, artboard);
                 break;
         }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -36,7 +36,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     private bool is_changing = false;
 
     // Keep track of newly imported images before creation.
-    private Lib.Managers.ImageManager? image_manager;
+    public Lib.Managers.ImageManager? image_manager;
 
     public ItemsManager (Akira.Window window) {
         Object (

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -577,15 +577,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         // moved to force the natural redraw of the canvas.
         var items = window.main_window.main_canvas.canvas.selected_bound_manager.selected_items.copy ();
 
-        // If we have images in the canvas, check if they're part of the selection to recalculate the size.
-        if (images.get_n_items () > 0) {
-            foreach (var image in images) {
-                if (items.find (image) != null) {
-                    image.check_resize_pixbuf ();
-                }
-            }
-        }
-
         // Update the size ratio to always be faithful to the updated size.
         foreach (var item in items) {
             if (item is Items.CanvasArtboard) {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -64,6 +64,7 @@ public class Akira.Services.EventBus : Object {
     public signal void selected_items_list_changed (List<Lib.Items.CanvasItem> selected_items);
     public signal void z_selected_changed ();
     public signal void detect_artboard_change ();
+    public signal void detect_image_size_change ();
 
     // Layers panel signals.
     public signal void hover_over_item (Lib.Items.CanvasItem? item);
@@ -80,8 +81,4 @@ public class Akira.Services.EventBus : Object {
     public signal void preview_completed ();
     public signal void exporting (string message);
     public signal void export_completed ();
-
-    public void test (string caller_id) {
-        debug (@"Test from EventBus called by $(caller_id)");
-    }
 }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -120,7 +120,7 @@ public class Akira.Utils.AffineTransform : Object {
                     ref inc_width
                 );
 
-                if (canvas.ctrl_is_pressed) {
+                if (canvas.ctrl_is_pressed || item.size.locked) {
                     inc_width = inc_height * item.size.ratio;
                     inc_x = -inc_width;
                     inc_y = -inc_height;
@@ -140,7 +140,7 @@ public class Akira.Utils.AffineTransform : Object {
                     ref inc_height
                 );
 
-                if (canvas.ctrl_is_pressed) {
+                if (canvas.ctrl_is_pressed || item.size.locked) {
                     inc_width = inc_height * item.size.ratio;
                     inc_x = - (inc_width / 2);
                 }
@@ -162,7 +162,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 fix_width (ref delta_x, ref event_x, ref item_x, ref item_width, ref inc_width);
 
-                if (canvas.ctrl_is_pressed) {
+                if (canvas.ctrl_is_pressed || item.size.locked) {
                     inc_height = inc_width / item.size.ratio;
                     inc_y = -inc_height;
                 }
@@ -173,7 +173,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 fix_width (ref delta_x, ref event_x, ref item_x, ref item_width, ref inc_width);
 
-                if (canvas.ctrl_is_pressed) {
+                if (canvas.ctrl_is_pressed || item.size.locked) {
                     inc_height = inc_width / item.size.ratio;
                     inc_y = - (inc_height / 2);
                 }
@@ -187,7 +187,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 fix_height (ref delta_y, ref event_y, ref item_y, ref item_height, ref inc_height);
 
-                if (canvas.ctrl_is_pressed) {
+                if (canvas.ctrl_is_pressed || item.size.locked) {
                     inc_height = inc_width / item.size.ratio;
                     if (item.size.ratio == 1 && item_width != item_height) {
                         inc_height = item_width - item_height;
@@ -200,7 +200,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 fix_height (ref delta_y, ref event_y, ref item_y, ref item_height, ref inc_height);
 
-                if (canvas.ctrl_is_pressed) {
+                if (canvas.ctrl_is_pressed || item.size.locked) {
                     inc_width = inc_height * item.size.ratio;
                     inc_x = - (inc_width / 2);
                 }
@@ -222,7 +222,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 fix_height (ref delta_y, ref event_y, ref item_y, ref item_height, ref inc_height);
 
-                if (canvas.ctrl_is_pressed) {
+                if (canvas.ctrl_is_pressed || item.size.locked) {
                     inc_width = inc_height * item.size.ratio;
                     inc_x = -inc_width;
                 }
@@ -241,7 +241,7 @@ public class Akira.Utils.AffineTransform : Object {
                     ref inc_width
                 );
 
-                if (canvas.ctrl_is_pressed) {
+                if (canvas.ctrl_is_pressed || item.size.locked) {
                     inc_height = inc_width * item.size.ratio;
                     inc_y = - (inc_height / 2);
                 }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -120,7 +120,7 @@ public class Akira.Utils.AffineTransform : Object {
                     ref inc_width
                 );
 
-                if (canvas.ctrl_is_pressed || item.size.locked) {
+                if (canvas.ctrl_is_pressed) {
                     inc_width = inc_height * item.size.ratio;
                     inc_x = -inc_width;
                     inc_y = -inc_height;
@@ -140,7 +140,7 @@ public class Akira.Utils.AffineTransform : Object {
                     ref inc_height
                 );
 
-                if (canvas.ctrl_is_pressed || item.size.locked) {
+                if (canvas.ctrl_is_pressed) {
                     inc_width = inc_height * item.size.ratio;
                     inc_x = - (inc_width / 2);
                 }
@@ -162,7 +162,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 fix_width (ref delta_x, ref event_x, ref item_x, ref item_width, ref inc_width);
 
-                if (canvas.ctrl_is_pressed || item.size.locked) {
+                if (canvas.ctrl_is_pressed) {
                     inc_height = inc_width / item.size.ratio;
                     inc_y = -inc_height;
                 }
@@ -173,7 +173,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 fix_width (ref delta_x, ref event_x, ref item_x, ref item_width, ref inc_width);
 
-                if (canvas.ctrl_is_pressed || item.size.locked) {
+                if (canvas.ctrl_is_pressed) {
                     inc_height = inc_width / item.size.ratio;
                     inc_y = - (inc_height / 2);
                 }
@@ -187,7 +187,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 fix_height (ref delta_y, ref event_y, ref item_y, ref item_height, ref inc_height);
 
-                if (canvas.ctrl_is_pressed || item.size.locked) {
+                if (canvas.ctrl_is_pressed) {
                     inc_height = inc_width / item.size.ratio;
                     if (item.size.ratio == 1 && item_width != item_height) {
                         inc_height = item_width - item_height;
@@ -200,7 +200,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 fix_height (ref delta_y, ref event_y, ref item_y, ref item_height, ref inc_height);
 
-                if (canvas.ctrl_is_pressed || item.size.locked) {
+                if (canvas.ctrl_is_pressed) {
                     inc_width = inc_height * item.size.ratio;
                     inc_x = - (inc_width / 2);
                 }
@@ -222,7 +222,7 @@ public class Akira.Utils.AffineTransform : Object {
 
                 fix_height (ref delta_y, ref event_y, ref item_y, ref item_height, ref inc_height);
 
-                if (canvas.ctrl_is_pressed || item.size.locked) {
+                if (canvas.ctrl_is_pressed) {
                     inc_width = inc_height * item.size.ratio;
                     inc_x = -inc_width;
                 }
@@ -241,7 +241,7 @@ public class Akira.Utils.AffineTransform : Object {
                     ref inc_width
                 );
 
-                if (canvas.ctrl_is_pressed || item.size.locked) {
+                if (canvas.ctrl_is_pressed) {
                     inc_height = inc_width * item.size.ratio;
                     inc_y = - (inc_height / 2);
                 }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
This PR updates the methodology used to add images in the Canvas.
It generates the `ImageManager` which holds the `Pixbuf` and waits for the user to click and drag on the Canvas to create an image and assign the manager.
This makes the image creation behave like a regular shape creation, allowing users to add images where they want.

## Steps to Test
- Press <kbd>i</kbd> or use the Add Shape menu.
- Select an image from the File Picker.
- Click and drag on the Canvas when the cursor turns into a cross. 

## Screenshots 
![insert-images](https://user-images.githubusercontent.com/2527103/108645168-c7a68f80-7466-11eb-8a7f-28b1fa1355e0.gif)

## Known Issues / Things To Do
There's a bit of trickery going on to get the proper size ratio of the image and then set an initial small size on creation. It doesn't seem to create any issue, but I might have miss some edge case.
Please, test this thoroughly. 

## This PR fixes/implements the following **bugs/features**:
- Insert images via Click and Drag action.
- Recalculate the image quality when resizing from Canvas or Transform Panel.
- Defer the size ratio calculation to the `Size` Component.

---

- Fixes #490 
