### PR TITLE
First snapping implementation

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -341,6 +341,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
         holding = false;
 
+        // This is a temporary approach to end operations. In the future we may want to have more specific
+        // methods.
+        selected_bound_manager.alert_held_button_release ();
+
         if (event.button == Gdk.BUTTON_MIDDLE) {
             edit_mode = EditMode.MODE_SELECTION;
         }

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -336,12 +336,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     /**
      * Move the item based on the mouse click and drag event.
      */
-    private void move_from_event (
-        Lib.Items.CanvasItem item,
-        double event_x,
-        double event_y
-        ) {
-
+    private void move_from_event ( Lib.Items.CanvasItem item, double event_x, double event_y ) {
         if (!initial_drag_registered) {
             initial_drag_registered = true;
             initial_drag_item_x = item.transform.x;
@@ -350,15 +345,15 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         // Keep reset and delta values for future adjustments.
 
-        // Calculate values needed to reset to the original position
+        // Calculate values needed to reset to the original position.
         var reset_x = item.transform.x - initial_drag_item_x;
         var reset_y = item.transform.y - initial_drag_item_y;
 
-        // Calculate the change based on the event
+        // Calculate the change based on the event.
         var delta_x = event_x - initial_drag_press_x;
         var delta_y = event_y - initial_drag_press_y;
 
-        // Keep reset and delta values for future adjustments. fix_size should
+        // Keep reset and delta values for future adjustments. fix_size should.
         // be called right before a transform.
         var first_move_x = Utils.AffineTransform.fix_size (delta_x - reset_x);
         var first_move_y = Utils.AffineTransform.fix_size (delta_y - reset_y);
@@ -371,9 +366,9 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         matrix.y0 += first_move_y;
         item.set_transform (matrix);
 
-        // Make adjustment basted on snaps
-        // Double the sensitivity to allow for reuse of grid after snap
-        var sensitivity = (int) Utils.Snapping.adjusted_sensitivity (canvas.current_scale);
+        // Make adjustment basted on snaps.
+        // Double the sensitivity to allow for reuse of grid after snap.
+        var sensitivity = Utils.Snapping.adjusted_sensitivity (canvas.current_scale);
         var snap_grid = Utils.Snapping.snap_grid_from_canvas (canvas, selected_items, sensitivity);
 
         if (!snap_grid.is_empty ()) {
@@ -410,7 +405,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
     private void update_grid_decorators (bool force) {
         if (force || snap_manager.is_active ()) {
-            var sensitivity = (int) Utils.Snapping.adjusted_sensitivity (canvas.current_scale);
+            var sensitivity = Utils.Snapping.adjusted_sensitivity (canvas.current_scale);
             var snap_grid = Utils.Snapping.snap_grid_from_canvas (canvas, selected_items, sensitivity);
             var matches = Utils.Snapping.generate_snap_matches (snap_grid, selected_items, sensitivity);
             snap_manager.populate_decorators_from_data (matches, snap_grid);

--- a/src/Lib/Managers/SnapManager.vala
+++ b/src/Lib/Managers/SnapManager.vala
@@ -94,20 +94,23 @@ public class Akira.Lib.Managers.SnapManager : Object {
 
     private void add_vertical_decorator_line (int pos, int polarity_offset, Utils.Snapping.SnapGrid grid) {
 
-        double lw = double.max (0.5, LINE_WIDTH / canvas.current_scale);
+        double lw = LINE_WIDTH / canvas.current_scale;
         var snap_value = grid.v_snaps.get (pos);
         if (snap_value != null) {
 
+            // To actually show decorators in their exact position, we offset by 0.5
+            double actual_pos = (double)(pos + polarity_offset);
+
             // add dots
             foreach (var normal in snap_value.normals) {
-                add_decorator_dot (normal, pos + polarity_offset);
+                add_decorator_dot (normal, actual_pos);
             }
 
             // add lines (reuse if possible
             foreach (var line in v_decorator_lines) {
                 if (line.visibility == Goo.CanvasItemVisibility.HIDDEN) {
                     line.set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
-                    line.set ("y", (double)pos + polarity_offset);
+                    line.set ("y", actual_pos);
                     line.set ("line-width", lw);
                     line.raise (null);
                     return;
@@ -116,8 +119,8 @@ public class Akira.Lib.Managers.SnapManager : Object {
 
             var tmp = new Goo.CanvasPolyline.line (
                 null,
-                canvas.x1, pos + polarity_offset,
-                canvas.x2, pos + polarity_offset,
+                canvas.x1, actual_pos,
+                canvas.x2, actual_pos,
                 "line-width", lw,
                 "stroke-color", STROKE_COLOR,
                 null
@@ -134,19 +137,21 @@ public class Akira.Lib.Managers.SnapManager : Object {
 
     private void add_horizontal_decorator_line (int pos, int polarity_offset, Utils.Snapping.SnapGrid grid) {
 
-        double lw = double.max (0.5, LINE_WIDTH / canvas.current_scale);
+        double lw = LINE_WIDTH / canvas.current_scale;
         var snap_value = grid.h_snaps.get (pos);
         if (snap_value != null) {
+            double actual_pos = (double)(pos + polarity_offset);
+
             // add dots
             foreach (var normal in snap_value.normals) {
-                add_decorator_dot (pos + polarity_offset, normal);
+                add_decorator_dot (actual_pos, normal);
             }
 
             // add lines (reuse if possible
             foreach (var line in h_decorator_lines) {
                 if (line.visibility == Goo.CanvasItemVisibility.HIDDEN) {
                     line.set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
-                    line.set ("x", (double)pos + polarity_offset);
+                    line.set ("x", actual_pos);
                     line.set ("line-width", lw);
                     line.raise (null);
                     return;
@@ -155,8 +160,8 @@ public class Akira.Lib.Managers.SnapManager : Object {
 
             var tmp = new Goo.CanvasPolyline.line (
                 null,
-                pos + polarity_offset, canvas.y1,
-                pos + polarity_offset, canvas.y2,
+                actual_pos, canvas.y1,
+                actual_pos, canvas.y2,
                 "line-width", lw,
                 "stroke-color", STROKE_COLOR,
                 null
@@ -171,15 +176,15 @@ public class Akira.Lib.Managers.SnapManager : Object {
         }
     }
 
-    private void add_decorator_dot (int x, int y) {
-        double dot_radius = double.max (1, DOT_RADIUS / canvas.current_scale);
+    private void add_decorator_dot (double x, double y) {
+        double dot_radius = DOT_RADIUS / canvas.current_scale;
 
         // add dot
         foreach (var line in decorator_dots) {
             if (line.visibility == Goo.CanvasItemVisibility.HIDDEN) {
                 line.set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
-                line.set ("center_x", (double)x);
-                line.set ("center_y", (double)y);
+                line.set ("center_x", x);
+                line.set ("center_y", y);
                 line.set ("radius_x", dot_radius);
                 line.set ("radius_y", dot_radius);
                 line.raise (null);

--- a/src/Lib/Managers/SnapManager.vala
+++ b/src/Lib/Managers/SnapManager.vala
@@ -1,0 +1,199 @@
+/*
+* Copyright (c) 2019 Alecaddd (https://alecaddd.com)
+*
+* This file is part of Akira.
+*
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
+*
+* Authored by: Martin "mbfraga" Fraga <mbfraga@gmail.com>
+*/
+
+// This manager handles snap generation. It uses a list of selected items, and a list of candidate items to determine
+// whether snaps in the vertical and horizontal directions are suggested.
+//
+// Selected items may be a collection of items being dragged.
+//
+// Candidate items may be all items in the canvas, or items within an artboard.
+//
+// Matching is done in the vertical and horizontal directiosn independently
+
+
+public class Akira.Lib.Managers.SnapManager : Object {
+    private const string STROKE_COLOR = "#ff0000";
+    private const double LINE_WIDTH = 0.5;
+    private const double DOT_RADIUS = 2.0;
+    private const double SENSITIVITY = 5.0;
+
+    public weak Akira.Lib.Canvas canvas { get; construct; }
+
+
+    // Decorator items to be drawn in the Canvas
+    private Goo.CanvasItem root;
+    private Gee.ArrayList<Goo.CanvasItemSimple> v_decorator_lines;
+    private Gee.ArrayList<Goo.CanvasItemSimple> h_decorator_lines;
+    private Gee.ArrayList<Goo.CanvasItemSimple> decorator_dots;
+
+    public SnapManager (Akira.Lib.Canvas canvas) {
+        Object (
+            canvas: canvas
+        );
+    }
+
+    construct {
+        v_decorator_lines = new Gee.ArrayList<Goo.CanvasItemSimple> ();
+        h_decorator_lines = new Gee.ArrayList<Goo.CanvasItemSimple> ();
+        decorator_dots = new Gee.ArrayList<Goo.CanvasItemSimple> ();
+    }
+
+    public void reset_decorators () {
+        foreach (var decorator in v_decorator_lines) {
+            decorator.set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+        }
+        foreach (var decorator in h_decorator_lines) {
+            decorator.set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+        }
+        foreach (var decorator in decorator_dots) {
+            decorator.set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
+        }
+    }
+
+    public void populate_decorators (Utils.Snapping.SnapMatchData data, Utils.Snapping.SnapGrid grid) {
+        if (root == null) {
+            root = canvas.get_root_item ();
+        }
+
+            reset_decorators ();
+
+        if (data.v_data.snap_found ()) {
+            foreach (var snap_position in data.v_data.exact_matches) {
+                add_vertical_decorator_line (snap_position.key, snap_position.value, grid);
+            }
+        }
+
+        if (data.h_data.snap_found ()) {
+            foreach (var snap_position in data.h_data.exact_matches) {
+                add_horizontal_decorator_line (snap_position.key, snap_position.value, grid);
+            }
+        }
+
+    }
+
+    private void add_vertical_decorator_line (int pos, int polarity_offset, Utils.Snapping.SnapGrid grid) {
+        var snap_value = grid.v_snaps.get (pos);
+        if (snap_value != null) {
+
+            // add dots
+            foreach (var normal in snap_value.normals) {
+                add_decorator_dot (normal, pos + polarity_offset);
+            }
+
+            // add lines (reuse if possible
+            foreach (var line in v_decorator_lines) {
+                if (line.visibility == Goo.CanvasItemVisibility.HIDDEN) {
+                    line.set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+                    line.set ("y", (double)pos + polarity_offset);
+                    line.set ("line-width", LINE_WIDTH / canvas.current_scale);
+                    line.raise (null);
+                    return;
+                }
+            }
+
+            var tmp = new Goo.CanvasPolyline.line (
+                null,
+                canvas.x1, pos + polarity_offset,
+                canvas.x2, pos + polarity_offset,
+                "line-width", LINE_WIDTH / canvas.current_scale,
+                "stroke-color", STROKE_COLOR,
+                null
+            );
+
+            tmp.can_focus = false;
+            tmp.pointer_events = Goo.CanvasPointerEvents.NONE;
+
+            tmp.set ("parent", root);
+            tmp.raise (null);
+            v_decorator_lines.add (tmp);
+        }
+    }
+
+    private void add_horizontal_decorator_line (int pos, int polarity_offset, Utils.Snapping.SnapGrid grid) {
+        var snap_value = grid.h_snaps.get (pos);
+        if (snap_value != null) {
+
+            // add dots
+            foreach (var normal in snap_value.normals) {
+                add_decorator_dot (pos + polarity_offset, normal);
+            }
+
+            // add lines (reuse if possible
+            foreach (var line in h_decorator_lines) {
+                if (line.visibility == Goo.CanvasItemVisibility.HIDDEN) {
+                    line.set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+                    line.set ("x", (double)pos + polarity_offset);
+                    line.set ("line-width", LINE_WIDTH / canvas.current_scale);
+                    line.raise (null);
+                    return;
+                }
+            }
+
+            var tmp = new Goo.CanvasPolyline.line (
+                null,
+                pos + polarity_offset, canvas.y1,
+                pos + polarity_offset, canvas.y2,
+                "line-width", LINE_WIDTH / canvas.current_scale,
+                "stroke-color", STROKE_COLOR,
+                null
+            );
+
+            tmp.can_focus = false;
+            tmp.pointer_events = Goo.CanvasPointerEvents.NONE;
+
+            tmp.set ("parent", root);
+            tmp.raise (null);
+            h_decorator_lines.add (tmp);
+        }
+    }
+
+    private void add_decorator_dot (int x, int y) {
+        // add dot
+        foreach (var line in decorator_dots) {
+            if (line.visibility == Goo.CanvasItemVisibility.HIDDEN) {
+                line.set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
+                line.set ("center_x", (double)x);
+                line.set ("center_y", (double)y);
+                line.set ("radius_x", DOT_RADIUS / canvas.current_scale);
+                line.set ("radius_y", DOT_RADIUS / canvas.current_scale);
+                line.raise (null);
+                return;
+            }
+        }
+
+        var tmp = new Goo.CanvasEllipse (
+            null,
+            x, y,
+            DOT_RADIUS / canvas.current_scale, DOT_RADIUS / canvas.current_scale,
+            "line-width", 0.0,
+            "fill-color", STROKE_COLOR,
+            null
+        );
+
+        tmp.can_focus = false;
+        tmp.pointer_events = Goo.CanvasPointerEvents.NONE;
+
+        tmp.set ("parent", root);
+        tmp.raise (null);
+        decorator_dots.add (tmp);
+    }
+
+}

--- a/src/Lib/Managers/SnapManager.vala
+++ b/src/Lib/Managers/SnapManager.vala
@@ -19,6 +19,7 @@
 * Authored by: Martin "mbfraga" Fraga <mbfraga@gmail.com>
 */
 
+// Manages Goo.CanvasItem decorators used to display snap lines and dots
 public class Akira.Lib.Managers.SnapManager : Object {
     private const string STROKE_COLOR = "#ff0000";
     private const double LINE_WIDTH = 0.5;
@@ -47,10 +48,12 @@ public class Akira.Lib.Managers.SnapManager : Object {
         decorator_dots = new Gee.ArrayList<Goo.CanvasItemSimple> ();
     }
 
+    // Returns true if the manager has active decorators
     public bool is_active () {
         return any_decorators_visible;
     }
 
+    // Makes all decorators invisible, and ready to be reused
     public void reset_decorators () {
         foreach (var decorator in v_decorator_lines) {
             decorator.set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
@@ -65,6 +68,8 @@ public class Akira.Lib.Managers.SnapManager : Object {
         any_decorators_visible = false;
     }
 
+    // Populates decorators (if applicable) based on match data and the snap grid
+    // Reuses decorator Goo.CanvasItems if possible, otherwise constructs new ones
     public void populate_decorators_from_data (Utils.Snapping.SnapMatchData data, Utils.Snapping.SnapGrid grid) {
         if (root == null) {
             root = canvas.get_root_item ();

--- a/src/Lib/Managers/SnapManager.vala
+++ b/src/Lib/Managers/SnapManager.vala
@@ -48,12 +48,16 @@ public class Akira.Lib.Managers.SnapManager : Object {
         decorator_dots = new Gee.ArrayList<Goo.CanvasItemSimple> ();
     }
 
-    // Returns true if the manager has active decorators
+    /**
+     * Returns true if the manager has active decorators
+     */
     public bool is_active () {
         return any_decorators_visible;
     }
 
-    // Makes all decorators invisible, and ready to be reused
+    /**
+     * Makes all decorators invisible, and ready to be reused
+     */
     public void reset_decorators () {
         foreach (var decorator in v_decorator_lines) {
             decorator.set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
@@ -68,8 +72,10 @@ public class Akira.Lib.Managers.SnapManager : Object {
         any_decorators_visible = false;
     }
 
-    // Populates decorators (if applicable) based on match data and the snap grid
-    // Reuses decorator Goo.CanvasItems if possible, otherwise constructs new ones
+    /**
+     * Populates decorators (if applicable) based on match data and the snap grid
+     * Reuses decorator Goo.CanvasItems if possible, otherwise constructs new ones
+     */
     public void populate_decorators_from_data (Utils.Snapping.SnapMatchData data, Utils.Snapping.SnapGrid grid) {
         if (root == null) {
             root = canvas.get_root_item ();
@@ -99,7 +105,7 @@ public class Akira.Lib.Managers.SnapManager : Object {
         if (snap_value != null) {
 
             // To actually show decorators in their exact position, we offset by 0.5
-            double actual_pos = (double)(pos + polarity_offset);
+            double actual_pos = (double) (pos + polarity_offset);
 
             // add dots
             foreach (var normal in snap_value.normals) {
@@ -140,7 +146,7 @@ public class Akira.Lib.Managers.SnapManager : Object {
         double lw = LINE_WIDTH / canvas.current_scale;
         var snap_value = grid.h_snaps.get (pos);
         if (snap_value != null) {
-            double actual_pos = (double)(pos + polarity_offset);
+            double actual_pos = (double) (pos + polarity_offset);
 
             // add dots
             foreach (var normal in snap_value.normals) {

--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -242,13 +242,13 @@ public class Akira.Utils.Snapping : Object {
     /*
      * Populates the horizontal snaps of an item.
      */
-    private static void populate_horizontal_snaps (lib.items.canvasitem item, ref gee.hashmap<int, snapmeta> map) {
+    private static void populate_horizontal_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
         int x_1 = (int) item.bounds.x1;
         int x_2 = (int) item.bounds.x2;
         int y_1 = (int) item.bounds.y1;
         int y_2 = (int) item.bounds.y2;
-        int center_x = (int) (math.ceil ((item.bounds.x2 - item.bounds.x1) / 2.0) + item.bounds.x1);
-        int center_y = (int) (math.ceil ((item.bounds.y2 - item.bounds.y1) / 2.0) + item.bounds.y1);
+        int center_x = (int) (Math.ceil ((item.bounds.x2 - item.bounds.x1) / 2.0) + item.bounds.x1);
+        int center_y = (int) (Math.ceil ((item.bounds.y2 - item.bounds.y1) / 2.0) + item.bounds.y1);
 
         add_to_map (x_1, y_1, y_2, center_y, -1, ref map);
         add_to_map (x_2, y_1, y_2, center_y, 1, ref map);

--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -23,16 +23,17 @@
 public class Akira.Utils.Snapping : Object {
     private const double SENSITIVITY = 4.0;
 
-    // Metadata used in the cosmetic aspects of snap lines and dots
+    /*
+     * Metadata used in the cosmetic aspects of snap lines and dots.
+     */
     public class SnapMeta {
-        public void add_polarity (int to_add) {
-            polarity += to_add;
-        }
         public Gee.HashSet<int> normals;
         public int polarity;
     }
 
-    // Grid snaps found for a given selection and set of candidates
+    /*
+     * Grid snaps found for a given selection and set of candidates.
+     */
     public struct SnapGrid {
         public bool is_empty () {
             return (v_snaps.size == 0 && h_snaps.size == 0);
@@ -42,22 +43,30 @@ public class Akira.Utils.Snapping : Object {
         public Gee.HashMap<int, SnapMeta> h_snaps;
     }
 
-    // Type of match that was found for a snap
+    /*
+     * Type of match that was found for a snap.
+     */
     public enum MatchType {
-        NONE=-1,    //< No match was found
-        FUZZY,      //< A match was found, but requires an offset
-        EXACT,      //< An exact match was found, no offset is necessary
+        NONE=-1,    //< No match was found.
+        FUZZY,      //< A match was found, but requires an offset.
+        EXACT,      //< An exact match was found, no offset is necessary.
     }
 
-    // Information used to define a match for a given selection.
-    // An instance of this class corresponds to a single direction (vertical or horizontal).
+    /*
+     * Information used to define a match for a given selection.
+     * An instance of this class corresponds to a single direction (vertical or horizontal).
+     */
     public struct SnapMatch {
-        // Returns true if a match was found
+        /*
+         * Returns true if a match was found
+         */
         public bool snap_found () {
             return type != MatchType.NONE;
         }
 
-        // Returns the offset necessary to bring the reference position to the selected items
+        /*
+         * Returns the offset necessary to bring the reference position to the selected items.
+         */
         public int snap_offset () {
             if (snap_found ()) {
                 return snap_position + polarity_offset - reference_position;
@@ -66,13 +75,15 @@ public class Akira.Utils.Snapping : Object {
         }
 
         public MatchType type;
-        public int snap_position; //< Position of matched snap
-        public int polarity_offset; //< Offset incurred by polarity properties. For now it is always zero
-        public int reference_position; //< Position relative to the selection used as a reference
-        public Gee.HashMap<int, int> exact_matches; //< map of exact matches and their polarities
+        public int snap_position; //< Position of matched snap.
+        public int polarity_offset; //< Offset incurred by polarity properties. For now it is always zero.
+        public int reference_position; //< Position relative to the selection used as a reference.
+        public Gee.HashMap<int, int> exact_matches; //< map of exact matches and their polarities.
     }
 
-    // Couple of MatchData used for convenience
+    /*
+     * Couple of MatchData used for convenience.
+     */
     public struct SnapMatchData {
         public bool snap_found () {
             return h_data.snap_found () || v_data.snap_found ();
@@ -82,18 +93,22 @@ public class Akira.Utils.Snapping : Object {
         SnapMatch v_data;
     }
 
-    /// Returns a sensitivity adjusted to the given canvas scale
-    public static double adjusted_sensitivity (double canvas_scale) {
-        // Limit the sensitivity. This seems like a sensible default for now
+    /*
+     * Returns a sensitivity adjusted to the given canvas scale.
+     */
+    public static int adjusted_sensitivity (double canvas_scale) {
+        // Limit the sensitivity. This seems like a sensible default for now.
         if (canvas_scale > SENSITIVITY) {
-            return 1.0;
+            return 1;
         }
 
         // beyond 0.002, the snapping breaks down. Arguably, it does before.
-        return SENSITIVITY / double.max(0.002, canvas_scale);
+        return (int) (SENSITIVITY / double.max (0.002, canvas_scale));
     }
 
-    // Generates a snap grid from a canvas.
+    /*
+     * Generates a snap grid from a canvas.
+     */
     public static SnapGrid snap_grid_from_canvas (
         Goo.Canvas canvas,
         List<Lib.Items.CanvasItem> selection,
@@ -123,7 +138,9 @@ public class Akira.Utils.Snapping : Object {
         return snap_grid_from_candidates (vertical_candidates, horizontal_candidates, selection);
     }
 
-    // Calculate snaps inside a grid that match the selection input
+    /*
+     * Calculate snaps inside a grid that match the selection input.
+     */
     public static SnapMatchData generate_snap_matches (
         SnapGrid grid,
         List<Lib.Items.CanvasItem> selection,
@@ -145,16 +162,17 @@ public class Akira.Utils.Snapping : Object {
         return matches;
     }
 
-    // Matches in one direction (vertical / horizontal)
+    /*
+     * Matches in one direction (vertical / horizontal).
+     */
     private static void populate_snap_matches_from_list (
         Gee.HashMap<int, SnapMeta> target_snap_list,
         Gee.HashMap<int, SnapMeta> grid_snap_list,
         ref SnapMatch matches,
         int sensitivity
     ) {
-
-        var sorted_target_snaps = new Gee.TreeMap<int, SnapMeta>();
-        var sorted_grid_snaps = new Gee.TreeMap<int, SnapMeta>();
+        var sorted_target_snaps = new Gee.TreeMap<int, SnapMeta> ();
+        var sorted_grid_snaps = new Gee.TreeMap<int, SnapMeta> ();
 
         sorted_target_snaps.set_all (target_snap_list);
         sorted_grid_snaps.set_all (grid_snap_list);
@@ -167,12 +185,12 @@ public class Akira.Utils.Snapping : Object {
 
                polarity_offset = 0;
 
-                diff = (int)(cand.key - target_snap.key);
+                diff = (int) (cand.key - target_snap.key);
                 diff = diff.abs ();
 
 
                if (diff < sensitivity) {
-                    if ((int)(cand.key + polarity_offset - target_snap.key) == 0) {
+                    if ((int) (cand.key + polarity_offset - target_snap.key) == 0) {
 
                        matches.type = MatchType.EXACT;
                         matches.snap_position = cand.key;
@@ -196,60 +214,66 @@ public class Akira.Utils.Snapping : Object {
 
 
     private static SnapGrid snap_grid_from_candidates (
-    List<weak Goo.CanvasItem> v_candidates,
-    List<weak Goo.CanvasItem> h_candidates,
-    List<Lib.Items.CanvasItem> selection
+        List<weak Goo.CanvasItem> v_candidates,
+        List<weak Goo.CanvasItem> h_candidates,
+        List<Lib.Items.CanvasItem> selection
     ) {
         var grid = SnapGrid ();
         grid.v_snaps = new Gee.HashMap<int, SnapMeta> ();
         grid.h_snaps = new Gee.HashMap<int, SnapMeta> ();
 
         foreach (var cand in v_candidates) {
-          var candidate_item = cand as Lib.Items.CanvasItem;
-          if (candidate_item != null && selection.find (candidate_item) == null) {
-            populate_vertical_snaps (candidate_item, ref grid.v_snaps);
-          }
+            var candidate_item = cand as Lib.Items.CanvasItem;
+            if (candidate_item != null && selection.find (candidate_item) == null) {
+                populate_vertical_snaps (candidate_item, ref grid.v_snaps);
+            }
         }
 
         foreach (var cand in h_candidates) {
-          var candidate_item = cand as Lib.Items.CanvasItem;
-          if (candidate_item != null && selection.find (candidate_item) == null) {
-            populate_horizontal_snaps (candidate_item, ref grid.h_snaps);
-          }
+            var candidate_item = cand as Lib.Items.CanvasItem;
+            if (candidate_item != null && selection.find (candidate_item) == null) {
+                populate_horizontal_snaps (candidate_item, ref grid.h_snaps);
+            }
         }
 
         return grid;
     }
 
-    /// Populates the horizontal snaps of an item
-    private static void populate_horizontal_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
-        int x_1 = (int)item.bounds.x1;
-        int x_2 = (int)item.bounds.x2;
-        int y_1 = (int)item.bounds.y1;
-        int y_2 = (int)item.bounds.y2;
-        int center_x = (int)(Math.ceil((item.bounds.x2 - item.bounds.x1) / 2.0) + item.bounds.x1);
-        int center_y = (int)(Math.ceil((item.bounds.y2 - item.bounds.y1) / 2.0) + item.bounds.y1);
+    /*
+     * Populates the horizontal snaps of an item.
+     */
+    private static void populate_horizontal_snaps (lib.items.canvasitem item, ref gee.hashmap<int, snapmeta> map) {
+        int x_1 = (int) item.bounds.x1;
+        int x_2 = (int) item.bounds.x2;
+        int y_1 = (int) item.bounds.y1;
+        int y_2 = (int) item.bounds.y2;
+        int center_x = (int) (math.ceil ((item.bounds.x2 - item.bounds.x1) / 2.0) + item.bounds.x1);
+        int center_y = (int) (math.ceil ((item.bounds.y2 - item.bounds.y1) / 2.0) + item.bounds.y1);
 
         add_to_map (x_1, y_1, y_2, center_y, -1, ref map);
         add_to_map (x_2, y_1, y_2, center_y, 1, ref map);
         add_to_map (center_x, center_y, center_y, center_y, 0, ref map);
     }
 
-    /// Populates the vertical snaps of an item
+    /*
+     * Populates the vertical snaps of an item.
+     */
     private static void populate_vertical_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
-        int x_1 = (int)item.bounds.x1;
-        int x_2 = (int)item.bounds.x2;
-        int y_1 = (int)item.bounds.y1;
-        int y_2 = (int)item.bounds.y2;
-        int center_x = (int)(Math.ceil((item.bounds.x2 - item.bounds.x1) / 2.0) + item.bounds.x1);
-        int center_y = (int)(Math.ceil((item.bounds.y2 - item.bounds.y1) / 2.0) + item.bounds.y1);
+        int x_1 = (int) item.bounds.x1;
+        int x_2 = (int) item.bounds.x2;
+        int y_1 = (int) item.bounds.y1;
+        int y_2 = (int) item.bounds.y2;
+        int center_x = (int) (Math.ceil ((item.bounds.x2 - item.bounds.x1) / 2.0) + item.bounds.x1);
+        int center_y = (int) (Math.ceil ((item.bounds.y2 - item.bounds.y1) / 2.0) + item.bounds.y1);
 
         add_to_map (y_1, x_1, x_2, center_x, -1, ref map);
         add_to_map (y_2, x_1, x_2, center_x, 1, ref map);
         add_to_map (center_y, center_x, center_x, center_x, 0, ref map);
     }
 
-    /// Simple method to add information to a snap list
+    /*
+     * Simple method to add information to a snap list.
+     */
     private static void add_to_map (
         int pos,
         int n1,
@@ -264,19 +288,21 @@ public class Akira.Utils.Snapping : Object {
             k.normals.add (n2);
             k.normals.add (n3);
             k.polarity += polarity;
+            return;
         }
-        else {
-            var v = new SnapMeta ();
-            v.normals = new Gee.HashSet<int> ();
-            v.normals.add (n1);
-            v.normals.add (n2);
-            v.normals.add (n3);
-            v.polarity = polarity;
-            map.set (pos, v);
-        }
+
+        var v = new SnapMeta ();
+        v.normals = new Gee.HashSet<int> ();
+        v.normals.add (n1);
+        v.normals.add (n2);
+        v.normals.add (n3);
+        v.polarity = polarity;
+        map.set (pos, v);
     }
 
-    // Generate a default match data
+    /*
+     * Generate a default match data.
+     */
     private static SnapMatchData default_match_data () {
         var matches = SnapMatchData ();
         matches.v_data.type = MatchType.NONE;

--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -85,7 +85,12 @@ public class Akira.Utils.Snapping : Object {
     /// Returns a sensitivity adjusted to the given canvas scale
     public static double adjusted_sensitivity (double canvas_scale) {
         // Limit the sensitivity. This seems like a sensible default for now
-        return double.max (SENSITIVITY / 2.0, SENSITIVITY / canvas_scale);
+        if (canvas_scale > SENSITIVITY) {
+            return 1.0;
+        }
+
+        // beyond 0.002, the snapping breaks down. Arguably, it does before.
+        return SENSITIVITY / double.max(0.002, canvas_scale);
     }
 
     // Generates a snap grid from a canvas.
@@ -147,26 +152,36 @@ public class Akira.Utils.Snapping : Object {
         ref SnapMatch matches,
         int sensitivity
     ) {
+
+        var sorted_target_snaps = new Gee.TreeMap<int, SnapMeta>();
+        var sorted_grid_snaps = new Gee.TreeMap<int, SnapMeta>();
+
+        sorted_target_snaps.set_all (target_snap_list);
+        sorted_grid_snaps.set_all (grid_snap_list);
+
         int diff = 0;
         int polarity_offset = 0;
         var tmpdiff = sensitivity;
-        foreach (var target_snap in target_snap_list) {
-            foreach (var cand in grid_snap_list) {
-                polarity_offset = 0;
+        foreach (var target_snap in sorted_target_snaps) {
+            foreach (var cand in sorted_grid_snaps) {
+
+               polarity_offset = 0;
 
                 diff = (int)(cand.key - target_snap.key);
                 diff = diff.abs ();
 
-                if (diff < sensitivity) {
+
+               if (diff < sensitivity) {
                     if ((int)(cand.key + polarity_offset - target_snap.key) == 0) {
-                        matches.type = MatchType.EXACT;
+
+                       matches.type = MatchType.EXACT;
                         matches.snap_position = cand.key;
                         matches.reference_position = target_snap.key;
                         matches.polarity_offset = polarity_offset;
                         matches.exact_matches[cand.key] = polarity_offset;
                         tmpdiff = diff;
                     }
-                    else if (diff < tmpdiff) {
+                  else if (diff < tmpdiff) {
                         matches.type = MatchType.FUZZY;
                         matches.snap_position = cand.key;
                         matches.reference_position = target_snap.key;
@@ -177,7 +192,6 @@ public class Akira.Utils.Snapping : Object {
                 tmpdiff = diff;
             }
         }
-
     }
 
 
@@ -213,8 +227,8 @@ public class Akira.Utils.Snapping : Object {
         int x_2 = (int)item.bounds.x2;
         int y_1 = (int)item.bounds.y1;
         int y_2 = (int)item.bounds.y2;
-        int center_x = (int)((item.bounds.x2 - item.bounds.x1) / 2.0 + item.bounds.x1);
-        int center_y = (int)((item.bounds.y2 - item.bounds.y1) / 2.0 + item.bounds.y1);
+        int center_x = (int)(Math.ceil((item.bounds.x2 - item.bounds.x1) / 2.0) + item.bounds.x1);
+        int center_y = (int)(Math.ceil((item.bounds.y2 - item.bounds.y1) / 2.0) + item.bounds.y1);
 
         add_to_map (x_1, y_1, y_2, center_y, -1, ref map);
         add_to_map (x_2, y_1, y_2, center_y, 1, ref map);
@@ -227,8 +241,8 @@ public class Akira.Utils.Snapping : Object {
         int x_2 = (int)item.bounds.x2;
         int y_1 = (int)item.bounds.y1;
         int y_2 = (int)item.bounds.y2;
-        int center_x = (int)((item.bounds.x2 - item.bounds.x1) / 2.0 + item.bounds.x1);
-        int center_y = (int)((item.bounds.y2 - item.bounds.y1) / 2.0 + item.bounds.y1);
+        int center_x = (int)(Math.ceil((item.bounds.x2 - item.bounds.x1) / 2.0) + item.bounds.x1);
+        int center_y = (int)(Math.ceil((item.bounds.y2 - item.bounds.y1) / 2.0) + item.bounds.y1);
 
         add_to_map (y_1, x_1, x_2, center_x, -1, ref map);
         add_to_map (y_2, x_1, x_2, center_x, 1, ref map);

--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -1,0 +1,267 @@
+/*
+* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+*
+* This file is part of Akira.
+*
+* Akira is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Akira is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+
+* You should have received a copy of the GNU General Public License
+* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+*
+* Authored by: Martin "mbfraga" Fraga <mbfraga@gmail.com>
+*/
+
+public class Akira.Utils.Snapping : Object {
+    private const string STROKE_COLOR = "#ff0000";
+    private const double LINE_WIDTH = 0.5;
+    private const double DOT_RADIUS = 2.0;
+
+    // Metadata used in the cosmetic aspects of snap lines and dots
+    public class SnapMeta {
+        public void add_polarity(int to_add) {
+            polarity += to_add;
+        }
+        public Gee.HashSet<int> normals;
+        public int polarity;
+    }
+
+    // Grid snaps found for a given selection and set of candidates
+    public struct SnapGrid {
+        public Gee.HashMap<int, SnapMeta> v_snaps;
+        public Gee.HashMap<int, SnapMeta> h_snaps;
+    }
+
+    // Type of match that was found for a snap
+    public enum MatchType {
+        NONE=-1,    //< No match was found
+        FUZZY,      //< A match was found, but requires an offset
+        EXACT,      //< An exact match was found, no offset is necessary
+    }
+
+    // Information used to define a match for a given selection.
+    // An instance of this class corresponds to a single direction (vertical or horizontal).
+    public struct SnapMatch {
+        // Returns true if a match was found
+        public bool snap_found () {
+            return type != MatchType.NONE;
+        }
+
+        // Returns the offset necessary to bring the reference position to the selected items
+        public int snap_offset () {
+            if (snap_found ()) {
+                return snap_position + polarity_offset - reference_position;
+            }
+            return 0;
+        }
+
+        public MatchType type;
+        public int snap_position; //< Position of matched snap
+        public int polarity_offset; //< Offset incurred by polarity properties. For now it is always zero
+        public int reference_position; //< Position relative to the selection used as a reference
+        public Gee.HashMap<int, int> exact_matches; //< map of exact matches and their polarities
+    }
+
+    // Couple of MatchData used for convenience
+    public struct SnapMatchData {
+        public bool snap_found () {
+            return h_data.snap_found () || v_data.snap_found ();
+        }
+
+        SnapMatch h_data;
+        SnapMatch v_data;
+    }
+
+    public static SnapGrid snap_grid_from_canvas (
+        Goo.Canvas canvas,
+        List<Lib.Items.CanvasItem> selection,
+        int sensitivity
+    ) {
+        List<weak Goo.CanvasItem> vertical_candidates = null;
+        List<weak Goo.CanvasItem> horizontal_candidates = null;
+
+        Goo.CanvasBounds vertical_filter = {0, 0, 0, 0};
+        Goo.CanvasBounds horizontal_filter = {0, 0, 0, 0};
+
+        foreach (var item in selection) {
+          horizontal_filter.x1 = item.bounds.x1 - sensitivity;
+          horizontal_filter.x2 = item.bounds.x2 + sensitivity;
+          horizontal_filter.y1 = canvas.y1;
+          horizontal_filter.y2 = canvas.y2;
+
+          vertical_filter.x1 = canvas.x1;
+          vertical_filter.x2 = canvas.x2;
+          vertical_filter.y1 = item.bounds.y1 - sensitivity;
+          vertical_filter.y2 = item.bounds.y2 + sensitivity;
+
+          vertical_candidates.concat (canvas.get_items_in_area (vertical_filter, true, true, false));
+          horizontal_candidates.concat (canvas.get_items_in_area (horizontal_filter, true, true, false));
+        }
+
+        return snap_grid_from_candidates(vertical_candidates, horizontal_candidates, selection, sensitivity);
+    }
+
+    public static SnapMatchData generate_snap_matches (
+        SnapGrid grid,
+        List<Lib.Items.CanvasItem> selection,
+        int sensitivity
+    ) {
+        var matches = defaultMatchData();
+
+        var v_sel_snaps = new Gee.HashMap<int, SnapMeta> ();
+        var h_sel_snaps = new Gee.HashMap<int, SnapMeta> ();
+
+        foreach (var item in selection) {
+            populate_horizontal_snaps (item, ref h_sel_snaps);
+            populate_vertical_snaps (item, ref v_sel_snaps);
+        }
+
+        populate_snap_matches_from_list(h_sel_snaps, grid.h_snaps, ref matches.h_data, sensitivity);
+        populate_snap_matches_from_list(v_sel_snaps, grid.v_snaps, ref matches.v_data, sensitivity);
+
+        return matches;
+    }
+
+    private static void populate_snap_matches_from_list(
+        Gee.HashMap<int, SnapMeta> target_snap_list,
+        Gee.HashMap<int, SnapMeta> grid_snap_list,
+        ref SnapMatch matches,
+        int sensitivity
+    ) {
+        int diff = 0;
+        int polarity_offset = 0;
+        var tmpdiff = sensitivity;
+        foreach (var target_snap in target_snap_list) {
+            foreach (var cand in grid_snap_list) {
+                polarity_offset = 0;
+
+                diff = (int)(cand.key - target_snap.key);
+                diff = diff.abs ();
+
+                if (diff < sensitivity) {
+                    if ((int)(cand.key + polarity_offset - target_snap.key) == 0) {
+                        matches.type = MatchType.EXACT;
+                        matches.snap_position = cand.key;
+                        matches.reference_position = target_snap.key;
+                        matches.polarity_offset = polarity_offset;
+                        matches.exact_matches[cand.key] = polarity_offset;
+                        tmpdiff = diff;
+                    }
+                    else if (diff < tmpdiff) {
+                        matches.type = MatchType.FUZZY;
+                        matches.snap_position = cand.key;
+                        matches.reference_position = target_snap.key;
+                        matches.polarity_offset = polarity_offset;
+                        tmpdiff = diff;
+                    }
+                }
+                tmpdiff = diff;
+            }
+        }
+
+    }
+
+
+    private static SnapGrid snap_grid_from_candidates (
+    List<weak Goo.CanvasItem> v_candidates,
+    List<weak Goo.CanvasItem> h_candidates,
+    List<Lib.Items.CanvasItem> selection,
+    int sensitivity
+    ) {
+        var grid = SnapGrid();
+        grid.v_snaps = new Gee.HashMap<int, SnapMeta>();
+        grid.h_snaps = new Gee.HashMap<int, SnapMeta>();
+
+        foreach (var cand in v_candidates) {
+          var candidate_item = cand as Lib.Items.CanvasItem;
+          if (candidate_item != null && selection.find (candidate_item) == null) {
+            populate_vertical_snaps (candidate_item, ref grid.v_snaps);
+          }
+        }
+
+        foreach (var cand in h_candidates) {
+          var candidate_item = cand as Lib.Items.CanvasItem;
+          if (candidate_item != null && selection.find (candidate_item) == null) {
+            populate_horizontal_snaps (candidate_item, ref grid.h_snaps);
+          }
+        }
+
+        return grid;
+    }
+
+    private static void populate_horizontal_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
+        int x_1 = (int)item.bounds.x1;
+        int x_2 = (int)item.bounds.x2;
+        int y_1 = (int)item.bounds.y1;
+        int y_2 = (int)item.bounds.y2;
+        int center_x = (int)((item.bounds.x2 - item.bounds.x1) / 2.0 + item.bounds.x1);
+        int center_y = (int)((item.bounds.y2 - item.bounds.y1) / 2.0 + item.bounds.y1);
+
+        add_to_map (x_1, y_1, y_2, center_y, -1, ref map);
+        add_to_map (x_2, y_1, y_2, center_y, 1, ref map);
+        add_to_map (center_x, center_y, center_y, center_y, 0, ref map);
+    }
+
+    private static void populate_vertical_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
+        int x_1 = (int)item.bounds.x1;
+        int x_2 = (int)item.bounds.x2;
+        int y_1 = (int)item.bounds.y1;
+        int y_2 = (int)item.bounds.y2;
+        int center_x = (int)((item.bounds.x2 - item.bounds.x1) / 2.0 + item.bounds.x1);
+        int center_y = (int)((item.bounds.y2 - item.bounds.y1) / 2.0 + item.bounds.y1);
+
+        add_to_map (y_1, x_1, x_2, center_x, -1, ref map);
+        add_to_map (y_2, x_1, x_2, center_x, 1, ref map);
+        add_to_map (center_y, center_x, center_x, center_x, 0, ref map);
+    }
+
+    private static void add_to_map (
+        int pos,
+        int n1,
+        int n2,
+        int n3,
+        int polarity,
+        ref Gee.HashMap<int, Utils.Snapping.SnapMeta> map
+    ) {
+        if (map.has_key (pos)) {
+            SnapMeta k = map.get (pos);
+            k.normals.add (n1);
+            k.normals.add (n2);
+            k.normals.add (n3);
+            k.polarity += polarity;
+        }
+        else {
+            var v = new SnapMeta ();
+            v.normals = new Gee.HashSet<int> ();
+            v.normals.add (n1);
+            v.normals.add (n2);
+            v.normals.add (n3);
+            v.polarity = polarity;
+            map.set (pos, v);
+        }
+    }
+
+    private static SnapMatchData defaultMatchData() {
+        var matches = SnapMatchData();
+        matches.v_data.type = MatchType.NONE;
+        matches.v_data.snap_position = 0;
+        matches.v_data.polarity_offset = 0;
+        matches.v_data.reference_position = 0;
+        matches.v_data.exact_matches = new Gee.HashMap<int, int> ();
+
+        matches.h_data.type = MatchType.NONE;
+        matches.h_data.snap_position = 0;
+        matches.h_data.polarity_offset = 0;
+        matches.h_data.reference_position = 0;
+        matches.h_data.exact_matches = new Gee.HashMap<int, int> ();
+        return matches;
+    }
+
+}

--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -19,6 +19,7 @@
 * Authored by: Martin "mbfraga" Fraga <mbfraga@gmail.com>
 */
 
+/// Utility providing snap functionality between objects.
 public class Akira.Utils.Snapping : Object {
     private const double SENSITIVITY = 4.0;
 
@@ -81,12 +82,13 @@ public class Akira.Utils.Snapping : Object {
         SnapMatch v_data;
     }
 
+    /// Returns a sensitivity adjusted to the given canvas scale
     public static double adjusted_sensitivity (double canvas_scale) {
         // Limit the sensitivity. This seems like a sensible default for now
         return double.max (SENSITIVITY / 2.0, SENSITIVITY / canvas_scale);
     }
 
-
+    // Generates a snap grid from a canvas.
     public static SnapGrid snap_grid_from_canvas (
         Goo.Canvas canvas,
         List<Lib.Items.CanvasItem> selection,
@@ -116,6 +118,7 @@ public class Akira.Utils.Snapping : Object {
         return snap_grid_from_candidates (vertical_candidates, horizontal_candidates, selection);
     }
 
+    // Calculate snaps inside a grid that match the selection input
     public static SnapMatchData generate_snap_matches (
         SnapGrid grid,
         List<Lib.Items.CanvasItem> selection,
@@ -137,6 +140,7 @@ public class Akira.Utils.Snapping : Object {
         return matches;
     }
 
+    // Matches in one direction (vertical / horizontal)
     private static void populate_snap_matches_from_list (
         Gee.HashMap<int, SnapMeta> target_snap_list,
         Gee.HashMap<int, SnapMeta> grid_snap_list,
@@ -203,6 +207,7 @@ public class Akira.Utils.Snapping : Object {
         return grid;
     }
 
+    /// Populates the horizontal snaps of an item
     private static void populate_horizontal_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
         int x_1 = (int)item.bounds.x1;
         int x_2 = (int)item.bounds.x2;
@@ -216,6 +221,7 @@ public class Akira.Utils.Snapping : Object {
         add_to_map (center_x, center_y, center_y, center_y, 0, ref map);
     }
 
+    /// Populates the vertical snaps of an item
     private static void populate_vertical_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
         int x_1 = (int)item.bounds.x1;
         int x_2 = (int)item.bounds.x2;
@@ -229,6 +235,7 @@ public class Akira.Utils.Snapping : Object {
         add_to_map (center_y, center_x, center_x, center_x, 0, ref map);
     }
 
+    /// Simple method to add information to a snap list
     private static void add_to_map (
         int pos,
         int n1,
@@ -255,6 +262,7 @@ public class Akira.Utils.Snapping : Object {
         }
     }
 
+    // Generate a default match data
     private static SnapMatchData default_match_data () {
         var matches = SnapMatchData ();
         matches.v_data.type = MatchType.NONE;

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,6 +36,7 @@ sources = files(
     'Utils/Color.vala',
     'Utils/Image.vala',
     'Utils/ColorPicker.vala',
+    'Utils/Snapping.vala',
 
     'Layouts/HeaderBar.vala',
     'Layouts/LeftSideBar.vala',
@@ -106,6 +107,7 @@ sources = files(
     'Lib/Managers/ItemsManager.vala',
     'Lib/Managers/NobManager.vala',
     'Lib/Managers/SelectedBoundManager.vala',
+    'Lib/Managers/SnapManager.vala',
 
     'Lib/Selection/Nob.vala',
 


### PR DESCRIPTION
Implements snapping between objects. Lays the groundwork for a future, more complete implementation.

Notable features:
* Stateless implementation for snapping.
* Snapping on object move
* First pass cosmetic implementation for guide lines and snap points (probably needs some reworking)

Notable missing features are: 
* Adding the snapping functionality to other transformations (resize). It should mostly require some hooking up of existing code
* Smarter generation of candidates, possibly only snapping to artboard items if the item is within an artboard. The code for this is mostly there, we mainly need a method to generate the list of items from an artboard.