### PR TITLE
Handle multiple colors

### DIFF
--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -65,6 +65,11 @@
     padding-right: 3px;
 }
 
+.color-picker-button {
+    border-radius: 0 3px 3px 0;
+    border-left: none;
+}
+
 .group-title {
     font-size: 9pt;
     font-weight: 600;

--- a/data/css/option-panel.css
+++ b/data/css/option-panel.css
@@ -28,11 +28,11 @@
                       linear-gradient(to bottom, black 50%, white 50%);
     background-blend-mode: normal, difference, normal;
     background-size: 8px 8px;
-    border-radius: 2px;
+    border-radius: 3px 0 0 3px;
 }
 
 button.selected-color {
-    border-radius: 2px;
+    border-radius: 3px 0 0 3px;
     border: 1px solid;
 }
 

--- a/src/FileFormat/JsonObject.vala
+++ b/src/FileFormat/JsonObject.vala
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
+/**
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
  *
  * This file is part of Akira.
  *
@@ -172,8 +172,7 @@ public class Akira.FileFormat.JsonObject : GLib.Object {
             foreach (Lib.Components.Fill fill in item.fills.fills) {
                 var obj = new Json.Object ();
                 obj.set_int_member ("id", fill.id);
-                obj.set_string_member ("color", Utils.Color.hex_to_rgba (fill.hex).to_string ());
-                obj.set_string_member ("hex", fill.hex);
+                obj.set_string_member ("color", fill.color.to_string ());
                 obj.set_int_member ("alpha", fill.alpha);
                 obj.set_boolean_member ("hidden", fill.hidden);
 
@@ -189,8 +188,7 @@ public class Akira.FileFormat.JsonObject : GLib.Object {
             foreach (Lib.Components.Border border in item.borders.borders) {
                 var obj = new Json.Object ();
                 obj.set_int_member ("id", border.id);
-                obj.set_int_member ("color", Utils.Color.rgba_to_uint (border.color));
-                obj.set_string_member ("hex", border.hex);
+                obj.set_string_member ("color", border.color.to_string ());
                 obj.set_int_member ("size", border.size);
                 obj.set_int_member ("alpha", border.alpha);
                 obj.set_boolean_member ("hidden", border.hidden);

--- a/src/Layouts/Partials/BorderItem.vala
+++ b/src/Layouts/Partials/BorderItem.vala
@@ -111,6 +111,9 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
         color_popover = new Gtk.Popover (color_picker);
         color_popover.position = Gtk.PositionType.BOTTOM;
 
+        var selected_color_container = new Gtk.Grid ();
+        selected_color_container.get_style_context ().add_class ("bg-pattern");
+
         selected_color = new Gtk.MenuButton ();
         selected_color.remove (selected_color.get_child ());
         selected_color.vexpand = true;
@@ -120,11 +123,21 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
         selected_color.popover = color_popover;
         selected_color.set_tooltip_text (_("Choose border color"));
 
+        selected_color_container.add (selected_color);
+
+        eyedropper_button = new Gtk.Button ();
+        eyedropper_button.get_style_context ().add_class ("color-picker-button");
+        eyedropper_button.can_focus = false;
+        eyedropper_button.valign = Gtk.Align.CENTER;
+        eyedropper_button.set_tooltip_text (_("Pick color"));
+        eyedropper_button.add (new Gtk.Image.from_icon_name ("color-select-symbolic",
+            Gtk.IconSize.SMALL_TOOLBAR));
+
         var picker_container = new Gtk.Grid ();
         picker_container.margin_end = 10;
         picker_container.margin_top = picker_container.margin_bottom = 1;
-        picker_container.get_style_context ().add_class ("bg-pattern");
-        picker_container.add (selected_color);
+        picker_container.add (selected_color_container);
+        picker_container.add (eyedropper_button);
 
         color_container = new Akira.Partials.ColorField (window);
         color_container.text = Utils.Color.rgba_to_hex (color);
@@ -168,15 +181,6 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
         color_chooser.attach (color_container, 1, 0, 1, 1);
         color_chooser.attach (tickness_container, 2, 0, 1, 1);
 
-        eyedropper_button = new Gtk.Button ();
-        eyedropper_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        eyedropper_button.get_style_context ().add_class ("button-rounded");
-        eyedropper_button.can_focus = false;
-        eyedropper_button.valign = Gtk.Align.CENTER;
-        eyedropper_button.set_tooltip_text (_("Pick color"));
-        eyedropper_button.add (new Gtk.Image.from_icon_name ("preferences-color-symbolic",
-            Gtk.IconSize.SMALL_TOOLBAR));
-
         hidden_button = new Gtk.Button ();
         hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         hidden_button.get_style_context ().add_class ("button-rounded");
@@ -203,9 +207,8 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
         color_popover.add (color_picker);
 
         attach (color_chooser, 0, 0, 1, 1);
-        attach (eyedropper_button, 1, 0, 1, 1);
-        attach (hidden_button, 2, 0, 1, 1);
-        attach (delete_button, 3, 0, 1, 1);
+        attach (hidden_button, 1, 0, 1, 1);
+        attach (delete_button, 2, 0, 1, 1);
 
         set_color_chooser_color ();
         set_button_color ();

--- a/src/Layouts/Partials/BorderItem.vala
+++ b/src/Layouts/Partials/BorderItem.vala
@@ -142,28 +142,27 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
         color_container = new Akira.Partials.ColorField (window);
         color_container.text = Utils.Color.rgba_to_hex (color);
 
-        color_container.bind_property (
-            "text", model, "color",
+        model.bind_property (
+            "color", color_container, "text",
             BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE,
-            // this => model
-            (binding, color_container_value, ref model_value) => {
-                color_set_manually = false;
-                var color_container_hex = color_container_value.dup_string ();
-
-                if (!Utils.Color.is_valid_hex (color_container_hex)) {
-                    model_value.set_string (Utils.Color.rgba_to_hex (old_color));
-                    return false;
-                }
-
-                var new_color_rgba = Utils.Color.hex_to_rgba (color_container_hex);
-                model_value.set_string (new_color_rgba.to_string ());
-                return true;
-            },
             // model => this
             (binding, model_value, ref color_container_value) => {
                 var model_rgba = model_value.dup_string ();
                 old_color = model_rgba;
                 color_container_value.set_string (Utils.Color.rgba_to_hex (model_rgba));
+                return true;
+            },
+            // this => model
+            (binding, color_container_value, ref model_value) => {
+                color_set_manually = false;
+                var color_container_hex = color_container_value.dup_string ();
+                if (!Utils.Color.is_valid_hex (color_container_hex)) {
+                    model_value.set_string (Utils.Color.rgba_to_hex (old_color));
+                    return false;
+                }
+                var new_color_rgba = Utils.Color.hex_to_rgba (color_container_hex);
+                new_color_rgba.alpha = alpha / 100;
+                model_value.set_string (new_color_rgba.to_string ());
                 return true;
             }
         );

--- a/src/Layouts/Partials/BordersPanel.vala
+++ b/src/Layouts/Partials/BordersPanel.vala
@@ -99,7 +99,6 @@ public class Akira.Layouts.Partials.BordersPanel : Gtk.Grid {
                 Lib.Components.Border border = item.borders.add_border_color (border_color, (int) settings.border_size);
                 var model_item = create_model (border);
                 list_model.add_item.begin (model_item);
-                item.borders.reload ();
             }
         });
 

--- a/src/Layouts/Partials/BordersPanel.vala
+++ b/src/Layouts/Partials/BordersPanel.vala
@@ -1,23 +1,23 @@
-/*
-* Copyright (c) 2019 Alecaddd (https://alecaddd.com)
-*
-* This file is part of Akira.
-*
-* Akira is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+/**
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
 
-* Akira is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
 
-* You should have received a copy of the GNU General Public License
-* along with Akira. If not, see <https://www.gnu.org/licenses/>.
-*
-* Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
-*/
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
+ */
 
 public class Akira.Layouts.Partials.BordersPanel : Gtk.Grid {
     public weak Akira.Window window { get; construct; }

--- a/src/Layouts/Partials/BordersPanel.vala
+++ b/src/Layouts/Partials/BordersPanel.vala
@@ -25,7 +25,6 @@ public class Akira.Layouts.Partials.BordersPanel : Gtk.Grid {
     public Gtk.Button add_btn;
     public Gtk.ListBox borders_list_container;
     public Akira.Models.ListModel<Akira.Models.BordersItemModel> list_model;
-    public Gtk.Grid title_cont;
     private unowned List<Lib.Items.CanvasItem>? items;
 
     public bool toggled {
@@ -45,7 +44,7 @@ public class Akira.Layouts.Partials.BordersPanel : Gtk.Grid {
     }
 
     construct {
-        title_cont = new Gtk.Grid ();
+        var title_cont = new Gtk.Grid ();
         title_cont.orientation = Gtk.Orientation.HORIZONTAL;
         title_cont.hexpand = true;
         title_cont.get_style_context ().add_class ("option-panel");

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -104,6 +104,9 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         color_popover = new Gtk.Popover (color_picker);
         color_popover.position = Gtk.PositionType.BOTTOM;
 
+        var selected_color_container = new Gtk.Grid ();
+        selected_color_container.get_style_context ().add_class ("bg-pattern");
+
         selected_color = new Gtk.MenuButton ();
         selected_color.remove (selected_color.get_child ());
         selected_color.vexpand = true;
@@ -113,11 +116,21 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         selected_color.popover = color_popover;
         selected_color.set_tooltip_text (_("Choose fill color"));
 
+        selected_color_container.add (selected_color);
+
+        eyedropper_button = new Gtk.Button ();
+        eyedropper_button.get_style_context ().add_class ("color-picker-button");
+        eyedropper_button.can_focus = false;
+        eyedropper_button.valign = Gtk.Align.CENTER;
+        eyedropper_button.set_tooltip_text (_("Pick color"));
+        eyedropper_button.add (new Gtk.Image.from_icon_name ("color-select-symbolic",
+            Gtk.IconSize.SMALL_TOOLBAR));
+
         var picker_container = new Gtk.Grid ();
         picker_container.margin_end = 10;
         picker_container.margin_top = picker_container.margin_bottom = 1;
-        picker_container.get_style_context ().add_class ("bg-pattern");
-        picker_container.add (selected_color);
+        picker_container.add (selected_color_container);
+        picker_container.add (eyedropper_button);
 
         color_container = new Akira.Partials.ColorField (window);
         color_container.text = Utils.Color.rgba_to_hex (color);
@@ -170,15 +183,6 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         fill_chooser.attach (color_container, 1, 0, 1, 1);
         fill_chooser.attach (opacity_container, 2, 0, 1, 1);
 
-        eyedropper_button = new Gtk.Button ();
-        eyedropper_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-        eyedropper_button.get_style_context ().add_class ("button-rounded");
-        eyedropper_button.can_focus = false;
-        eyedropper_button.valign = Gtk.Align.CENTER;
-        eyedropper_button.set_tooltip_text (_("Pick color"));
-        eyedropper_button.add (new Gtk.Image.from_icon_name ("preferences-color-symbolic",
-            Gtk.IconSize.SMALL_TOOLBAR));
-
         hidden_button = new Gtk.Button ();
         hidden_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         hidden_button.get_style_context ().add_class ("button-rounded");
@@ -205,9 +209,8 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         color_popover.add (color_picker);
 
         attach (fill_chooser, 0, 0, 1, 1);
-        attach (eyedropper_button, 1, 0, 1, 1);
-        attach (hidden_button, 2, 0, 1, 1);
-        attach (delete_button, 3, 0, 1, 1);
+        attach (hidden_button, 1, 0, 1, 1);
+        attach (delete_button, 2, 0, 1, 1);
 
         set_color_chooser_color ();
         set_button_color ();

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -135,28 +135,27 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         color_container = new Akira.Partials.ColorField (window);
         color_container.text = Utils.Color.rgba_to_hex (color);
 
-        color_container.bind_property (
-            "text", model, "color",
+        model.bind_property (
+            "color", color_container, "text",
             BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE,
-            // this => model
-            (binding, color_container_value, ref model_value) => {
-                color_set_manually = false;
-                var color_container_hex = color_container_value.dup_string ();
-
-                if (!Utils.Color.is_valid_hex (color_container_hex)) {
-                    model_value.set_string (Utils.Color.rgba_to_hex (old_color));
-                    return false;
-                }
-
-                var new_color_rgba = Utils.Color.hex_to_rgba (color_container_hex);
-                model_value.set_string (new_color_rgba.to_string ());
-                return true;
-            },
             // model => this
             (binding, model_value, ref color_container_value) => {
                 var model_rgba = model_value.dup_string ();
                 old_color = model_rgba;
                 color_container_value.set_string (Utils.Color.rgba_to_hex (model_rgba));
+                return true;
+            },
+            // this => model
+            (binding, color_container_value, ref model_value) => {
+                color_set_manually = false;
+                var color_container_hex = color_container_value.dup_string ();
+                if (!Utils.Color.is_valid_hex (color_container_hex)) {
+                    model_value.set_string (Utils.Color.rgba_to_hex (old_color));
+                    return false;
+                }
+                var new_color_rgba = Utils.Color.hex_to_rgba (color_container_hex);
+                new_color_rgba.alpha = alpha / 100;
+                model_value.set_string (new_color_rgba.to_string ());
                 return true;
             }
         );

--- a/src/Layouts/Partials/FillsPanel.vala
+++ b/src/Layouts/Partials/FillsPanel.vala
@@ -1,24 +1,24 @@
-/*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
-*
-* This file is part of Akira.
-*
-* Akira is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+/**
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
 
-* Akira is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
 
-* You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
-*
-* Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
-* Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
-*/
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+ * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
+ */
 
 public class Akira.Layouts.Partials.FillsPanel : Gtk.Grid {
     public weak Akira.Window window { get; construct; }
@@ -26,7 +26,6 @@ public class Akira.Layouts.Partials.FillsPanel : Gtk.Grid {
     public Gtk.Button add_btn;
     public Gtk.ListBox fills_list_container;
     public Akira.Models.ListModel<Akira.Models.FillsItemModel> list_model;
-    public Gtk.Grid title_cont;
     private unowned List<Lib.Items.CanvasItem>? items;
 
     public bool toggled {
@@ -46,7 +45,7 @@ public class Akira.Layouts.Partials.FillsPanel : Gtk.Grid {
     }
 
     construct {
-        title_cont = new Gtk.Grid ();
+        var title_cont = new Gtk.Grid ();
         title_cont.orientation = Gtk.Orientation.HORIZONTAL;
         title_cont.hexpand = true;
         title_cont.get_style_context ().add_class ("option-panel");

--- a/src/Layouts/Partials/FillsPanel.vala
+++ b/src/Layouts/Partials/FillsPanel.vala
@@ -100,7 +100,6 @@ public class Akira.Layouts.Partials.FillsPanel : Gtk.Grid {
                 Lib.Components.Fill fill = item.fills.add_fill_color (fill_color);
                 var model_item = create_model (fill);
                 list_model.add_item.begin (model_item);
-                item.fills.reload ();
             }
         });
 

--- a/src/Lib/Components/Border.vala
+++ b/src/Lib/Components/Border.vala
@@ -43,6 +43,20 @@ public class Akira.Lib.Components.Border : Component {
         color = init_color;
         size = init_size;
         alpha = 255;
+
+        // Listen for changed to the border attributes to properly trigger the color generation.
+        this.notify["color"].connect (() => {
+            hex = Utils.Color.rgba_to_hex (color.to_string ());
+            borders.reload ();
+        });
+
+        this.notify["size"].connect (() => {
+            borders.reload ();
+        });
+
+        this.notify["hidden"].connect (() => {
+            borders.reload ();
+        });
     }
 
     public void remove () {

--- a/src/Lib/Components/Border.vala
+++ b/src/Lib/Components/Border.vala
@@ -43,59 +43,6 @@ public class Akira.Lib.Components.Border : Component {
         color = init_color;
         size = init_size;
         alpha = 255;
-
-        set_border ();
-    }
-
-    /**
-     * Apply the properly converted border color to the item.
-     */
-    private void set_border () {
-        // Make the item transparent if the color is set by hidden.
-        if (hidden) {
-            item.set ("stroke-color-rgba", null);
-            item.set ("line-width", 0.0);
-            hex = "";
-            return;
-        }
-
-        // Store the color in a new RGBA variable so we can manipulate it.
-        var rgba_fill = Gdk.RGBA ();
-        rgba_fill = color;
-
-        // Keep in consideration the global opacity to properly update the border color.
-        rgba_fill.alpha = ((double) alpha) / 255 * item.opacity.opacity / 100;
-        hex = Utils.Color.rgba_to_hex (rgba_fill.to_string ());
-
-        // Temporarily set the item color here. This will be moved to the Borders component
-        // once we enable multiple borders.
-        item.set ("stroke-color-rgba", Utils.Color.rgba_to_uint (rgba_fill));
-        // The "line-width" property expects a DOUBLE type, but we don't support subpixels
-        // so we always handle the border size as INT, therefore we need to type cast it here.
-        item.set ("line-width", (double) size);
-    }
-
-    /**
-     * Helper method used by the Borders component to force a reset of of the applied colors.
-     * This will most likely be removed once we start supporting multiple borders.
-     */
-    public void reload () {
-        set_border ();
-    }
-
-    /**
-     * Get the new hexadecimal string defined by the user and update the border color.
-     */
-    public void set_border_hex (string new_hex) {
-        // Interrupt if the value didn't change.
-        if (new_hex == hex) {
-            return;
-        }
-
-        hex = new_hex;
-        color.parse (hex);
-
-        set_border ();
     }
 
     public void remove () {

--- a/src/Lib/Components/Borders.vala
+++ b/src/Lib/Components/Borders.vala
@@ -55,6 +55,9 @@ public class Akira.Lib.Components.Borders : Component {
         // Increase the ID to keep an incremental unique identifier.
         id++;
 
+        // Trigger the generation of the border color.
+        reload ();
+
         return new_border;
     }
 
@@ -96,9 +99,9 @@ public class Akira.Lib.Components.Borders : Component {
             // Keep in consideration the global opacity to properly update the border color.
             rgba_border.alpha = rgba_border.alpha * item.opacity.opacity / 100;
 
-            uint sroke_color_rgba = Utils.Color.rgba_to_uint (rgba_border);
+            uint stroke_color_rgba = Utils.Color.rgba_to_uint (rgba_border);
 
-            item.set ("stroke-color-rgba", sroke_color_rgba);
+            item.set ("stroke-color-rgba", stroke_color_rgba);
             // The "line-width" property expects a DOUBLE type, but we don't support subpixels
             // so we always handle the border size as INT, therefore we need to type cast it here.
             item.set ("line-width", (double) size);

--- a/src/Lib/Components/Borders.vala
+++ b/src/Lib/Components/Borders.vala
@@ -34,7 +34,12 @@ public class Akira.Lib.Components.Borders : Component {
         item = _item;
         borders = new Gee.ArrayList<Border> ();
 
-        add_border_color (init_color, init_size);
+        // Only add the initial border if the user configured it in the Settings.
+        if (settings.set_border) {
+            add_border_color (init_color, init_size);
+        } else {
+            reload ();
+        }
     }
 
     /**

--- a/src/Lib/Components/Fill.vala
+++ b/src/Lib/Components/Fill.vala
@@ -41,64 +41,6 @@ public class Akira.Lib.Components.Fill : Component {
         id = fill_id;
         color = init_color;
         alpha = 255;
-
-        set_fill ();
-    }
-
-    /**
-     * Apply the properly converted fill color to the item.
-     */
-    private void set_fill () {
-        // Make the item transparent if the color is set to hidden.
-        if (hidden) {
-            if (item is Items.CanvasArtboard) {
-                ((Items.CanvasArtboard) item).background.set ("fill-color-rgba", null);
-            } else {
-                item.set ("fill-color-rgba", null);
-            }
-            hex = "";
-            return;
-        }
-
-        // Store the color in a new RGBA variable so we can manipulate it.
-        var rgba_fill = Gdk.RGBA ();
-        rgba_fill = color;
-
-        // Keep in consideration the global opacity to properly update the fill color.
-        rgba_fill.alpha = ((double) alpha) / 255 * item.opacity.opacity / 100;
-        hex = Utils.Color.rgba_to_hex (rgba_fill.to_string ());
-        uint fill_color_rgba = Utils.Color.rgba_to_uint (rgba_fill);
-
-        // Temporarily set the item color here. This will be moved to the Fills component
-        // once we enable multiple fillings.
-        if (item is Items.CanvasArtboard) {
-            ((Items.CanvasArtboard) item).background.set ("fill-color-rgba", fill_color_rgba);
-        } else {
-            item.set ("fill-color-rgba", fill_color_rgba);
-        }
-    }
-
-    /**
-     * Helper method used by the Fills component to force a reset of of the applied colors.
-     * This will most likely be removed once we start supporting multiple fillings.
-     */
-    public void reload () {
-        set_fill ();
-    }
-
-    /**
-     * Get the new hexadecimal string defined by the user and update the fill color.
-     */
-    public void set_fill_hex (string new_hex) {
-        // Interrupt if the value didn't change.
-        if (new_hex == hex) {
-            return;
-        }
-
-        hex = new_hex;
-        color.parse (hex);
-
-        set_fill ();
     }
 
     public void remove () {

--- a/src/Lib/Components/Fill.vala
+++ b/src/Lib/Components/Fill.vala
@@ -40,7 +40,18 @@ public class Akira.Lib.Components.Fill : Component {
         item = _item;
         id = fill_id;
         color = init_color;
+        hex = color.to_string ();
         alpha = 255;
+
+        // Listen for changed to the fill attributes to properly trigger the color generation.
+        this.notify["color"].connect (() => {
+            hex = Utils.Color.rgba_to_hex (color.to_string ());
+            fills.reload ();
+        });
+
+        this.notify["hidden"].connect (() => {
+            fills.reload ();
+        });
     }
 
     public void remove () {

--- a/src/Lib/Components/Fills.vala
+++ b/src/Lib/Components/Fills.vala
@@ -104,7 +104,6 @@ public class Akira.Lib.Components.Fills : Component {
                 item.set ("fill-color-rgba", fill_color_rgba);
             }
         } else {
-            warning ("HERE");
             if (item is Items.CanvasArtboard) {
                 ((Items.CanvasArtboard) item).background.set ("fill-color-rgba", null);
             } else {

--- a/src/Lib/Components/Fills.vala
+++ b/src/Lib/Components/Fills.vala
@@ -50,6 +50,9 @@ public class Akira.Lib.Components.Fills : Component {
         // Increase the ID to keep an incremental unique identifier.
         id++;
 
+        // Trigger the generation of the fill color.
+        reload ();
+
         return new_fill;
     }
 

--- a/src/Lib/Components/Fills.vala
+++ b/src/Lib/Components/Fills.vala
@@ -72,23 +72,20 @@ public class Akira.Lib.Components.Fills : Component {
         }
 
         bool has_colors = false;
-        // Store the first available color
-        var rgba_fill = fills[0].color;
+        // Set an initial arbitrary color with full transparency.
+        var rgba_fill = Gdk.RGBA ();
+        rgba_fill.alpha = 0;
 
-        if (count () > 1) {
-            // Loop through all the configured fills.
-            foreach (Fill fill in fills) {
-                // Skip if the fill is hidden as we don't need to blend colors.
-                if (fill.hidden) {
-                    continue;
-                }
-
-                // Set the new blended color.
-                rgba_fill = Utils.Color.blend_colors (rgba_fill, fill.color);
-                has_colors = true;
+        // Loop through all the configured fills.
+        foreach (Fill fill in fills) {
+            // Skip if the fill is hidden as we don't need to blend colors.
+            if (fill.hidden) {
+                continue;
             }
-        } else {
-            has_colors = !fills[0].hidden;
+
+            // Set the new blended color.
+            rgba_fill = Utils.Color.blend_colors (rgba_fill, fill.color);
+            has_colors = true;
         }
 
         // Calculate the mixed RGBA only if all the values are valid.

--- a/src/Lib/Components/Fills.vala
+++ b/src/Lib/Components/Fills.vala
@@ -88,7 +88,7 @@ public class Akira.Lib.Components.Fills : Component {
             has_colors = true;
         }
 
-        // Calculate the mixed RGBA only if all the values are valid.
+        // Apply the mixed RGBA value only if we had one.
         if (has_colors) {
             // Keep in consideration the global opacity to properly update the fill color.
             rgba_fill.alpha = rgba_fill.alpha * item.opacity.opacity / 100;

--- a/src/Lib/Components/Fills.vala
+++ b/src/Lib/Components/Fills.vala
@@ -72,56 +72,29 @@ public class Akira.Lib.Components.Fills : Component {
         }
 
         bool has_colors = false;
-        double alpha = 0;
-        double red = 0;
-        double blue = 0;
-        double green = 0;
+        // Store the first available color
+        var rgba_fill = fills[0].color;
 
-        // alpha = 0.25 + 0.85 * (1 - 0.25) = 0.8875
-        // red   = (57 * 0.25 + 255 * 0.85 * (1 - 0.25)) / 0.8875 = 199.2
-        // green = (40 * 0.25 + 255 * 0.85 * (1 - 0.25)) / 0.8875 = 194.4
-        // blue  = (28 * 0.25 + 255 * 0.85 * (1 - 0.25)) / 0.8875 = 191.1
+        if (count () > 1) {
+            // Loop through all the configured fills.
+            foreach (Fill fill in fills) {
+                // Skip if the fill is hidden as we don't need to blend colors.
+                if (fill.hidden) {
+                    continue;
+                }
 
-        // Loop through all the configured fill.
-        foreach (Fill fill in fills) {
-            // Skip if the fill is hidden.
-            if (fill.hidden) {
-                continue;
+                // Set the new blended color.
+                rgba_fill = Utils.Color.blend_colors (rgba_fill, fill.color);
+                has_colors = true;
             }
-
-            // warning ("%f, %f, %f, %f", fill.color.red, fill.color.green, fill.color.blue, fill.color.alpha);
-
-            // alpha += ((double) fill.alpha) / 255;
-            // red += ((double) fill.color.red) * fill.color.alpha;
-            // green += ((double) fill.color.green) * fill.color.alpha;
-            // blue += ((double) fill.color.blue) * fill.color.alpha;
-            alpha += fill.color.alpha;
-            red += fill.color.red * fill.color.alpha;
-            green += fill.color.green * fill.color.alpha;
-            blue += fill.color.blue * fill.color.alpha;
-
-            has_colors = true;
+        } else {
+            has_colors = !fills[0].hidden;
         }
 
         // Calculate the mixed RGBA only if all the values are valid.
         if (has_colors) {
             // Keep in consideration the global opacity to properly update the fill color.
-            // double final_alpha = alpha * (1 - 0.25);
-
-            // var rgba_fill = Gdk.RGBA ();
-            // rgba_fill.red = (red * (1 - 0.25)) / final_alpha;
-            // rgba_fill.green = (green * (1 - 0.25)) / final_alpha;
-            // rgba_fill.blue = (blue * (1 - 0.25)) / final_alpha;
-            // rgba_fill.alpha = final_alpha;
-            double final_alpha = alpha / count ();
-
-            var rgba_fill = Gdk.RGBA ();
-            rgba_fill.red = red / final_alpha;
-            rgba_fill.green = green / final_alpha;
-            rgba_fill.blue = blue / final_alpha;
-            rgba_fill.alpha = final_alpha * item.opacity.opacity / 100;
-
-            warning ("%f, %f, %f, %f", rgba_fill.red, rgba_fill.green, rgba_fill.blue, rgba_fill.alpha);
+            rgba_fill.alpha = rgba_fill.alpha * item.opacity.opacity / 100;
 
             uint fill_color_rgba = Utils.Color.rgba_to_uint (rgba_fill);
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -507,6 +507,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 fill.alpha = (int) obj.get_int_member ("alpha");
                 fill.hidden = obj.get_boolean_member ("hidden");
             });
+
+            item.fills.reload ();
         }
 
         // Restore borders.
@@ -525,6 +527,8 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 border.alpha = (int) obj.get_int_member ("alpha");
                 border.hidden = obj.get_boolean_member ("hidden");
             });
+
+            item.borders.reload ();
         }
 
         // Restore image size.

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2019-2020 Alecaddd (http://alecaddd.com)
+/**
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
  *
  * This file is part of Akira.
  *
@@ -501,13 +501,12 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             var fills = components.get_member ("Fills").get_object ();
             fills.foreach_member ((i, name, node) => {
                 var obj = node.get_object ();
-                var fill = item.fills.add_fill_color (Utils.Color.hex_to_rgba (obj.get_string_member ("hex")));
-                fill.hex = obj.get_string_member ("hex");
+                var color = Gdk.RGBA ();
+                color.parse (obj.get_string_member ("color"));
+                var fill = item.fills.add_fill_color (color);
                 fill.alpha = (int) obj.get_int_member ("alpha");
                 fill.hidden = obj.get_boolean_member ("hidden");
             });
-
-            item.fills.reload ();
         }
 
         // Restore borders.
@@ -520,16 +519,12 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             var borders = components.get_member ("Borders").get_object ();
             borders.foreach_member ((i, name, node) => {
                 var obj = node.get_object ();
-                var border = item.borders.add_border_color (
-                    Utils.Color.hex_to_rgba (obj.get_string_member ("hex")),
-                    (int) obj.get_int_member ("size")
-                );
-                border.hex = obj.get_string_member ("hex");
+                var color = Gdk.RGBA ();
+                color.parse (obj.get_string_member ("color"));
+                var border = item.borders.add_border_color (color, (int) obj.get_int_member ("size"));
                 border.alpha = (int) obj.get_int_member ("alpha");
                 border.hidden = obj.get_boolean_member ("hidden");
             });
-
-            item.borders.reload ();
         }
 
         // Restore image size.

--- a/src/Models/BordersItemModel.vala
+++ b/src/Models/BordersItemModel.vala
@@ -1,23 +1,23 @@
-/*
-* Copyright (c) 2019 Alecaddd (https://alecaddd.com)
-*
-* This file is part of Akira.
-*
-* Akira is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+/**
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
 
-* Akira is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
 
-* You should have received a copy of the GNU General Public License
-* along with Akira. If not, see <https://www.gnu.org/licenses/>.
-*
-* Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
-*/
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
+ */
 
 public class Akira.Models.BordersItemModel : Models.BaseModel {
     public string color {
@@ -28,7 +28,6 @@ public class Akira.Models.BordersItemModel : Models.BaseModel {
             var new_rgba = Gdk.RGBA ();
             new_rgba.parse (value);
             border.color = new_rgba;
-            border.borders.reload ();
         }
     }
 
@@ -38,7 +37,6 @@ public class Akira.Models.BordersItemModel : Models.BaseModel {
         }
         set {
             border.alpha = value;
-            border.borders.reload ();
         }
     }
 
@@ -48,7 +46,6 @@ public class Akira.Models.BordersItemModel : Models.BaseModel {
         }
         set {
             border.size = value;
-            border.borders.reload ();
         }
     }
 
@@ -58,7 +55,6 @@ public class Akira.Models.BordersItemModel : Models.BaseModel {
         }
         set {
             border.hidden = value;
-            border.borders.reload ();
         }
     }
 

--- a/src/Models/BordersItemModel.vala
+++ b/src/Models/BordersItemModel.vala
@@ -28,7 +28,7 @@ public class Akira.Models.BordersItemModel : Models.BaseModel {
             var new_rgba = Gdk.RGBA ();
             new_rgba.parse (value);
             border.color = new_rgba;
-            border.reload ();
+            border.borders.reload ();
         }
     }
 
@@ -38,7 +38,7 @@ public class Akira.Models.BordersItemModel : Models.BaseModel {
         }
         set {
             border.alpha = value;
-            border.reload ();
+            border.borders.reload ();
         }
     }
 
@@ -48,7 +48,7 @@ public class Akira.Models.BordersItemModel : Models.BaseModel {
         }
         set {
             border.size = value;
-            border.reload ();
+            border.borders.reload ();
         }
     }
 
@@ -58,7 +58,7 @@ public class Akira.Models.BordersItemModel : Models.BaseModel {
         }
         set {
             border.hidden = value;
-            border.reload ();
+            border.borders.reload ();
         }
     }
 

--- a/src/Models/FillsItemModel.vala
+++ b/src/Models/FillsItemModel.vala
@@ -1,24 +1,24 @@
-/*
-* Copyright (c) 2019 Alecaddd (https://alecaddd.com)
-*
-* This file is part of Akira.
-*
-* Akira is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+/**
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
 
-* Akira is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
 
-* You should have received a copy of the GNU General Public License
-* along with Akira. If not, see <https://www.gnu.org/licenses/>.
-*
-* Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
-* Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
-*/
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+ * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
+ */
 
 public class Akira.Models.FillsItemModel : Models.BaseModel {
     public string color {
@@ -29,7 +29,6 @@ public class Akira.Models.FillsItemModel : Models.BaseModel {
             var new_rgba = Gdk.RGBA ();
             new_rgba.parse (value);
             fill.color = new_rgba;
-            fill.fills.reload ();
         }
     }
 
@@ -39,7 +38,6 @@ public class Akira.Models.FillsItemModel : Models.BaseModel {
         }
         set {
             fill.alpha = value;
-            fill.fills.reload ();
         }
     }
 
@@ -49,7 +47,6 @@ public class Akira.Models.FillsItemModel : Models.BaseModel {
         }
         set {
             fill.hidden = value;
-            fill.fills.reload ();
         }
     }
 

--- a/src/Models/FillsItemModel.vala
+++ b/src/Models/FillsItemModel.vala
@@ -29,7 +29,7 @@ public class Akira.Models.FillsItemModel : Models.BaseModel {
             var new_rgba = Gdk.RGBA ();
             new_rgba.parse (value);
             fill.color = new_rgba;
-            fill.reload ();
+            fill.fills.reload ();
         }
     }
 
@@ -39,7 +39,7 @@ public class Akira.Models.FillsItemModel : Models.BaseModel {
         }
         set {
             fill.alpha = value;
-            fill.reload ();
+            fill.fills.reload ();
         }
     }
 
@@ -49,7 +49,7 @@ public class Akira.Models.FillsItemModel : Models.BaseModel {
         }
         set {
             fill.hidden = value;
-            fill.reload ();
+            fill.fills.reload ();
         }
     }
 

--- a/src/Utils/Color.vala
+++ b/src/Utils/Color.vala
@@ -90,13 +90,12 @@ public class Akira.Utils.Color : Object {
         // Simple blend using Alpha channels. In the future we will support
         // different blending modes.
         double alpha = 1 - (1 - added_color.alpha) * (1 - base_color.alpha);
+        double ar1 = added_color.alpha / alpha;
+        double ar2 = (1 - added_color.alpha) / alpha;
 
-        double red = added_color.red * added_color.alpha /
-            alpha + base_color.red * base_color.alpha * (1 - added_color.alpha) / alpha;
-        double green = added_color.green * added_color.alpha /
-            alpha + base_color.green * base_color.alpha * (1 - added_color.alpha) / alpha;
-        double blue = added_color.blue * added_color.alpha /
-            alpha + base_color.blue * base_color.alpha * (1 - added_color.alpha) / alpha;
+        double red = added_color.red * ar1 + base_color.red * base_color.alpha * ar2;
+        double green = added_color.green * ar1 + base_color.green * base_color.alpha * ar2;
+        double blue = added_color.blue * ar1 + base_color.blue * base_color.alpha * ar2;
 
         var rgba = Gdk.RGBA ();
         rgba.alpha = alpha;

--- a/src/Utils/Color.vala
+++ b/src/Utils/Color.vala
@@ -80,9 +80,10 @@ public class Akira.Utils.Color : Object {
             return base_color;
         }
 
-        // If the newly added color alpha is 1 we don't need to do any color mixing,
-        // as the added color will completely cover the base color.
-        if (added_color.alpha == 1.0) {
+        // If the newly added color alpha is 1 or the base color alpha is 0
+        // we don't need to do any color mixing, as the added color will be
+        // the only one visible.
+        if (added_color.alpha == 1.0 || base_color.alpha == 0) {
             return added_color;
         }
 

--- a/src/Utils/Color.vala
+++ b/src/Utils/Color.vala
@@ -77,7 +77,6 @@ public class Akira.Utils.Color : Object {
         // If the newly added color alpha is 0 we don't need to do any color mixing
         // as the added color won't alter the base color.
         if (added_color.alpha == 0.0) {
-            warning ("added alpha 0");
             return base_color;
         }
 
@@ -87,22 +86,16 @@ public class Akira.Utils.Color : Object {
             return added_color;
         }
 
-        double alpha = base_color.alpha + added_color.alpha * (1 - base_color.alpha);
-        double red = Math.round (
-            ((base_color.red * base_color.alpha) +
-            (added_color.red * added_color.alpha) *
-            (1 - base_color.alpha)) / alpha
-        );
-        double green = Math.round (
-            ((base_color.green * base_color.alpha) +
-            (added_color.green * added_color.alpha) *
-            (1 - base_color.alpha)) / alpha
-        );
-        double blue = Math.round (
-            ((base_color.blue * base_color.alpha) +
-            (added_color.blue * added_color.alpha) *
-            (1 - base_color.alpha)) / alpha
-        );
+        // Simple blend using Alpha channels. In the future we will support
+        // different blending modes.
+        double alpha = 1 - (1 - added_color.alpha) * (1 - base_color.alpha);
+
+        double red = added_color.red * added_color.alpha /
+            alpha + base_color.red * base_color.alpha * (1 - added_color.alpha) / alpha;
+        double green = added_color.green * added_color.alpha /
+            alpha + base_color.green * base_color.alpha * (1 - added_color.alpha) / alpha;
+        double blue = added_color.blue * added_color.alpha /
+            alpha + base_color.blue * base_color.alpha * (1 - added_color.alpha) / alpha;
 
         var rgba = Gdk.RGBA ();
         rgba.alpha = alpha;

--- a/src/Utils/Color.vala
+++ b/src/Utils/Color.vala
@@ -1,24 +1,27 @@
-/*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
-*
-* This file is part of Akira.
-*
-* Akira is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+/**
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
 
-* Akira is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
 
-* You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
-*
-* Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
-*/
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+ */
 
+/**
+ * Helper object class containing all static methods for RGBA manipulation.
+ */
 public class Akira.Utils.Color : Object {
     public static string rgba_to_hex (string rgba_string) {
         var rgba = Gdk.RGBA ();

--- a/src/Utils/Color.vala
+++ b/src/Utils/Color.vala
@@ -69,4 +69,44 @@ public class Akira.Utils.Color : Object {
 
         return uint_rgba;
     }
+
+    public static Gdk.RGBA blend_colors (Gdk.RGBA base_color, Gdk.RGBA added_color) {
+        // If the newly added color alpha is 0 we don't need to do any color mixing
+        // as the added color won't alter the base color.
+        if (added_color.alpha == 0.0) {
+            warning ("added alpha 0");
+            return base_color;
+        }
+
+        // If the newly added color alpha is 1 we don't need to do any color mixing,
+        // as the added color will completely cover the base color.
+        if (added_color.alpha == 1.0) {
+            return added_color;
+        }
+
+        double alpha = base_color.alpha + added_color.alpha * (1 - base_color.alpha);
+        double red = Math.round (
+            ((base_color.red * base_color.alpha) +
+            (added_color.red * added_color.alpha) *
+            (1 - base_color.alpha)) / alpha
+        );
+        double green = Math.round (
+            ((base_color.green * base_color.alpha) +
+            (added_color.green * added_color.alpha) *
+            (1 - base_color.alpha)) / alpha
+        );
+        double blue = Math.round (
+            ((base_color.blue * base_color.alpha) +
+            (added_color.blue * added_color.alpha) *
+            (1 - base_color.alpha)) / alpha
+        );
+
+        var rgba = Gdk.RGBA ();
+        rgba.alpha = alpha;
+        rgba.red = red;
+        rgba.green = green;
+        rgba.blue = blue;
+
+        return rgba;
+    }
 }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implement the alpha mixing of multiple fill and border colors.

## Steps to Test
- Create a shape
- Add multiple colors and fills
- Play with the alpha of the extra colors

## Screenshots 
![color-blending](https://user-images.githubusercontent.com/2527103/109769877-a9036f80-7baf-11eb-8c01-78ebf8ece462.gif)

## Known Issues / Things To Do
~The color gets reset once the item is selected, which doesn't make sense.~ Fixed!
For now we only handle 1 border size, so we get the bigger and go with it.
In the future we will probably implement child items just to handle different border sizes and also different offset once implemented in goocanvas.

## This PR fixes/implements the following **bugs/features**:
- Blend colors by their alpha channel for fills and borders.
- Use the color picker icon for the color picker button.
- Move the color picker close to the color button and style them to make them related.
