### PR TITLE
Add option to customize pixel grid color

### DIFF
--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -66,6 +66,12 @@
             <description>Allow user to choose between default and inverted panels order.</description>
         </key>
 
+        <key name="grid-color" type="s">
+            <default>'#888888'</default>
+            <summary>Default Grid Color.</summary>
+            <description>The default color of the pixel grid.</description>
+        </key>
+
         <key name="fill-color" type="s">
             <default>'#CCCCCC'</default>
             <summary>Default Shape Color.</summary>

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -26,6 +26,7 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
     private Gtk.Switch label_switch;
     private Gtk.Switch symbolic_switch;
     private Gtk.Switch border_switch;
+    private Gtk.ColorButton grid_color;
     private Gtk.ColorButton fill_color;
     private Gtk.ColorButton border_color;
     private Gtk.SpinButton border_size;
@@ -49,6 +50,7 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         stack.margin_top = 15;
         stack.add_titled (get_general_box (), "general", _("General"));
         stack.add_titled (get_interface_box (), "interface", _("Interface"));
+        stack.add_titled (get_canvas_box (), "canvas", _("Canvas"));
         stack.add_titled (get_shapes_box (), "shapes", _("Shapes"));
         stack.add_titled (get_about_box (), "about", _("About"));
 
@@ -115,6 +117,47 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         return grid;
     }
 
