### PR TITLE
Include artboards in snap grid generation

### DIFF
--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -161,8 +161,8 @@ public class Akira.Utils.Snapping : Object {
             vertical_filter.y1 = item.transform.y1 - sensitivity;
             vertical_filter.y2 = item.transform.y2 + sensitivity;
 
-            vertical_candidates.concat (canvas.get_items_in_area (vertical_filter, true, true, false));
-            horizontal_candidates.concat (canvas.get_items_in_area (horizontal_filter, true, true, false));
+            vertical_candidates.concat (canvas.get_items_in_area (vertical_filter, true, true, true));
+            horizontal_candidates.concat (canvas.get_items_in_area (horizontal_filter, true, true, true));
         }
 
         return snap_grid_from_canvas_candidates (vertical_candidates, horizontal_candidates, selection, false);
@@ -180,10 +180,8 @@ public class Akira.Utils.Snapping : Object {
         List<weak Goo.CanvasItem> candidates = null;
 
         foreach (var item in selection) {
-          candidates.concat (canvas.get_items_in_area (artboard.background.bounds, true, true, false));
+          candidates.concat (canvas.get_items_in_area (artboard.background.bounds, true, true, true));
         }
-
-        candidates.append (artboard);
 
         return snap_grid_from_artboard_candidates (candidates, selection, artboard);
     }


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
Artboards were not being included in snap grid generation, specially for free items

## Steps to Test
Create a an artboards an a free item. Try to snap item to artboard.

## This PR fixes/implements the following **bugs/features**:
Artboards are now included correctly in snap grid generation.
<!--- If there was an issue that this PR targets, adding it here will auto close it --> 

- Fixes #<!--- Replace me with Issue number -->
- Fixes #<!--- Replace me with Issue number -->
