### PR TITLE
Add transform boundaries

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -504,8 +504,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         if (show) {
             ghost = new Goo.CanvasRect (
                 null,
-                item.transform.x, item.transform.y,
-                item.transform.x2 - item.transform.x, item.transform.y2 - item.transform.y,
+                item.transform.x1, item.transform.y1,
+                item.transform.x2 - item.transform.x1, item.transform.y2 - item.transform.y1,
                 "line-width", 1.0 / current_scale,
                 "stroke-color", "#41c9fd",
                 null

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -504,8 +504,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         if (show) {
             ghost = new Goo.CanvasRect (
                 null,
-                item.bounds.x1, item.bounds.y1,
-                item.bounds.x2 - item.bounds.x1, item.bounds.y2 - item.bounds.y1,
+                item.transform.x, item.transform.y,
+                item.transform.x2 - item.transform.x, item.transform.y2 - item.transform.y,
                 "line-width", 1.0 / current_scale,
                 "stroke-color", "#41c9fd",
                 null

--- a/src/Lib/Components/Transform.vala
+++ b/src/Lib/Components/Transform.vala
@@ -48,6 +48,26 @@ public class Akira.Lib.Components.Transform : Component {
         }
     }
 
+    public double x2 {
+        get {
+            double item_x2 = item.bounds.x2 - get_border ();
+
+            if (item.artboard != null) {
+                double temp_y = 0.0;
+                item.canvas.convert_to_item_space (item.artboard, ref item_x2, ref temp_y);
+            }
+
+            // If the item is an artboard we need to get the bounds of the background since
+            // the artboard group will have its bounds changing based on the location of the
+            // child items.
+            if (item is Items.CanvasArtboard) {
+                item_x2 = ((Items.CanvasArtboard) item).background.bounds.x2;
+            }
+
+            return item_x2;
+        }
+    }
+
     private double _y;
     public double y {
         get {
@@ -70,6 +90,26 @@ public class Akira.Lib.Components.Transform : Component {
         set {
             _y = value;
             ((Lib.Canvas) item.canvas).window.event_bus.item_value_changed ();
+        }
+    }
+
+    public double y2 {
+        get {
+            double item_y2 = item.bounds.y2 - get_border ();
+
+            if (item.artboard != null) {
+                double temp_x = 0.0;
+                item.canvas.convert_to_item_space (item.artboard, ref temp_x, ref item_y2);
+            }
+
+            // If the item is an artboard we need to get the bounds of the background since
+            // the artboard group will have its bounds changing based on the location of the
+            // child items.
+            if (item is Items.CanvasArtboard) {
+                item_y2 = ((Items.CanvasArtboard) item).background.bounds.y2;
+            }
+
+            return item_y2;
         }
     }
 

--- a/src/Lib/Components/Transform.vala
+++ b/src/Lib/Components/Transform.vala
@@ -48,14 +48,24 @@ public class Akira.Lib.Components.Transform : Component {
         }
     }
 
+    public double x1 {
+        get {
+            double item_x1 = item.bounds.x1 + get_border ();
+
+            // If the item is an artboard we need to get the bounds of the background since
+            // the artboard group will have its bounds changing based on the location of the
+            // child items.
+            if (item is Items.CanvasArtboard) {
+                item_x1 = ((Items.CanvasArtboard) item).background.bounds.x1;
+            }
+
+            return item_x1;
+        }
+    }
+
     public double x2 {
         get {
             double item_x2 = item.bounds.x2 - get_border ();
-
-            if (item.artboard != null) {
-                double temp_y = 0.0;
-                item.canvas.convert_to_item_space (item.artboard, ref item_x2, ref temp_y);
-            }
 
             // If the item is an artboard we need to get the bounds of the background since
             // the artboard group will have its bounds changing based on the location of the
@@ -93,14 +103,24 @@ public class Akira.Lib.Components.Transform : Component {
         }
     }
 
+    public double y1 {
+        get {
+            double item_y1 = item.bounds.y1 + get_border ();
+
+            // If the item is an artboard we need to get the bounds of the background since
+            // the artboard group will have its bounds changing based on the location of the
+            // child items.
+            if (item is Items.CanvasArtboard) {
+                item_y1 = ((Items.CanvasArtboard) item).background.bounds.y1;
+            }
+
+            return item_y1;
+        }
+    }
+
     public double y2 {
         get {
             double item_y2 = item.bounds.y2 - get_border ();
-
-            if (item.artboard != null) {
-                double temp_x = 0.0;
-                item.canvas.convert_to_item_space (item.artboard, ref temp_x, ref item_y2);
-            }
 
             // If the item is an artboard we need to get the bounds of the background since
             // the artboard group will have its bounds changing based on the location of the

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -406,6 +406,7 @@ public class Akira.Lib.Managers.ExportManager : Object {
         // If the item is null it means we're dealing with a custom area and we
         // don't have the bounds manager.
         if (item != null) {
+            // Use the item's bounds to include the border.
             double x1 = item.bounds.x1;
             double x2 = item.bounds.x2;
             double y1 = item.bounds.y1;

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -310,7 +310,6 @@ public class Akira.Lib.Managers.ExportManager : Object {
 
         // Loop through all the currently selected elements.
         for (var i = 0; i < canvas.selected_bound_manager.selected_items.length (); i++) {
-            var label_height = 0.0;
             var item = canvas.selected_bound_manager.selected_items.nth_data (i);
             var name = _("Untitled %i").printf (i);
 
@@ -325,24 +324,33 @@ public class Akira.Lib.Managers.ExportManager : Object {
             // If the item is an artboard, account for the label's height.
             if (item is Akira.Lib.Items.CanvasArtboard) {
                 var artboard = item as Akira.Lib.Items.CanvasArtboard;
-                // label_height = artboard.get_label_height ();
                 name = artboard.name.name;
             }
 
             // Hide the ghost item.
-            // item.bounds_manager.hide ();
+            ((Lib.Canvas) item.canvas).toggle_item_ghost (false);
 
-            // Account for items inside or outside artboards.
+            // Always use the item's bounds so we can include borders.
             double x1 = item.bounds.x1;
             double x2 = item.bounds.x2;
             double y1 = item.bounds.y1;
             double y2 = item.bounds.y2;
 
+            // If the item is an artboard, use the bounds of the background item
+            // since the CanvasGroup bounds will grow based on the position of its children.
+            if (item is Items.CanvasArtboard) {
+                var item_artboard = item as Items.CanvasArtboard;
+                x1 = item_artboard.background.bounds.x1;
+                x2 = item_artboard.background.bounds.x2;
+                y1 = item_artboard.background.bounds.y1;
+                y2 = item_artboard.background.bounds.y2;
+            }
+
             // Create the rendered image with Cairo.
             surface = new Cairo.ImageSurface (
                 format,
                 (int) Math.round (x2 - x1),
-                (int) Math.round (y2 - y1 - label_height)
+                (int) Math.round (y2 - y1)
             );
             context = new Cairo.Context (surface);
 
@@ -352,12 +360,13 @@ public class Akira.Lib.Managers.ExportManager : Object {
                 context.rectangle (
                     0, 0,
                     (int) Math.round (x2 - x1),
-                    (int) Math.round (y2 - y1 - label_height));
+                    (int) Math.round (y2 - y1)
+                );
                 context.fill ();
             }
 
             // Move to the currently selected item.
-            context.translate (-x1, -y1 - label_height);
+            context.translate (-x1, -y1);
 
             // Render the selected item.
             canvas.render (context, null, canvas.current_scale);
@@ -391,17 +400,10 @@ public class Akira.Lib.Managers.ExportManager : Object {
 
     public Gdk.Pixbuf rescale_image (Gdk.Pixbuf pixbuf, Lib.Items.CanvasItem? item = null) {
         Gdk.Pixbuf scaled_image;
-        var label_height = 0.0;
-
-        // If the item is an artboard, account for the label's height.
-        // if (item != null && item is Lib.Items.CanvasArtboard) {
-            // var artboard = item as Lib.Items.CanvasArtboard;
-            // label_height = artboard.get_label_height ();
-        // }
 
         double width, height;
 
-        // If the item is null it mean we're dealing with a custom area and we
+        // If the item is null it means we're dealing with a custom area and we
         // don't have the bounds manager.
         if (item != null) {
             double x1 = item.bounds.x1;
@@ -409,8 +411,18 @@ public class Akira.Lib.Managers.ExportManager : Object {
             double y1 = item.bounds.y1;
             double y2 = item.bounds.y2;
 
+            // If the item is an artboard, use the bounds of the background item
+            // since the CanvasGroup bounds will grow based on the position of its children.
+            if (item is Items.CanvasArtboard) {
+                var item_artboard = item as Items.CanvasArtboard;
+                x1 = item_artboard.background.bounds.x1;
+                x2 = item_artboard.background.bounds.x2;
+                y1 = item_artboard.background.bounds.y1;
+                y2 = item_artboard.background.bounds.y2;
+            }
+
             width = x2 - x1;
-            height = y2 - y1 - label_height;
+            height = y2 - y1;
         } else {
             width = area.width;
             height = area.height;

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -106,10 +106,10 @@ public class Akira.Lib.Managers.NobManager : Object {
         double bb_left = 1e6, bb_top = 1e6, bb_right = 0, bb_bottom = 0;
 
         foreach (var item in selected_items) {
-            bb_left = double.min (bb_left, item.bounds.x1);
-            bb_top = double.min (bb_top, item.bounds.y1);
-            bb_right = double.max (bb_right, item.bounds.x2);
-            bb_bottom = double.max (bb_bottom, item.bounds.y2);
+            bb_left = double.min (bb_left, item.transform.x1);
+            bb_top = double.min (bb_top, item.transform.y1);
+            bb_right = double.max (bb_right, item.transform.x2);
+            bb_bottom = double.max (bb_bottom, item.transform.y2);
         }
 
         select_bb = Goo.CanvasBounds () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -121,7 +121,6 @@ public class Akira.Services.ActionManager : Object {
         action_accelerators.set (ACTION_LOAD_FIRST, "<Control><Alt>1");
         action_accelerators.set (ACTION_LOAD_SECOND, "<Control><Alt>2");
         action_accelerators.set (ACTION_LOAD_THIRD, "<Control><Alt>3");
-        action_accelerators.set (ACTION_TOGGLE_PIXEL_GRID, "<Shift>Tab");
         action_accelerators.set (ACTION_PRESENTATION, "<Control>period");
         action_accelerators.set (ACTION_PREFERENCES, "<Control>comma");
         action_accelerators.set (ACTION_EXPORT_SELECTION, "<Control><Alt>e");
@@ -149,6 +148,7 @@ public class Akira.Services.ActionManager : Object {
         typing_accelerators.set (ACTION_IMAGE_TOOL, "i");
         typing_accelerators.set (ACTION_DELETE, "Delete");
         typing_accelerators.set (ACTION_DELETE, "BackSpace");
+        typing_accelerators.set (ACTION_TOGGLE_PIXEL_GRID, "<Shift>Tab");
     }
 
     construct {

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -54,8 +54,8 @@ public class Akira.Utils.AffineTransform : Object {
 
         double item_width = item.size.width;
         double item_height = item.size.height;
-        double item_x = item.bounds.x1;
-        double item_y = item.bounds.y1;
+        double item_x = item.transform.x1;
+        double item_y = item.transform.y1;
         canvas.convert_to_item_space (item, ref item_x, ref item_y);
 
         double inc_width = 0;
@@ -343,8 +343,8 @@ public class Akira.Utils.AffineTransform : Object {
             canvas.convert_to_item_space (item.artboard, ref x, ref y);
             canvas.convert_to_item_space (item.artboard, ref initial_x, ref initial_y);
 
-            diff_x = item.bounds.x1 - item.artboard.bounds.x1;
-            diff_y = item.bounds.y1 - item.artboard.bounds.y1;
+            diff_x = item.transform.x1 - item.artboard.transform.x1;
+            diff_y = item.transform.y1 - item.artboard.transform.y1;
 
             x -= diff_x;
             y -= diff_y;

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -226,6 +226,11 @@ public class Akira.Utils.AffineTransform : Object {
         item.translate (inc_x, inc_y);
         // Update the item size.
         set_size (item, inc_width, inc_height);
+
+        // If the item is an Artboard, move the label with it.
+        if (item is Lib.Items.CanvasArtboard) {
+            ((Lib.Items.CanvasArtboard) item).label.translate (inc_x, inc_y);
+        }
     }
 
     // Width size constraints.

--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -123,18 +123,18 @@ public class Akira.Utils.Snapping : Object {
         Goo.CanvasBounds horizontal_filter = {0, 0, 0, 0};
 
         foreach (var item in selection) {
-          horizontal_filter.x1 = item.bounds.x1 - sensitivity;
-          horizontal_filter.x2 = item.bounds.x2 + sensitivity;
-          horizontal_filter.y1 = canvas.y1;
-          horizontal_filter.y2 = canvas.y2;
+            horizontal_filter.x1 = item.bounds.x1 - sensitivity;
+            horizontal_filter.x2 = item.bounds.x2 + sensitivity;
+            horizontal_filter.y1 = canvas.y1;
+            horizontal_filter.y2 = canvas.y2;
 
-          vertical_filter.x1 = canvas.x1;
-          vertical_filter.x2 = canvas.x2;
-          vertical_filter.y1 = item.bounds.y1 - sensitivity;
-          vertical_filter.y2 = item.bounds.y2 + sensitivity;
+            vertical_filter.x1 = canvas.x1;
+            vertical_filter.x2 = canvas.x2;
+            vertical_filter.y1 = item.bounds.y1 - sensitivity;
+            vertical_filter.y2 = item.bounds.y2 + sensitivity;
 
-          vertical_candidates.concat (canvas.get_items_in_area (vertical_filter, true, true, false));
-          horizontal_candidates.concat (canvas.get_items_in_area (horizontal_filter, true, true, false));
+            vertical_candidates.concat (canvas.get_items_in_area (vertical_filter, true, true, false));
+            horizontal_candidates.concat (canvas.get_items_in_area (horizontal_filter, true, true, false));
         }
 
         return snap_grid_from_candidates (vertical_candidates, horizontal_candidates, selection);

--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -123,15 +123,15 @@ public class Akira.Utils.Snapping : Object {
         Goo.CanvasBounds horizontal_filter = {0, 0, 0, 0};
 
         foreach (var item in selection) {
-            horizontal_filter.x1 = item.bounds.x1 - sensitivity;
-            horizontal_filter.x2 = item.bounds.x2 + sensitivity;
+            horizontal_filter.x1 = item.transform.x1 - sensitivity;
+            horizontal_filter.x2 = item.transform.x2 + sensitivity;
             horizontal_filter.y1 = canvas.y1;
             horizontal_filter.y2 = canvas.y2;
 
             vertical_filter.x1 = canvas.x1;
             vertical_filter.x2 = canvas.x2;
-            vertical_filter.y1 = item.bounds.y1 - sensitivity;
-            vertical_filter.y2 = item.bounds.y2 + sensitivity;
+            vertical_filter.y1 = item.transform.y1 - sensitivity;
+            vertical_filter.y2 = item.transform.y2 + sensitivity;
 
             vertical_candidates.concat (canvas.get_items_in_area (vertical_filter, true, true, false));
             horizontal_candidates.concat (canvas.get_items_in_area (horizontal_filter, true, true, false));
@@ -239,12 +239,12 @@ public class Akira.Utils.Snapping : Object {
      * Populates the horizontal snaps of an item.
      */
     private static void populate_horizontal_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
-        int x_1 = (int) item.bounds.x1;
-        int x_2 = (int) item.bounds.x2;
-        int y_1 = (int) item.bounds.y1;
-        int y_2 = (int) item.bounds.y2;
-        int center_x = (int) (Math.ceil ((item.bounds.x2 - item.bounds.x1) / 2.0) + item.bounds.x1);
-        int center_y = (int) (Math.ceil ((item.bounds.y2 - item.bounds.y1) / 2.0) + item.bounds.y1);
+        int x_1 = (int) item.transform.x1;
+        int x_2 = (int) item.transform.x2;
+        int y_1 = (int) item.transform.y1;
+        int y_2 = (int) item.transform.y2;
+        int center_x = (int) (Math.ceil ((item.transform.x2 - item.transform.x1) / 2.0) + item.transform.x1);
+        int center_y = (int) (Math.ceil ((item.transform.y2 - item.transform.y1) / 2.0) + item.transform.y1);
 
         add_to_map (x_1, y_1, y_2, center_y, -1, ref map);
         add_to_map (x_2, y_1, y_2, center_y, 1, ref map);
@@ -255,12 +255,12 @@ public class Akira.Utils.Snapping : Object {
      * Populates the vertical snaps of an item.
      */
     private static void populate_vertical_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
-        int x_1 = (int) item.bounds.x1;
-        int x_2 = (int) item.bounds.x2;
-        int y_1 = (int) item.bounds.y1;
-        int y_2 = (int) item.bounds.y2;
-        int center_x = (int) (Math.ceil ((item.bounds.x2 - item.bounds.x1) / 2.0) + item.bounds.x1);
-        int center_y = (int) (Math.ceil ((item.bounds.y2 - item.bounds.y1) / 2.0) + item.bounds.y1);
+        int x_1 = (int) item.transform.x1;
+        int x_2 = (int) item.transform.x2;
+        int y_1 = (int) item.transform.y1;
+        int y_2 = (int) item.transform.y2;
+        int center_x = (int) (Math.ceil ((item.transform.x2 - item.transform.x1) / 2.0) + item.transform.x1);
+        int center_y = (int) (Math.ceil ((item.transform.y2 - item.transform.y1) / 2.0) + item.transform.y1);
 
         add_to_map (y_1, x_1, x_2, center_x, -1, ref map);
         add_to_map (y_2, x_1, x_2, center_x, 1, ref map);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implement the `x1, x2, y1, y2` attributes to the `Transform` component, which are used to return the correct boundaries of an item excluding the stroke width or masked child items.

## Steps to Test
- Create multiple items and Artboards with items partially outside.
- Move the items around and see how the snaps appear in the proper position.
- Change the stroke width to confirm that the snaps ignore it. 

## This PR fixes/implements the following **bugs/features**:
- Implement new `Transform` coordiantes.
- Keep the usage of bounds for the export selection in order to include borders during export.
- Fix the snapping for Artboards with items partially outside the Artboard's boundaries.
- Move the Artboard's label when a scale event affects the origin coordinates.