+    private Gtk.Widget get_canvas_box () {
+        var grid = new Gtk.Grid ();
+        grid.row_spacing = 6;
+        grid.column_spacing = 12;
+        grid.column_homogeneous = true;
+
+        var grid_rgba = Gdk.RGBA ();
+        grid_rgba.parse (settings.grid_color);
+
+        grid.attach (new SettingsHeader (_("Pixel Grid")), 0, 0, 2, 1);
+
+        var description = new Gtk.Label (_("Define the default color for the Canvas pixel grid."));
+        description.halign = Gtk.Align.START;
+        description.margin_bottom = 10;
+        grid.attach (description, 0, 1, 2, 1);
+
+        grid.attach (new SettingsLabel (_("Pixel Grid Color:")), 0, 2, 1, 1);
+        grid_color = new Gtk.ColorButton.with_rgba (grid_rgba);
+        grid_color.halign = Gtk.Align.START;
+        grid.attach (grid_color, 1, 2, 1, 1);
+
+        grid_color.color_set.connect (() => {
+            var rgba = grid_color.get_rgba ();
+
+            // Gdk.RGBA uses rgb() if alpha is 1.
+            string rgba_str = "rgba(%d,%d,%d,%d)".printf (
+                (int) (rgba.red * 255),
+                (int) (rgba.green * 255),
+                (int) (rgba.blue * 255),
+                (int) (rgba.alpha)
+            );
+
+            debug ("pixel grid color: %s", rgba_str);
+
+            settings.grid_color = rgba_str;
+            window.event_bus.update_pixel_grid ();
+        });
+
+        return grid;
+    }
+
     private Gtk.Widget get_shapes_box () {
         var grid = new Gtk.Grid ();
         grid.row_spacing = 6;
@@ -141,8 +184,8 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         fill_color.color_set.connect (() => {
             var rgba = fill_color.get_rgba ();
 
-            //Gdk.RGBA uses rgb() if alpha is 1.
-            string rgba_str = "rgba(%d,%d,%d,%d)" .printf (
+            // Gdk.RGBA uses rgb() if alpha is 1.
+            string rgba_str = "rgba(%d,%d,%d,%d)".printf (
                 (int) (rgba.red * 255),
                 (int) (rgba.green * 255),
                 (int) (rgba.blue * 255),
@@ -165,7 +208,7 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         border_color.color_set.connect (() => {
             var rgba = border_color.get_rgba ();
 
-            //Gdk.RGBA uses rgb() if alpha is 1.
+            // Gdk.RGBA uses rgb() if alpha is 1.
             string rgba_str = "rgba(%d,%d,%d,%d)".printf (
                 (int) (rgba.red * 255),
                 (int) (rgba.green * 255),

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -27,7 +27,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     private const int MIN_SIZE = 1;
     private const int MIN_POS = 10;
-    private const int GRID_THRESHOLD = 7;
+    private const int GRID_THRESHOLD = 3;
 
     public signal void canvas_moved (double delta_x, double delta_y);
     public signal void canvas_scroll_set_origin (double origin_x, double origin_y);
@@ -92,6 +92,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         create_pixel_grid ();
 
         window.event_bus.toggle_pixel_grid.connect (on_toggle_pixel_grid);
+        window.event_bus.update_pixel_grid.connect (on_update_pixel_grid);
         window.event_bus.update_scale.connect (on_update_scale);
         window.event_bus.set_scale.connect (on_set_scale);
         window.event_bus.request_change_cursor.connect (on_request_change_cursor);
@@ -110,7 +111,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             1, 1, 0, 0);
 
         var grid_rgba = Gdk.RGBA ();
-        grid_rgba.parse ("#888888");
+        grid_rgba.parse (settings.grid_color);
 
         pixel_grid.horz_grid_line_width = pixel_grid.vert_grid_line_width = 0.02;
         pixel_grid.horz_grid_line_color_gdk_rgba = pixel_grid.vert_grid_line_color_gdk_rgba = grid_rgba;
@@ -119,6 +120,16 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         pixel_grid.can_focus = false;
         pixel_grid.pointer_events = Goo.CanvasPointerEvents.NONE;
         is_grid_visible = false;
+    }
+
+    /**
+     * Trigger the update of the pixel grid after the settings color have been changed.
+     */
+    private void on_update_pixel_grid () {
+        var grid_rgba = Gdk.RGBA ();
+        grid_rgba.parse (settings.grid_color);
+
+        pixel_grid.horz_grid_line_color_gdk_rgba = pixel_grid.vert_grid_line_color_gdk_rgba = grid_rgba;
     }
 
     public void set_cursor_by_edit_mode () {
@@ -436,10 +447,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         window.event_bus.zoom ();
 
         // Check if the user requested the pixel grid and if is not already visible.
-        if (
-            !is_grid_visible ||
-            pixel_grid.visibility == Goo.CanvasItemVisibility.VISIBLE
-        ) {
+        if (!is_grid_visible) {
             return;
         }
 

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -49,6 +49,7 @@ public class Akira.Services.EventBus : Object {
     public signal void hide_select_effect ();
     public signal void show_select_effect ();
     public signal void toggle_pixel_grid ();
+    public signal void update_pixel_grid ();
 
     // Options panel signals.
     public signal void align_items (string align_action);

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -64,12 +64,18 @@ public class Akira.Services.Settings : GLib.Settings {
         get { return get_boolean ("use-symbolic"); }
         set { set_boolean ("use-symbolic", value); }
     }
+
+    // Default canvas settings.
+    public string grid_color {
+        owned get { return get_string ("grid-color"); }
+        set { set_string ("grid-color", value); }
+    }
+
+    // Default shape settings.
     public string fill_color {
         owned get { return get_string ("fill-color"); }
         set { set_string ("fill-color", value); }
     }
-
-    // Default shape settings.
     public bool set_border {
         get { return get_boolean ("set-border"); }
         set { set_boolean ("set-border", value); }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
The color of the pixel grid should be customizable so users can adapt the grid to be as visible as possible regardless of the colors of the shapes.

## Steps to Test
- Enable pixel grid.
- Zoom passed 300%.
- Open the Settings Panel and customize the Canvas Pixel color.

## Screenshots 
![pixel-grid-color](https://user-images.githubusercontent.com/2527103/109370776-9d821280-7856-11eb-84ca-90026d3b864e.gif)

![Screenshot from 2021-02-26 17-00-07](https://user-images.githubusercontent.com/2527103/109370784-aa066b00-7856-11eb-9abf-e273550ae267.png)

## Known Issues / Things To Do
The `Canvas` section of the Settings Dialog looks very ugly because it's empty, but we will slowly add other options once we implement smart guides and rulers, which should also be color customizable.

## This PR fixes/implements the following **bugs/features**:
- Implement a new gsetting to save the pixel grid color.
- Properly show and hide the pixel grid at the 300% zoom mark.
