### PR TITLE
Implement canvas pixel grid

### DIFF
--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -39,7 +39,6 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
     public Akira.Partials.HeaderBarButton move_top;
     public Akira.Partials.HeaderBarButton move_bottom;
     public Akira.Partials.HeaderBarButton preferences;
-    public Akira.Partials.HeaderBarButton layout;
     public Akira.Partials.HeaderBarButton path_difference;
     public Akira.Partials.HeaderBarButton path_exclusion;
     public Akira.Partials.HeaderBarButton path_intersect;
@@ -373,12 +372,19 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         grid.width_request = 240;
         grid.name = "main";
 
+        var pixel_grid = create_model_button (
+            _("Toggle Pixel Grid"),
+            null,
+            Akira.Services.ActionManager.ACTION_PREFIX
+            + Akira.Services.ActionManager.ACTION_TOGGLE_PIXEL_GRID);
+
         var presentation_mode = create_model_button (
             _("Presentation Mode"),
             null,
             Akira.Services.ActionManager.ACTION_PREFIX
             + Akira.Services.ActionManager.ACTION_PRESENTATION);
 
+        grid.add (pixel_grid);
         grid.add (presentation_mode);
         grid.show_all ();
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -84,6 +84,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         nob_manager = new Managers.NobManager (this);
         hover_manager = new Managers.HoverManager (this);
 
+        window.event_bus.toggle_pixel_grid.connect (on_toggle_pixel_grid);
         window.event_bus.update_scale.connect (on_update_scale);
         window.event_bus.set_scale.connect (on_set_scale);
         window.event_bus.request_change_cursor.connect (on_request_change_cursor);
@@ -454,5 +455,17 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         if (ghost != null) {
             ghost.remove ();
         }
+    }
+
+    private void on_toggle_pixel_grid () {
+        // Show or hide the pixel grid based on its state.
+
+        // Create the pixel grid if it doesn't exist.
+
+        // Add the grid to the canvas.
+
+        // Make sure it can't be selected.
+
+        // Make sure newly created items won't be on top.
     }
 }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -27,6 +27,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     private const int MIN_SIZE = 1;
     private const int MIN_POS = 10;
+    private const int GRID_THRESHOLD = 8;
 
     public signal void canvas_moved (double delta_x, double delta_y);
     public signal void canvas_scroll_set_origin (double origin_x, double origin_y);
@@ -65,6 +66,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     // Used to show the canvas bounds of selected items.
     private Goo.CanvasRect ghost;
 
+    // Used to show a pixel grid on the whole canvas.
+    private Goo.CanvasGrid pixel_grid;
+    private bool is_grid_visible;
+
     public Canvas (Akira.Window window) {
         Object (window: window);
     }
@@ -84,6 +89,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         nob_manager = new Managers.NobManager (this);
         hover_manager = new Managers.HoverManager (this);
 
+        create_pixel_grid ();
+
         window.event_bus.toggle_pixel_grid.connect (on_toggle_pixel_grid);
         window.event_bus.update_scale.connect (on_update_scale);
         window.event_bus.set_scale.connect (on_set_scale);
@@ -92,6 +99,26 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         window.event_bus.set_focus_on_canvas.connect (on_set_focus_on_canvas);
         window.event_bus.request_escape.connect (on_set_focus_on_canvas);
         window.event_bus.insert_item.connect (on_insert_item);
