### PR TITLE
Implement the disabling of the Snapping Guides

### DIFF
--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -72,6 +72,12 @@
             <description>The default color of the pixel grid.</description>
         </key>
 
+        <key name="enable-snaps" type="b">
+            <default>true</default>
+            <summary>Enable Snapping Guides</summary>
+            <description>Allow user to enable or disable the snapping guides when moving items.</description>
+        </key>
+
         <key name="snaps-color" type="s">
             <default>'#ff0000'</default>
             <summary>Default Snaps Color.</summary>

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -163,15 +163,19 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
 
         grid.attach (new SettingsHeader (_("Snapping Guides")), 0, 3, 2, 1);
 
-        var snaps_description = new Gtk.Label (_("Define the default color for the Snapping Guides."));
+        var snaps_description = new Gtk.Label (_("Define the default options for the Snapping Guides."));
         snaps_description.halign = Gtk.Align.START;
         snaps_description.margin_bottom = 10;
         grid.attach (snaps_description, 0, 4, 2, 1);
 
-        grid.attach (new SettingsLabel (_("Snapping Guides Color:")), 0, 5, 1, 1);
+        grid.attach (new SettingsLabel (_("Enable Snapping Guides:")), 0, 5, 1, 1);
+        var snaps_switch = new SettingsSwitch ("enable-snaps");
+        grid.attach (snaps_switch, 1, 5, 1, 1);
+
+        grid.attach (new SettingsLabel (_("Snapping Guides Color:")), 0, 6, 1, 1);
         snaps_color = new Gtk.ColorButton.with_rgba (snaps_rgba);
         snaps_color.halign = Gtk.Align.START;
-        grid.attach (snaps_color, 1, 5, 1, 1);
+        grid.attach (snaps_color, 1, 6, 1, 1);
 
         snaps_color.color_set.connect (() => {
             var rgba = snaps_color.get_rgba ();
@@ -189,6 +193,8 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
             settings.snaps_color = rgba_str;
             window.event_bus.update_snaps_color ();
         });
+
+        snaps_switch.bind_property ("active", snaps_color, "sensitive", BindingFlags.SYNC_CREATE);
 
         return grid;
     }

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -366,36 +366,46 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         matrix.y0 += first_move_y;
         item.set_transform (matrix);
 
+        // If the item is an Artboard, move the label with it.
+        if (item is Lib.Items.CanvasArtboard) {
+            ((Lib.Items.CanvasArtboard) item).label.translate (first_move_x, first_move_y);
+        }
+
+        // Interrupt if the user disabled the snapping.
+        if (!settings.enable_snaps) {
+            return;
+        }
+
         // Make adjustment basted on snaps.
         // Double the sensitivity to allow for reuse of grid after snap.
         var sensitivity = Utils.Snapping.adjusted_sensitivity (canvas.current_scale);
         var snap_grid = Utils.Snapping.generate_best_snap_grid (canvas, selected_items, sensitivity);
 
-        if (!snap_grid.is_empty ()) {
-            int snap_offset_x = 0;
-            int snap_offset_y = 0;
-            var matches = Utils.Snapping.generate_snap_matches (snap_grid, selected_items, sensitivity);
-
-            if (matches.h_data.snap_found ()) {
-                snap_offset_x = matches.h_data.snap_offset ();
-                first_move_x += snap_offset_x;
-                matrix.x0 += snap_offset_x;
-            }
-
-            if (matches.v_data.snap_found ()) {
-                snap_offset_y = matches.v_data.snap_offset ();
-                first_move_y += snap_offset_y;
-                matrix.y0 += snap_offset_y;
-            }
-
-            item.set_transform (matrix);
-            update_grid_decorators (true);
+        // Interrupt if we don't have any snap to use.
+        if (snap_grid.is_empty ()) {
+            return;
         }
 
+        int snap_offset_x = 0;
+        int snap_offset_y = 0;
+        var matches = Utils.Snapping.generate_snap_matches (snap_grid, selected_items, sensitivity);
+
+        if (matches.h_data.snap_found ()) {
+            snap_offset_x = matches.h_data.snap_offset ();
+            matrix.x0 += snap_offset_x;
+        }
+
+        if (matches.v_data.snap_found ()) {
+            snap_offset_y = matches.v_data.snap_offset ();
+            matrix.y0 += snap_offset_y;
+        }
+
+        item.set_transform (matrix);
+        update_grid_decorators (true);
 
         // If the item is an Artboard, move the label with it.
         if (item is Lib.Items.CanvasArtboard) {
-            ((Lib.Items.CanvasArtboard) item).label.translate (first_move_x, first_move_y);
+            ((Lib.Items.CanvasArtboard) item).label.translate (snap_offset_x, snap_offset_y);
         }
     }
 

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -70,6 +70,10 @@ public class Akira.Services.Settings : GLib.Settings {
         owned get { return get_string ("grid-color"); }
         set { set_string ("grid-color", value); }
     }
+    public bool enable_snaps {
+        get { return get_boolean ("enable-snaps"); }
+        set { set_boolean ("enable-snaps", value); }
+    }
     public string snaps_color {
         owned get { return get_string ("snaps-color"); }
         set { set_string ("snaps-color", value); }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implement an option in the settings to allow users to disable the Snapping Guides.

## Steps to Test
- You need to `sudo ninja install` to properly test this and use the new GSetting.
- Create a bunch of items and artboards and move them around to show the snaps.
- Open the settings and in the `Canvas` tab, disable the Snapping toggle.
- Move the items around to confirm the snaps don't appear.
