### PR TITLE
Fix hover effect line width not adapting to canvas zoom

### DIFF
--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -38,6 +38,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
     }
 
     construct {
+        canvas.window.event_bus.zoom.connect (on_canvas_zoom);
         canvas.window.event_bus.hover_over_layer.connect (on_layer_hovered);
     }
 
@@ -196,5 +197,15 @@ public class Akira.Lib.Managers.HoverManager : Object {
             canvas.window.event_bus.request_change_cursor (selected_cursor);
             current_hovering_nob = grabbed_id;
         }
+    }
+
+    private void on_canvas_zoom () {
+        // Interrupt if we don't have any hover effect currently visible.
+        if (hover_effect == null) {
+            return;
+        }
+
+        // Update the line width of the hover effect based on the canvas scale.
+        hover_effect.set ("line-width", LINE_WIDTH / canvas.current_scale);
     }
 }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Make the hover effect border width properly scale based on the Canvas zoom.

## Steps to Test
- Hover over an item
- Zoom in and out

## Screenshots 
![hover-effect](https://user-images.githubusercontent.com/2527103/110071765-771a1680-7d31-11eb-8a65-4288e5aa8daf.gif)

