### PR TITLE
Fix sorting order of loading items

### DIFF
--- a/src/FileFormat/JsonLoader.vala
+++ b/src/FileFormat/JsonLoader.vala
@@ -42,7 +42,10 @@ public class Akira.FileFormat.JsonLoader : Object {
         // Load saved Artboards.
         if (obj.get_member ("artboards") != null) {
             Json.Array artboards = obj.get_member ("artboards").get_array ();
-            foreach (unowned Json.Node node in artboards.get_elements ()) {
+            var artboards_list = artboards.get_elements ();
+            artboards_list.reverse ();
+
+            foreach (unowned Json.Node node in artboards_list) {
                 load_item (node.get_object (), "artboard");
             }
         }
@@ -50,7 +53,10 @@ public class Akira.FileFormat.JsonLoader : Object {
         // Load saved Items.
         if (obj.get_member ("items") != null) {
             Json.Array items = obj.get_member ("items").get_array ();
-            foreach (unowned Json.Node node in items.get_elements ()) {
+            var items_list = items.get_elements ();
+            items_list.reverse ();
+
+            foreach (unowned Json.Node node in items_list) {
                 load_item (node.get_object (), "item");
             }
         }

--- a/src/Lib/Components/Size.vala
+++ b/src/Lib/Components/Size.vala
@@ -50,8 +50,8 @@ public class Akira.Lib.Components.Size : Component {
                 canvas.window.event_bus.item_value_changed ();
 
                 // If the value wasn't changed automatically by the auto resize,
-                // and the image is selected and not loaded, recalculate the pixbuf quality.
-                if (item is Items.CanvasImage && item.layer.selected && !canvas.holding && !item.is_loaded) {
+                // and the image is selected, recalculate the pixbuf quality.
+                if (item is Items.CanvasImage && item.layer.selected && !canvas.holding) {
                     canvas.window.event_bus.detect_image_size_change ();
                 }
             }
@@ -79,8 +79,8 @@ public class Akira.Lib.Components.Size : Component {
                 canvas.window.event_bus.item_value_changed ();
 
                 // If the value wasn't changed automatically by the auto resize,
-                // and the image is selected and not loaded, recalculate the pixbuf quality.
-                if (item is Items.CanvasImage && item.layer.selected && !canvas.holding && !item.is_loaded) {
+                // and the image is selected, recalculate the pixbuf quality.
+                if (item is Items.CanvasImage && item.layer.selected && !canvas.holding) {
                     canvas.window.event_bus.detect_image_size_change ();
                 }
             }

--- a/src/Lib/Items/CanvasArtboard.vala
+++ b/src/Lib/Items/CanvasArtboard.vala
@@ -29,8 +29,6 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
 
    public Items.CanvasArtboard? artboard { get; set; }
 
-   public bool is_loaded { get; set; }
-
    // Override the list type from the CanvasGroup.
    public new Akira.Models.ListModel<Lib.Items.CanvasItem> items;
 
@@ -50,9 +48,6 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       init_position (this, _x, _y);
 
       create_background ();
-
-      // Add extra attributes.
-      is_loaded = _is_loaded;
 
       // Add the newly created item to the Canvas.
       parent.add_child (this, -1);

--- a/src/Lib/Items/CanvasEllipse.vala
+++ b/src/Lib/Items/CanvasEllipse.vala
@@ -29,8 +29,6 @@ public class Akira.Lib.Items.CanvasEllipse : Goo.CanvasEllipse, Akira.Lib.Items.
 
     public Items.CanvasArtboard? artboard { get; set; }
 
-    public bool is_loaded { get; set; }
-
     public CanvasEllipse (
         double _x,
         double _y,
@@ -38,8 +36,7 @@ public class Akira.Lib.Items.CanvasEllipse : Goo.CanvasEllipse, Akira.Lib.Items.
         Gdk.RGBA border_color,
         Gdk.RGBA fill_color,
         Goo.CanvasItem? _parent,
-        Items.CanvasArtboard? _artboard,
-        bool _loaded
+        Items.CanvasArtboard? _artboard
     ) {
         parent = _artboard != null ? _artboard : _parent;
         artboard = _artboard;
@@ -50,9 +47,6 @@ public class Akira.Lib.Items.CanvasEllipse : Goo.CanvasEllipse, Akira.Lib.Items.
         // The CanvasEllipse needs a starting radius at least half of the initial width.
         radius_x = radius_y = 0.5;
         init_position (this, _x, _y);
-
-        // Add extra attributes.
-        is_loaded = _is_loaded;
 
         // Add the newly created item to the Canvas or Artboard.
         parent.add_child (this, -1);

--- a/src/Lib/Items/CanvasImage.vala
+++ b/src/Lib/Items/CanvasImage.vala
@@ -29,8 +29,6 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
 
     public Items.CanvasArtboard? artboard { get; set; }
 
-    public bool is_loaded { get; set; }
-
     // CanvasImage unique attributes.
     public Lib.Managers.ImageManager manager { get; set; }
     private Gdk.Pixbuf original_pixbuf;
@@ -40,8 +38,7 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
         double _y,
         Lib.Managers.ImageManager _manager,
         Goo.CanvasItem? _parent,
-        Items.CanvasArtboard? _artboard,
-        bool _loaded = false
+        Items.CanvasArtboard? _artboard
     ) {
         parent = _artboard != null ? _artboard : _parent;
         artboard = _artboard;
@@ -54,9 +51,6 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
         width = height = 1;
         scale_to_fit = true;
         init_position (this, _x, _y);
-
-        // Add extra attributes.
-        is_loaded = _is_loaded;
 
         // Add the newly created item to the Canvas or Artboard.
         parent.add_child (this, -1);

--- a/src/Lib/Items/CanvasItem.vala
+++ b/src/Lib/Items/CanvasItem.vala
@@ -33,9 +33,6 @@ public interface Akira.Lib.Items.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasIt
     // Keep track of the parent artboard if the item belongs to one.
     public abstract Items.CanvasArtboard? artboard { get; set; }
 
-    // Check if an item was created or it was loaded for ordering purpose.
-    public abstract bool is_loaded { get; set; }
-
     /**
      * Find the component attached to the item by its GLib.Type.
      */
@@ -70,7 +67,7 @@ public interface Akira.Lib.Items.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasIt
      */
     public void check_add_to_artboard (Items.CanvasItem item) {
         if (item.artboard != null) {
-            item.artboard.items.add_item.begin (item, item.is_loaded);
+            item.artboard.items.add_item.begin (item);
         }
     }
 

--- a/src/Lib/Items/CanvasRect.vala
+++ b/src/Lib/Items/CanvasRect.vala
@@ -29,8 +29,6 @@ public class Akira.Lib.Items.CanvasRect : Goo.CanvasRect, Akira.Lib.Items.Canvas
 
     public Items.CanvasArtboard? artboard { get; set; }
 
-    public bool is_loaded { get; set; }
-
     public CanvasRect (
         double _x,
         double _y,
@@ -38,8 +36,7 @@ public class Akira.Lib.Items.CanvasRect : Goo.CanvasRect, Akira.Lib.Items.Canvas
         Gdk.RGBA border_color,
         Gdk.RGBA fill_color,
         Goo.CanvasItem? _parent,
-        Items.CanvasArtboard? _artboard,
-        bool _is_loaded
+        Items.CanvasArtboard? _artboard
     ) {
         parent = _artboard != null ? _artboard : _parent;
         artboard = _artboard;
@@ -49,9 +46,6 @@ public class Akira.Lib.Items.CanvasRect : Goo.CanvasRect, Akira.Lib.Items.Canvas
         width = height = 1;
         radius_x = radius_y = 0.0;
         init_position (this, _x, _y);
-
-        // Add extra attributes.
-        is_loaded = _is_loaded;
 
         // Add the newly created item to the Canvas or Artboard.
         parent.add_child (this, -1);

--- a/src/Lib/Items/CanvasText.vala
+++ b/src/Lib/Items/CanvasText.vala
@@ -29,8 +29,6 @@ public class Akira.Lib.Items.CanvasText : Goo.CanvasText, Akira.Lib.Items.Canvas
 
     public Items.CanvasArtboard? artboard { get; set; }
 
-    public bool is_loaded { get; set; }
-
     public CanvasText (
         string _text,
         double _x,
@@ -40,8 +38,7 @@ public class Akira.Lib.Items.CanvasText : Goo.CanvasText, Akira.Lib.Items.Canvas
         Goo.CanvasAnchorType _anchor = Goo.CanvasAnchorType.NW,
         string _font = "Open Sans 16",
         Goo.CanvasItem? _parent,
-        Items.CanvasArtboard? _artboard,
-        bool _loaded = false
+        Items.CanvasArtboard? _artboard
     ) {
         parent = _artboard != null ? _artboard : _parent;
         artboard = _artboard;
@@ -53,9 +50,6 @@ public class Akira.Lib.Items.CanvasText : Goo.CanvasText, Akira.Lib.Items.Canvas
         anchor = _anchor;
         font = _font;
         init_position (this, _x, _y);
-
-        // Add extra attributes.
-        is_loaded = _is_loaded;
 
         // Add the newly created item to the Canvas or Artboard.
         parent.add_child (this, -1);

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -66,7 +66,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         double x,
         double y,
         Lib.Managers.ImageManager? manager = null,
-        bool loaded = false,
         Items.CanvasArtboard? artboard = null
     ) {
         update_default_values ();
@@ -95,15 +94,15 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         }
 
         if (item_type == typeof (Items.CanvasRect)) {
-            new_item = add_rect (x, y, root, artboard, loaded);
+            new_item = add_rect (x, y, root, artboard);
         }
 
         if (item_type == typeof (Items.CanvasEllipse)) {
-            new_item = add_ellipse (x, y, root, artboard, loaded);
+            new_item = add_ellipse (x, y, root, artboard);
         }
 
         if (item_type == typeof (Items.CanvasText)) {
-            new_item = add_text (x, y, root, artboard, loaded);
+            new_item = add_text (x, y, root, artboard);
         }
 
         if (item_type == typeof (Items.CanvasImage)) {
@@ -112,7 +111,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             if (manager == null && image_manager != null) {
                 manager = image_manager;
             }
-            new_item = add_image (x, y, manager, root, artboard, loaded);
+            new_item = add_image (x, y, manager, root, artboard);
 
             // Empty the image manager since we used it.
             image_manager = null;
@@ -127,7 +126,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         } else {
             // Add it to "free items" if it doesn't belong to an artboard.
             if (new_item.artboard == null) {
-                free_items.add_item.begin ((Items.CanvasItem) new_item, loaded);
+                free_items.add_item.begin ((Items.CanvasItem) new_item);
             }
 
             // We need to additionally store images in a dedicated list in order
@@ -135,7 +134,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             // If we don't curate this dedicated list, it would be a nightamer to
             // loop through all the free items and artboard items to check for images.
             if (new_item is Items.CanvasImage) {
-                images.add_item.begin ((new_item as Akira.Lib.Items.CanvasImage), loaded);
+                images.add_item.begin ((new_item as Akira.Lib.Items.CanvasImage));
             }
         }
 
@@ -211,8 +210,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         double x,
         double y,
         Goo.CanvasItem parent,
-        Items.CanvasArtboard? artboard,
-        bool loaded
+        Items.CanvasArtboard? artboard
     ) {
         return new Items.CanvasRect (
             Utils.AffineTransform.fix_size (x),
@@ -221,8 +219,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             border_color,
             fill_color,
             parent,
-            artboard,
-            loaded
+            artboard
         );
     }
 
@@ -230,8 +227,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         double x,
         double y,
         Goo.CanvasItem parent,
-        Items.CanvasArtboard? artboard,
-        bool loaded
+        Items.CanvasArtboard? artboard
     ) {
         return new Items.CanvasEllipse (
             Utils.AffineTransform.fix_size (x),
@@ -240,8 +236,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             border_color,
             fill_color,
             parent,
-            artboard,
-            loaded
+            artboard
         );
     }
 
@@ -249,8 +244,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         double x,
         double y,
         Goo.CanvasItem parent,
-        Items.CanvasArtboard? artboard,
-        bool loaded
+        Items.CanvasArtboard? artboard
     ) {
         return new Items.CanvasText (
             "Akira is awesome :)",
@@ -261,8 +255,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             Goo.CanvasAnchorType.NW,
             "Open Sans 18",
             parent,
-            artboard,
-            loaded
+            artboard
         );
     }
 
@@ -271,16 +264,14 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         double y,
         Lib.Managers.ImageManager manager,
         Goo.CanvasItem parent,
-        Items.CanvasArtboard? artboard,
-        bool loaded
+        Items.CanvasArtboard? artboard
     ) {
         return new Items.CanvasImage (
             Utils.AffineTransform.fix_size (x),
             Utils.AffineTransform.fix_size (y),
             manager,
             parent,
-            artboard,
-            loaded
+            artboard
         );
     }
 
@@ -381,22 +372,22 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         switch (obj.get_string_member ("type")) {
             case "rectangle":
                 item_type = typeof (Items.CanvasRect);
-                item = insert_item (pos_x, pos_y, null, true, artboard);
+                item = insert_item (pos_x, pos_y, null, artboard);
                 break;
 
             case "ellipse":
                 item_type = typeof (Items.CanvasEllipse);
-                item = insert_item (pos_x, pos_y, null, true, artboard);
+                item = insert_item (pos_x, pos_y, null, artboard);
                 break;
 
             case "text":
                 item_type = typeof (Items.CanvasText);
-                item = insert_item (pos_x, pos_y, null, true, artboard);
+                item = insert_item (pos_x, pos_y, null, artboard);
                 break;
 
             case "artboard":
                 item_type = typeof (Items.CanvasArtboard);
-                item = insert_item (pos_x, pos_y, null, true, artboard);
+                item = insert_item (pos_x, pos_y, null, artboard);
                 break;
 
             case "image":
@@ -409,7 +400,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                     )
                 );
                 var manager = new Lib.Managers.ImageManager.from_archive (file, filename);
-                item = insert_item (pos_x, pos_y, manager, true, artboard);
+                item = insert_item (pos_x, pos_y, manager, artboard);
                 break;
         }
 
@@ -539,15 +530,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
                 true
             );
         }