+    }
+
+    private void create_pixel_grid () {
+        pixel_grid = new Goo.CanvasGrid (
+            null,
+            0, 0,
+            Layouts.MainCanvas.CANVAS_SIZE,
+            Layouts.MainCanvas.CANVAS_SIZE,
+            1, 1, 0, 0);
+
+        var grid_rgba = Gdk.RGBA ();
+        grid_rgba.parse ("#999999");
+
+        pixel_grid.horz_grid_line_width = pixel_grid.vert_grid_line_width = 0.02;
+        pixel_grid.horz_grid_line_color_gdk_rgba = pixel_grid.vert_grid_line_color_gdk_rgba = grid_rgba;
+        pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
+        pixel_grid.set ("parent", get_root_item ());
+        pixel_grid.can_focus = false;
+        pixel_grid.pointer_events = Goo.CanvasPointerEvents.NONE;
+        is_grid_visible = false;
     }
 
     public void set_cursor_by_edit_mode () {
@@ -402,6 +429,25 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         current_scale = scale;
         set_scale (scale);
         window.event_bus.zoom ();
+
+        // Check if the user requested the pixel grid and if is not already visible.
+        if (
+            !is_grid_visible ||
+            pixel_grid.visibility == Goo.CanvasItemVisibility.VISIBLE
+        ) {
+            return;
+        }
+
+        // If the pixel grid is visible, hide it based on the canvas scale
+        // in order to avoid a visually jarring canvas.
+        if (current_scale < GRID_THRESHOLD) {
+            pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
+        } else {
+            pixel_grid.visibility = Goo.CanvasItemVisibility.VISIBLE;
+            // Always move the grid to the top of the stack.
+            var root = get_root_item ();
+            root.move_child (root.find_child (pixel_grid), window.items_manager.get_items_count ());
+        }
     }
 
     private void on_request_change_cursor (Gdk.CursorType? cursor_type) {
@@ -457,15 +503,23 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
     }
 
+    /**
+     * Show or hide the pixel grid based on its state.
+     */
     private void on_toggle_pixel_grid () {
-        // Show or hide the pixel grid based on its state.
+        if (!is_grid_visible) {
+            // Show the grid only if we're zoomed in enough.
+            if (current_scale >= GRID_THRESHOLD) {
+                pixel_grid.visibility = Goo.CanvasItemVisibility.VISIBLE;
+                // Always move the grid to the top of the stack.
+                var root = get_root_item ();
+                root.move_child (root.find_child (pixel_grid), window.items_manager.get_items_count ());
+            }
+            is_grid_visible = true;
+            return;
+        }
 
-        // Create the pixel grid if it doesn't exist.
-
-        // Add the grid to the canvas.
-
-        // Make sure it can't be selected.
-
-        // Make sure newly created items won't be on top.
+        pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
+        is_grid_visible = false;
     }
 }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -27,7 +27,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     private const int MIN_SIZE = 1;
     private const int MIN_POS = 10;
-    private const int GRID_THRESHOLD = 8;
+    private const int GRID_THRESHOLD = 7;
 
     public signal void canvas_moved (double delta_x, double delta_y);
     public signal void canvas_scroll_set_origin (double origin_x, double origin_y);
@@ -110,7 +110,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             1, 1, 0, 0);
 
         var grid_rgba = Gdk.RGBA ();
-        grid_rgba.parse ("#999999");
+        grid_rgba.parse ("#888888");
 
         pixel_grid.horz_grid_line_width = pixel_grid.vert_grid_line_width = 0.02;
         pixel_grid.horz_grid_line_color_gdk_rgba = pixel_grid.vert_grid_line_color_gdk_rgba = grid_rgba;
@@ -245,6 +245,11 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 selected_bound_manager.set_initial_coordinates (event.x, event.y);
 
                 nob_manager.selected_nob = Managers.NobManager.Nob.BOTTOM_RIGHT;
+
+                // Update the pixel grid if it's visible in order to move it to the foreground.
+                if (is_grid_visible) {
+                    update_pixel_grid ();
+                }
                 break;
 
             case EditMode.MODE_SELECTION:
@@ -508,18 +513,22 @@ public class Akira.Lib.Canvas : Goo.Canvas {
      */
     private void on_toggle_pixel_grid () {
         if (!is_grid_visible) {
-            // Show the grid only if we're zoomed in enough.
-            if (current_scale >= GRID_THRESHOLD) {
-                pixel_grid.visibility = Goo.CanvasItemVisibility.VISIBLE;
-                // Always move the grid to the top of the stack.
-                var root = get_root_item ();
-                root.move_child (root.find_child (pixel_grid), window.items_manager.get_items_count ());
-            }
+            update_pixel_grid ();
             is_grid_visible = true;
             return;
         }
 
         pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
         is_grid_visible = false;
+    }
+
+    private void update_pixel_grid () {
+        // Show the grid only if we're zoomed in enough.
+        if (current_scale >= GRID_THRESHOLD) {
+            pixel_grid.visibility = Goo.CanvasItemVisibility.VISIBLE;
+            // Always move the grid to the top of the stack.
+            var root = get_root_item ();
+            root.move_child (root.find_child (pixel_grid), window.items_manager.get_items_count ());
+        }
     }
 }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -708,4 +708,13 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             return;
         }
     }
