### PR TITLE
Add color customization of Snapping guides

### DIFF
--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -72,6 +72,12 @@
             <description>The default color of the pixel grid.</description>
         </key>
 
+        <key name="snaps-color" type="s">
+            <default>'#ff0000'</default>
+            <summary>Default Snaps Color.</summary>
+            <description>The default color of the snapping guides.</description>
+        </key>
+
         <key name="fill-color" type="s">
             <default>'#CCCCCC'</default>
             <summary>Default Shape Color.</summary>

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -27,6 +27,7 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
     private Gtk.Switch symbolic_switch;
     private Gtk.Switch border_switch;
     private Gtk.ColorButton grid_color;
+    private Gtk.ColorButton snaps_color;
     private Gtk.ColorButton fill_color;
     private Gtk.ColorButton border_color;
     private Gtk.SpinButton border_size;
@@ -123,6 +124,7 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         grid.column_spacing = 12;
         grid.column_homogeneous = true;
 
+        // Pixel grid.
         var grid_rgba = Gdk.RGBA ();
         grid_rgba.parse (settings.grid_color);
 
@@ -153,6 +155,39 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
 
             settings.grid_color = rgba_str;
             window.event_bus.update_pixel_grid ();
+        });
+
+        // Snapping guides.
+        var snaps_rgba = Gdk.RGBA ();
+        snaps_rgba.parse (settings.snaps_color);
+
+        grid.attach (new SettingsHeader (_("Snapping Guides")), 0, 3, 2, 1);
+
+        var snaps_description = new Gtk.Label (_("Define the default color for the Snapping Guides."));
+        snaps_description.halign = Gtk.Align.START;
+        snaps_description.margin_bottom = 10;
+        grid.attach (snaps_description, 0, 4, 2, 1);
+
+        grid.attach (new SettingsLabel (_("Snapping Guides Color:")), 0, 5, 1, 1);
+        snaps_color = new Gtk.ColorButton.with_rgba (snaps_rgba);
+        snaps_color.halign = Gtk.Align.START;
+        grid.attach (snaps_color, 1, 5, 1, 1);
+
+        snaps_color.color_set.connect (() => {
+            var rgba = snaps_color.get_rgba ();
+
+            // Gdk.RGBA uses rgb() if alpha is 1.
+            string rgba_str = "rgba(%d,%d,%d,%d)".printf (
+                (int) (rgba.red * 255),
+                (int) (rgba.green * 255),
+                (int) (rgba.blue * 255),
+                (int) (rgba.alpha)
+            );
+
+            debug ("pixel snaps color: %s", rgba_str);
+
+            settings.snaps_color = rgba_str;
+            window.event_bus.update_snaps_color ();
         });
 
         return grid;

--- a/src/Lib/Managers/SnapManager.vala
+++ b/src/Lib/Managers/SnapManager.vala
@@ -23,7 +23,6 @@
  * Manages Goo.CanvasItem decorators used to display snap lines and dots.
  */
 public class Akira.Lib.Managers.SnapManager : Object {
-    private const string STROKE_COLOR = "#ff0000";
     private const double LINE_WIDTH = 0.5;
     private const double DOT_RADIUS = 2.0;
 
@@ -47,6 +46,8 @@ public class Akira.Lib.Managers.SnapManager : Object {
         v_decorator_lines = new Gee.ArrayList<Goo.CanvasItemSimple> ();
         h_decorator_lines = new Gee.ArrayList<Goo.CanvasItemSimple> ();
         decorator_dots = new Gee.ArrayList<Goo.CanvasItemSimple> ();
+
+        canvas.window.event_bus.update_snaps_color.connect (on_update_snaps_color);
     }
 
     /**
@@ -127,7 +128,7 @@ public class Akira.Lib.Managers.SnapManager : Object {
                 canvas.x1, actual_pos,
                 canvas.x2, actual_pos,
                 "line-width", lw,
-                "stroke-color", STROKE_COLOR,
+                "stroke-color", settings.snaps_color,
                 null
             );
 
@@ -167,7 +168,7 @@ public class Akira.Lib.Managers.SnapManager : Object {
                 actual_pos, canvas.y1,
                 actual_pos, canvas.y2,
                 "line-width", lw,
-                "stroke-color", STROKE_COLOR,
+                "stroke-color", settings.snaps_color,
                 null
             );
 
@@ -201,7 +202,7 @@ public class Akira.Lib.Managers.SnapManager : Object {
             x, y,
             dot_radius, dot_radius,
             "line-width", 0.0,
-            "fill-color", STROKE_COLOR,
+            "fill-color", settings.snaps_color,
             null
         );
 
@@ -211,5 +212,25 @@ public class Akira.Lib.Managers.SnapManager : Object {
         tmp.set ("parent", root);
         tmp.raise (null);
         decorator_dots.add (tmp);
+    }
+
+    /**
+     * Loop through all the existing guides and update the color.
+     */
+    private void on_update_snaps_color () {
+        // Points.
+        foreach (var dot in decorator_dots) {
+            dot.set ("fill-color", settings.snaps_color);
+        }
+
+        // Horizontal lines.
+        foreach (var line in h_decorator_lines) {
+            line.set ("stroke-color", settings.snaps_color);
+        }
+
+        // Vertical lines.
+        foreach (var line in v_decorator_lines) {
+            line.set ("stroke-color", settings.snaps_color);
+        }
     }
 }

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -50,6 +50,7 @@ public class Akira.Services.EventBus : Object {
     public signal void show_select_effect ();
     public signal void toggle_pixel_grid ();
     public signal void update_pixel_grid ();
+    public signal void update_snaps_color ();
 
     // Options panel signals.
     public signal void align_items (string align_action);

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -70,6 +70,10 @@ public class Akira.Services.Settings : GLib.Settings {
         owned get { return get_string ("grid-color"); }
         set { set_string ("grid-color", value); }
     }
+    public string snaps_color {
+        owned get { return get_string ("snaps-color"); }
+        set { set_string ("snaps-color", value); }
+    }
 
     // Default shape settings.
     public string fill_color {


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Add the ability to customize the color of the snapping guides.

## Steps to Test
- Create many items
- Move them around and look at the snapping guides default red color.
- Open the settings and in the `Canvas` tab change the snapping guides color.
- Move the items on the Canvas and confirm the new color was applied.

## Screenshots 
![snap-color](https://user-images.githubusercontent.com/2527103/110279743-77631d80-7f8e-11eb-8ef0-4349c8f1c820.gif)
