### PR TITLE
Disable pointer events to items that do not need interaction

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -448,6 +448,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             );
             ghost.set ("parent", get_root_item ());
             ghost.can_focus = false;
+            ghost.pointer_events = Goo.CanvasPointerEvents.NONE;
             return;
         }
 

--- a/src/Lib/Items/CanvasArtboard.vala
+++ b/src/Lib/Items/CanvasArtboard.vala
@@ -84,6 +84,9 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       background = new Goo.CanvasRect (this, 0, 0, 1, 1, "line-width", 0.0, null);
       background.translate (0, 0);
       background.can_focus = false;
+      // Even if this item doesn't receive any pointer events we can't set NONE
+      // since users should be able to click on the artboard's background to drag
+      // the artboard around when the artboard is selected.
 
       this.bind_property ("width", background, "width", BindingFlags.SYNC_CREATE);
       this.bind_property ("height", background, "height", BindingFlags.SYNC_CREATE);

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -78,6 +78,7 @@ public class Akira.Lib.Managers.ExportManager : Object {
 
         area.set ("parent", canvas.get_root_item ());
         area.can_focus = false;
+        area.pointer_events = Goo.CanvasPointerEvents.NONE;
 
         return area;
     }

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -142,6 +142,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
 
         hover_effect.set ("parent", canvas.get_root_item ());
         hover_effect.can_focus = false;
+        hover_effect.pointer_events = Goo.CanvasPointerEvents.NONE;
     }
 
     public void remove_hover_effect () {

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -177,6 +177,7 @@ public class Akira.Lib.Managers.NobManager : Object {
                 null
             );
             select_effect.set ("parent", root);
+            select_effect.pointer_events = Goo.CanvasPointerEvents.NONE;
         }
 
         // If only one item is selected and it's inside an artboard,


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Set pointer events to `NONE` for those items that don't need a pointer interaction.

- Fixes #496 
