### PR TITLE
Filter candidates and specialize artboard snaps

### DIFF
--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -369,7 +369,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         // Make adjustment basted on snaps.
         // Double the sensitivity to allow for reuse of grid after snap.
         var sensitivity = Utils.Snapping.adjusted_sensitivity (canvas.current_scale);
-        var snap_grid = Utils.Snapping.snap_grid_from_canvas (canvas, selected_items, sensitivity);
+        var snap_grid = Utils.Snapping.generate_best_snap_grid (canvas, selected_items, sensitivity);
 
         if (!snap_grid.is_empty ()) {
             int snap_offset_x = 0;
@@ -406,7 +406,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     private void update_grid_decorators (bool force) {
         if (force || snap_manager.is_active ()) {
             var sensitivity = Utils.Snapping.adjusted_sensitivity (canvas.current_scale);
-            var snap_grid = Utils.Snapping.snap_grid_from_canvas (canvas, selected_items, sensitivity);
+            var snap_grid = Utils.Snapping.generate_best_snap_grid (canvas, selected_items, sensitivity);
             var matches = Utils.Snapping.generate_snap_matches (snap_grid, selected_items, sensitivity);
             snap_manager.populate_decorators_from_data (matches, snap_grid);
         }


### PR DESCRIPTION

<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
Candidates are now filtered with regards to artboards.

Properly generate artboard snaps.

## Steps to Test

* Moving items inside of an artboard should snap to the artboard snaps and to any other items inside the artboard
* Moving rectangles not in an artboard should not snap to objects inside of an artboard

## This PR fixes/implements the following **bugs/features**:
   * Canvas items will not include artboard contents as candidates.
   * Artboard items will only include contents as candidates.