+
+    /**
+     * Helper method to get the count of all the created items in the canvas.
+     * This count excludes pseudo items like the select effect, hover effect,
+     * or grids items.
+     */
+    public int get_items_count () {
+        return (int) free_items.get_n_items () + (int) artboards.get_n_items ();
+    }
 }

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -40,8 +40,7 @@ public class Akira.Services.ActionManager : Object {
     public const string ACTION_LOAD_FIRST = "action_load_first";
     public const string ACTION_LOAD_SECOND = "action_load_second";
     public const string ACTION_LOAD_THIRD = "action_load_third";
-    public const string ACTION_SHOW_PIXEL_GRID = "action-show-pixel-grid";
-    public const string ACTION_SHOW_UI_GRID = "action-show-ui-grid";
+    public const string ACTION_TOGGLE_PIXEL_GRID = "action-show-pixel-grid";
     public const string ACTION_PRESENTATION = "action_presentation";
     public const string ACTION_PREFERENCES = "action_preferences";
     public const string ACTION_EXPORT_SELECTION = "action_export_selection";
@@ -79,8 +78,7 @@ public class Akira.Services.ActionManager : Object {
         { ACTION_LOAD_FIRST, action_load_first },
         { ACTION_LOAD_SECOND, action_load_second },
         { ACTION_LOAD_THIRD, action_load_third },
-        { ACTION_SHOW_PIXEL_GRID, action_show_pixel_grid },
-        { ACTION_SHOW_UI_GRID, action_show_ui_grid },
+        { ACTION_TOGGLE_PIXEL_GRID, action_toggle_pixel_grid },
         { ACTION_PRESENTATION, action_presentation },
         { ACTION_PREFERENCES, action_preferences },
         { ACTION_EXPORT_SELECTION, action_export_selection },
@@ -123,8 +121,7 @@ public class Akira.Services.ActionManager : Object {
         action_accelerators.set (ACTION_LOAD_FIRST, "<Control><Alt>1");
         action_accelerators.set (ACTION_LOAD_SECOND, "<Control><Alt>2");
         action_accelerators.set (ACTION_LOAD_THIRD, "<Control><Alt>3");
-        action_accelerators.set (ACTION_SHOW_PIXEL_GRID, "<Control><Shift>p");
-        action_accelerators.set (ACTION_SHOW_UI_GRID, "<Control><Shift>g");
+        action_accelerators.set (ACTION_TOGGLE_PIXEL_GRID, "<Shift>Tab");
         action_accelerators.set (ACTION_PRESENTATION, "<Control>period");
         action_accelerators.set (ACTION_PREFERENCES, "<Control>comma");
         action_accelerators.set (ACTION_EXPORT_SELECTION, "<Control><Alt>e");
@@ -267,12 +264,8 @@ public class Akira.Services.ActionManager : Object {
         window.app.open (files, "");
     }
 
-    private void action_show_pixel_grid () {
-        warning ("show pixel grid");
-    }
-
-    private void action_show_ui_grid () {
-        warning ("show UI grid");
+    private void action_toggle_pixel_grid () {
+        window.event_bus.toggle_pixel_grid ();
     }
 
     private void action_preferences () {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -48,6 +48,7 @@ public class Akira.Services.EventBus : Object {
     public signal void canvas_notification (string message);
     public signal void hide_select_effect ();
     public signal void show_select_effect ();
+    public signal void toggle_pixel_grid ();
 
     // Options panel signals.
     public signal void align_items (string align_action);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implement the Canvas Pixel Grid.

## Steps to Test
- Zoom in past 800%
- Enable the Pixel grid
- Create items to be sure they appear below the grid

## Screenshots 
![pixel-grid](https://user-images.githubusercontent.com/2527103/109256538-06ac4c00-77ab-11eb-989e-07f3e2cd8e4b.gif)

## This PR fixes/implements the following **bugs/features**:
- Toggle Pixel grid via the headerbar button or with the shortcut.
- The Pixel grid hides automatically when the Canvas zoom is below 800% since the pixels would be so small the grid would be just a grey fill.
- The Pixel grid is not clickable, selectable, and shouldn't affect anything pointer related.