-
-        // Since free items are loaded upside down, always raise to the top position
-        // the newly added free item.
-        if (artboard == null & !(item is Items.CanvasArtboard)) {
-            item.lower (null);
-        }
-
-        // Reset the loaded attribute to prevent sorting issues inside artboards.
-        item.is_loaded = false;
     }
 
     /**

--- a/src/Models/ListModel.vala
+++ b/src/Models/ListModel.vala
@@ -57,13 +57,7 @@ public class Akira.Models.ListModel<Model> : GLib.Object, GLib.ListModel {
         return (int) list.index (find_item (item));
     }
 
-    public async void add_item (Model model_item, bool append = false) {
-        if (append) {
-            list.append (model_item);
-            items_changed (get_n_items () - 1, 0, 1);
-            return;
-        }
-
+    public async void add_item (Model model_item) {
         list.prepend (model_item);
         items_changed (0, 0, 1);
     }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Avoid messing with the `ListModel` order and properly load the saved items in the correct order.

## Steps to Test
- Open this file: [test-file.zip](https://github.com/akiraux/Akira/files/6106317/test-file.zip)
- Make some changes to the sorting of items, save and close.
- Open and close the file multiple times to confirm the order is correct.

## This PR fixes/implements the following **bugs/features**:
- Remove the `loaded` attribute for the items.
- Always prepend items to the list model and don't mess with the sorting.
- Flip the array of loaded items to create them in the right order.

---

- Fixes #515
