### PR TITLE
Implement multi select

### DIFF
--- a/src/FileFormat/JsonObject.vala
+++ b/src/FileFormat/JsonObject.vala
@@ -111,8 +111,8 @@ public class Akira.FileFormat.JsonObject : GLib.Object {
 
         if (item.transform != null) {
             var transform = new Json.Object ();
-            transform.set_double_member ("x", item.transform.x);
-            transform.set_double_member ("y", item.transform.y);
+            transform.set_double_member ("x", item.coordinates.x);
+            transform.set_double_member ("y", item.coordinates.y);
 
             components.set_object_member ("Transform", transform);
         }

--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -495,20 +495,24 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
 
             if (active) {
                 button_locked.get_style_context ().add_class ("show");
+                // Disable any pointer events for a locked item.
+                model.pointer_events = Goo.CanvasPointerEvents.NONE;
+
+                // Let the UI know that this item was locked.
+                window.event_bus.item_locked (model);
+                ((Gtk.ListBox) parent).unselect_row (this);
+                model.layer.selected = false;
             } else {
                 button_locked.get_style_context ().remove_class ("show");
+                // Re-enable pointer events.
+                model.pointer_events = Goo.CanvasPointerEvents.ALL;
             }
 
             icon_unlocked.visible = active;
-            icon_unlocked.no_show_all = ! active;
+            icon_unlocked.no_show_all = !active;
 
-            icon_locked.visible = ! active;
+            icon_locked.visible = !active;
             icon_locked.no_show_all = active;
-
-            if (active) {
-                window.event_bus.item_locked (model);
-                ((Gtk.ListBox) parent).unselect_row (this);
-            }
 
             window.event_bus.set_focus_on_canvas ();
             window.event_bus.file_edited ();

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -681,20 +681,24 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
 
             if (active) {
                 button_locked.get_style_context ().add_class ("show");
+                // Disable any pointer events for a locked item.
+                model.pointer_events = Goo.CanvasPointerEvents.NONE;
+
+                // Let the UI know that this item was locked.
+                window.event_bus.item_locked (model);
+                ((Gtk.ListBox) parent).unselect_row (this);
+                model.layer.selected = false;
             } else {
                 button_locked.get_style_context ().remove_class ("show");
+                // Re-enable pointer events.
+                model.pointer_events = Goo.CanvasPointerEvents.ALL;
             }
 
             icon_unlocked.visible = active;
-            icon_unlocked.no_show_all = ! active;
+            icon_unlocked.no_show_all = !active;
 
-            icon_locked.visible = ! active;
+            icon_locked.visible = !active;
             icon_locked.no_show_all = active;
-
-            if (active) {
-                window.event_bus.item_locked (model);
-                ((Gtk.ListBox) parent).unselect_row (this);
-            }
 
             window.event_bus.set_focus_on_canvas ();
             window.event_bus.file_edited ();

--- a/src/Layouts/Partials/LayersPanel.vala
+++ b/src/Layouts/Partials/LayersPanel.vala
@@ -64,10 +64,10 @@ public class Akira.Layouts.Partials.LayersPanel : Gtk.Grid {
         artboards_list = new Gtk.ListBox ();
 
         items_list.activate_on_single_click = false;
-        items_list.selection_mode = Gtk.SelectionMode.SINGLE;
+        items_list.selection_mode = Gtk.SelectionMode.MULTIPLE;
 
         artboards_list.activate_on_single_click = false;
-        artboards_list.selection_mode = Gtk.SelectionMode.SINGLE;
+        artboards_list.selection_mode = Gtk.SelectionMode.MULTIPLE;
 
         items_list.bind_model (window.items_manager.free_items, item => {
             return new Layouts.Partials.Layer (window, ((Lib.Items.CanvasItem) item), items_list);

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -336,16 +336,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                         return true;
                     }
 
-                    // Check if the clicked item is currently locked.
-                    if (item.layer.locked) {
-                        // If the shift key is not pressed, reset the selection.
-                        if (!shift_is_pressed) {
-                            selected_bound_manager.reset_selection ();
-                        }
-
-                        return true;
-                    }
-
                     if (!selected_bound_manager.contains_item (item) && !shift_is_pressed) {
                         selected_bound_manager.reset_selection ();
                     }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -585,8 +585,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         if (show) {
             ghost = new Goo.CanvasRect (
                 null,
-                item.transform.x1, item.transform.y1,
-                item.transform.x2 - item.transform.x1, item.transform.y2 - item.transform.y1,
+                item.coordinates.x1, item.coordinates.y1,
+                item.coordinates.x2 - item.coordinates.x1, item.coordinates.y2 - item.coordinates.y1,
                 "line-width", 1.0 / current_scale,
                 "stroke-color", "#41c9fd",
                 null

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -55,7 +55,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     public Managers.ExportManager export_manager;
     public Managers.SelectedBoundManager selected_bound_manager;
-    private Managers.NobManager nob_manager;
+    public Managers.NobManager nob_manager;
     private Managers.HoverManager hover_manager;
 
     // HashMap to keep track of the event coordinates on button press.

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -315,8 +315,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                     // If the item is selected and the shift key is pressed,
                     // remove the item from the selection.
                     if (selected_bound_manager.contains_item (item) && is_shift) {
-                       selected_bound_manager.remove_item_from_selection (item);
-                       return true;
+                        selected_bound_manager.remove_item_from_selection (item);
+                        return true;
                     }
 
                     // Check if the clicked item is currently locked.
@@ -327,6 +327,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                         }
 
                         return true;
+                    }
+
+                    if (!selected_bound_manager.contains_item (item) && !is_shift) {
+                        selected_bound_manager.reset_selection ();
                     }
 
                     // Item has been selected.

--- a/src/Lib/Components/Coordinates.vala
+++ b/src/Lib/Components/Coordinates.vala
@@ -23,7 +23,6 @@
  * Coordinates component to keep track of the item's initial coordinates.
  */
 public class Akira.Lib.Components.Coordinates : Component {
-    private double _x;
     public double x {
         get {
             double item_x = item.bounds.x1 + get_border ();
@@ -41,10 +40,6 @@ public class Akira.Lib.Components.Coordinates : Component {
             }
 
             return item_x;
-        }
-        set {
-            _x = value;
-            ((Lib.Canvas) item.canvas).window.event_bus.item_value_changed ();
         }
     }
 
@@ -78,7 +73,6 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
-    private double _y;
     public double y {
         get {
             double item_y = item.bounds.y1 + get_border ();
@@ -96,10 +90,6 @@ public class Akira.Lib.Components.Coordinates : Component {
             }
 
             return item_y;
-        }
-        set {
-            _y = value;
-            ((Lib.Canvas) item.canvas).window.event_bus.item_value_changed ();
         }
     }
 

--- a/src/Lib/Components/Coordinates.vala
+++ b/src/Lib/Components/Coordinates.vala
@@ -20,9 +20,9 @@
  */
 
 /**
- * Transform component to keep track of the item's initial coordinates.
+ * Coordinates component to keep track of the item's initial coordinates.
  */
-public class Akira.Lib.Components.Transform : Component {
+public class Akira.Lib.Components.Coordinates : Component {
     private double _x;
     public double x {
         get {
@@ -133,7 +133,7 @@ public class Akira.Lib.Components.Transform : Component {
         }
     }
 
-    public Transform (Items.CanvasItem _item) {
+    public Coordinates (Items.CanvasItem _item) {
         item = _item;
     }
 

--- a/src/Lib/Components/Coordinates.vala
+++ b/src/Lib/Components/Coordinates.vala
@@ -25,18 +25,18 @@
 public class Akira.Lib.Components.Coordinates : Component {
     public double x {
         get {
+            // If the item is an artboard we need to get the bounds of the background since
+            // the artboard group will have its bounds changing based on the location of the
+            // child items.
+            if (item is Items.CanvasArtboard) {
+                return ((Items.CanvasArtboard) item).background.bounds.x1;
+            }
+
             double item_x = item.bounds.x1 + get_border ();
 
             if (item.artboard != null) {
                 double temp_y = 0.0;
                 item.canvas.convert_to_item_space (item.artboard, ref item_x, ref temp_y);
-            }
-
-            // If the item is an artboard we need to get the bounds of the background since
-            // the artboard group will have its bounds changing based on the location of the
-            // child items.
-            if (item is Items.CanvasArtboard) {
-                item_x = ((Items.CanvasArtboard) item).background.bounds.x1;
             }
 
             return item_x;
@@ -45,48 +45,44 @@ public class Akira.Lib.Components.Coordinates : Component {
 
     public double x1 {
         get {
-            double item_x1 = item.bounds.x1 + get_border ();
-
             // If the item is an artboard we need to get the bounds of the background since
             // the artboard group will have its bounds changing based on the location of the
             // child items.
             if (item is Items.CanvasArtboard) {
-                item_x1 = ((Items.CanvasArtboard) item).background.bounds.x1;
+                return ((Items.CanvasArtboard) item).background.bounds.x1;
             }
 
-            return item_x1;
+            return item.bounds.x1 + get_border ();
         }
     }
 
     public double x2 {
         get {
-            double item_x2 = item.bounds.x2 - get_border ();
-
             // If the item is an artboard we need to get the bounds of the background since
             // the artboard group will have its bounds changing based on the location of the
             // child items.
             if (item is Items.CanvasArtboard) {
-                item_x2 = ((Items.CanvasArtboard) item).background.bounds.x2;
+                return ((Items.CanvasArtboard) item).background.bounds.x2;
             }
 
-            return item_x2;
+            return item.bounds.x2 - get_border ();
         }
     }
 
     public double y {
         get {
+            // If the item is an artboard we need to get the bounds of the background since
+            // the artboard group will have its bounds changing based on the location of the
+            // child items.
+            if (item is Items.CanvasArtboard) {
+                return ((Items.CanvasArtboard) item).background.bounds.y1;
+            }
+
             double item_y = item.bounds.y1 + get_border ();
 
             if (item.artboard != null) {
                 double temp_x = 0.0;
                 item.canvas.convert_to_item_space (item.artboard, ref temp_x, ref item_y);
-            }
-
-            // If the item is an artboard we need to get the bounds of the background since
-            // the artboard group will have its bounds changing based on the location of the
-            // child items.
-            if (item is Items.CanvasArtboard) {
-                item_y = ((Items.CanvasArtboard) item).background.bounds.y1;
             }
 
             return item_y;
@@ -95,31 +91,27 @@ public class Akira.Lib.Components.Coordinates : Component {
 
     public double y1 {
         get {
-            double item_y1 = item.bounds.y1 + get_border ();
-
             // If the item is an artboard we need to get the bounds of the background since
             // the artboard group will have its bounds changing based on the location of the
             // child items.
             if (item is Items.CanvasArtboard) {
-                item_y1 = ((Items.CanvasArtboard) item).background.bounds.y1;
+                return ((Items.CanvasArtboard) item).background.bounds.y1;
             }
 
-            return item_y1;
+            return item.bounds.y1 + get_border ();
         }
     }
 
     public double y2 {
         get {
-            double item_y2 = item.bounds.y2 - get_border ();
-
             // If the item is an artboard we need to get the bounds of the background since
             // the artboard group will have its bounds changing based on the location of the
             // child items.
             if (item is Items.CanvasArtboard) {
-                item_y2 = ((Items.CanvasArtboard) item).background.bounds.y2;
+                return ((Items.CanvasArtboard) item).background.bounds.y2;
             }
 
-            return item_y2;
+            return item.bounds.y2 - get_border ();
         }
     }
 

--- a/src/Lib/Items/CanvasArtboard.vala
+++ b/src/Lib/Items/CanvasArtboard.vala
@@ -29,10 +29,10 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
 
    public Items.CanvasArtboard? artboard { get; set; }
 
-   // Override the list type from the CanvasGroup.
+   // Override the list type of the Goo.CanvasAnimateTypeCanvasGroup.
    public new Akira.Models.ListModel<Lib.Items.CanvasItem> items;
 
-   // Private attributes of the Artboard.
+   // Unique attributes of the Artboard.
    public Goo.CanvasRect background;
    public Goo.CanvasText label;
 
@@ -47,8 +47,6 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       width = height = 1;
       init_position (this, _x, _y);
 
-      create_background ();
-
       // Add the newly created item to the Canvas.
       parent.add_child (this, -1);
 
@@ -61,12 +59,16 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       components.add (new Name (this));
       components.add (new Transform (this));
       components.add (new Opacity (this));
+      components.add (new Size (this));
+
+      // Create the background element before adding the Fills component.
+      create_background ();
+
       // Artboards have fills that can be edited, but they always start
       // with a full white background.
       var fill_color = Gdk.RGBA ();
       fill_color.parse ("#fff");
       components.add (new Fills (this, fill_color));
-      components.add (new Size (this));
       components.add (new Layer ());
 
       // Init the items list.
@@ -83,8 +85,8 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       // since users should be able to click on the artboard's background to drag
       // the artboard around when the artboard is selected.
 
-      this.bind_property ("width", background, "width", BindingFlags.SYNC_CREATE);
-      this.bind_property ("height", background, "height", BindingFlags.SYNC_CREATE);
+      this.size.bind_property ("width", background, "width", BindingFlags.SYNC_CREATE);
+      this.size.bind_property ("height", background, "height", BindingFlags.SYNC_CREATE);
    }
 
    private void create_label () {
@@ -95,14 +97,15 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
          "font", "Open Sans 10",
          "ellipsize", Pango.EllipsizeMode.END,
          null);
-      label.translate (transform.x, transform.y);
       label.can_focus = false;
       // Change the parent to allow mouse pointer selection.
       label.parent = this;
 
-      this.bind_property ("width", label, "width", BindingFlags.SYNC_CREATE);
       this.bind_property ("visibility", label, "visibility", BindingFlags.SYNC_CREATE);
       this.name.bind_property ("name", label, "text", BindingFlags.SYNC_CREATE);
+      this.size.bind_property ("width", label, "width", BindingFlags.SYNC_CREATE);
+      this.transform.bind_property ("x", label, "x", BindingFlags.SYNC_CREATE);
+      this.transform.bind_property ("y", label, "y", BindingFlags.SYNC_CREATE);
    }
 
    /**

--- a/src/Lib/Items/CanvasArtboard.vala
+++ b/src/Lib/Items/CanvasArtboard.vala
@@ -57,7 +57,7 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       // Add all the components that this item uses.
       components = new Gee.ArrayList<Component> ();
       components.add (new Name (this));
-      components.add (new Transform (this));
+      components.add (new Coordinates (this));
       components.add (new Opacity (this));
       components.add (new Size (this));
 
@@ -104,8 +104,6 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       this.bind_property ("visibility", label, "visibility", BindingFlags.SYNC_CREATE);
       this.name.bind_property ("name", label, "text", BindingFlags.SYNC_CREATE);
       this.size.bind_property ("width", label, "width", BindingFlags.SYNC_CREATE);
-      this.transform.bind_property ("x", label, "x", BindingFlags.SYNC_CREATE);
-      this.transform.bind_property ("y", label, "y", BindingFlags.SYNC_CREATE);
    }
 
    /**
@@ -125,10 +123,10 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
     * artboard's background, the artboard bounds will reflect the new group bounds.
     */
    public bool is_outside (Items.CanvasItem item) {
-      return item.bounds.x1 > background.bounds.x2 ||
-             item.bounds.y1 > background.bounds.y2 ||
-             item.bounds.x2 < background.bounds.x1 ||
-             item.bounds.y2 < background.bounds.y1;
+      return item.coordinates.x1 > background.bounds.x2 ||
+             item.coordinates.y1 > background.bounds.y2 ||
+             item.coordinates.x2 < background.bounds.x1 ||
+             item.coordinates.y2 < background.bounds.y1;
 
    }
 

--- a/src/Lib/Items/CanvasEllipse.vala
+++ b/src/Lib/Items/CanvasEllipse.vala
@@ -58,7 +58,7 @@ public class Akira.Lib.Items.CanvasEllipse : Goo.CanvasEllipse, Akira.Lib.Items.
         // Add all the components that this item uses.
         components = new Gee.ArrayList<Component> ();
         components.add (new Name (this));
-        components.add (new Transform (this));
+        components.add (new Coordinates (this));
         components.add (new Opacity (this));
         components.add (new Rotation (this));
         components.add (new Fills (this, fill_color));

--- a/src/Lib/Items/CanvasImage.vala
+++ b/src/Lib/Items/CanvasImage.vala
@@ -65,7 +65,7 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
         // Add all the components that this item uses.
         components = new Gee.ArrayList<Component> ();
         components.add (new Name (this));
-        components.add (new Transform (this));
+        components.add (new Coordinates (this));
         components.add (new Opacity (this));
         components.add (new Rotation (this));
         components.add (new Size (this));

--- a/src/Lib/Items/CanvasItem.vala
+++ b/src/Lib/Items/CanvasItem.vala
@@ -78,10 +78,10 @@ public interface Akira.Lib.Items.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasIt
         }
     }
 
-    public Components.Transform? transform {
+    public Components.Coordinates? coordinates {
         get {
-            Component? component = this.get_component (typeof (Components.Transform));
-            return (Components.Transform) component;
+            Component? component = this.get_component (typeof (Components.Coordinates));
+            return (Components.Coordinates) component;
         }
     }
 

--- a/src/Lib/Items/CanvasRect.vala
+++ b/src/Lib/Items/CanvasRect.vala
@@ -57,7 +57,7 @@ public class Akira.Lib.Items.CanvasRect : Goo.CanvasRect, Akira.Lib.Items.Canvas
         // Add all the components that this item uses.
         components = new Gee.ArrayList<Component> ();
         components.add (new Name (this));
-        components.add (new Transform (this));
+        components.add (new Coordinates (this));
         components.add (new Opacity (this));
         components.add (new Rotation (this));
         components.add (new Fills (this, fill_color));

--- a/src/Lib/Items/CanvasText.vala
+++ b/src/Lib/Items/CanvasText.vala
@@ -61,7 +61,7 @@ public class Akira.Lib.Items.CanvasText : Goo.CanvasText, Akira.Lib.Items.Canvas
         // Add all the components that this item uses.
         components = new Gee.ArrayList<Component> ();
         components.add (new Name (this));
-        components.add (new Transform (this));
+        components.add (new Coordinates (this));
         components.add (new Opacity (this));
         components.add (new Rotation (this));
         components.add (new Size (this));

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -99,7 +99,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
 
         create_hover_effect (item);
 
-        if (!item.layer.selected && !item.layer.locked) {
+        if (!item.layer.selected) {
             canvas.window.event_bus.hover_over_item (item);
         }
 
@@ -117,7 +117,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
     }
 
     private void create_hover_effect (Items.CanvasItem item) {
-        if (item.layer.locked || item.layer.selected) {
+        if (item.layer.selected) {
             return;
         }
 

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -106,16 +106,16 @@ public class Akira.Lib.Managers.NobManager : Object {
 
         if (selected_items.length () == 1) {
             var item = selected_items.nth_data (0);
-            bb_left = item.transform.x1;
-            bb_top = item.transform.y1;
-            bb_right = item.transform.x2;
-            bb_bottom = item.transform.y2;
+            bb_left = item.coordinates.x1;
+            bb_top = item.coordinates.y1;
+            bb_right = item.coordinates.x2;
+            bb_bottom = item.coordinates.y2;
         } else {
             foreach (var item in selected_items) {
-                bb_left = double.min (bb_left, item.transform.x1);
-                bb_top = double.min (bb_top, item.transform.y1);
-                bb_right = double.max (bb_right, item.transform.x2);
-                bb_bottom = double.max (bb_bottom, item.transform.y2);
+                bb_left = double.min (bb_left, item.coordinates.x1);
+                bb_top = double.min (bb_top, item.coordinates.y1);
+                bb_right = double.max (bb_right, item.coordinates.x2);
+                bb_bottom = double.max (bb_bottom, item.coordinates.y2);
             }
         }
 

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -388,6 +388,8 @@ public class Akira.Lib.Managers.NobManager : Object {
             return;
         }
 
+        matrix.y0 = top;
+        matrix.x0 = left;
         _width = width;
         _height = height;
     }

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -54,11 +54,10 @@ public class Akira.Lib.Managers.NobManager : Object {
     private Goo.CanvasRect? select_effect;
     private Goo.CanvasItemSimple[] nobs = new Goo.CanvasItemSimple[9];
     private Goo.CanvasPolyline? rotation_line;
-    private Goo.CanvasBounds select_bb;
-    private double top;
-    private double left;
-    private double width;
-    private double height;
+    public double top;
+    public double left;
+    public double width;
+    public double height;
     private double nob_size;
 
     // Tracks if an artboard is part of the current selection.
@@ -105,24 +104,25 @@ public class Akira.Lib.Managers.NobManager : Object {
         // Bounding box edges
         double bb_left = 1e6, bb_top = 1e6, bb_right = 0, bb_bottom = 0;
 
-        foreach (var item in selected_items) {
-            bb_left = double.min (bb_left, item.transform.x1);
-            bb_top = double.min (bb_top, item.transform.y1);
-            bb_right = double.max (bb_right, item.transform.x2);
-            bb_bottom = double.max (bb_bottom, item.transform.y2);
+        if (selected_items.length () == 1) {
+            var item = selected_items.nth_data (0);
+            bb_left = item.transform.x1;
+            bb_top = item.transform.y1;
+            bb_right = item.transform.x2;
+            bb_bottom = item.transform.y2;
+        } else {
+            foreach (var item in selected_items) {
+                bb_left = double.min (bb_left, item.transform.x1);
+                bb_top = double.min (bb_top, item.transform.y1);
+                bb_right = double.max (bb_right, item.transform.x2);
+                bb_bottom = double.max (bb_bottom, item.transform.y2);
+            }
         }
 
-        select_bb = Goo.CanvasBounds () {
-            x1 = bb_left,
-            y1 = bb_top,
-            x2 = bb_right,
-            y2 = bb_bottom
-        };
-
-        top = select_bb.y1;
-        left = select_bb.x1;
-        width = select_bb.x2 - select_bb.x1;
-        height = select_bb.y2 - select_bb.y1;
+        top = bb_top;
+        left = bb_left;
+        width = bb_right - bb_left;
+        height = bb_bottom - bb_top;
     }
 
     private void on_add_select_effect (List<Items.CanvasItem> selected_items) {
@@ -131,10 +131,7 @@ public class Akira.Lib.Managers.NobManager : Object {
             return;
         }
 
-        if (selected_items.length () > 1) {
-            update_select_bb_coords (selected_items);
-        }
-
+        update_select_bb_coords (selected_items);
         update_select_effect (selected_items);
         update_nob_position (selected_items);
         // We don't need to recreate those objects after this.

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -138,9 +138,13 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         canvas.window.event_bus.reset_state_coords (selected_item);
     }
 
+    public bool contains_item (Items.CanvasItem item) {
+        return selected_items.index (item) != -1;
+    }
+
     public void add_item_to_selection (Items.CanvasItem item) {
-        // Don't clear and reselect the same element if it's already selected.
-        if (selected_items.index (item) != -1) {
+        // Interrupt if the item is already selected.
+        if (contains_item (item)) {
             return;
         }
 
@@ -325,8 +329,8 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         window.event_bus.update_state_coords (x, y);
     }
 
-    private void remove_item_from_selection (Lib.Items.CanvasItem item) {
-        if (selected_items.index (item) > -1) {
+    public void remove_item_from_selection (Items.CanvasItem item) {
+        if (contains_item (item)) {
             selected_items.remove (item);
         }
 
@@ -336,7 +340,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     /**
      * Move the item based on the mouse click and drag event.
      */
-    private void move_from_event ( Lib.Items.CanvasItem item, double event_x, double event_y ) {
+    private void move_from_event (Items.CanvasItem item, double event_x, double event_y) {
         if (!initial_drag_registered) {
             initial_drag_registered = true;
             initial_drag_item_x = item.transform.x;

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -63,6 +63,8 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         canvas.window.event_bus.move_item_from_canvas.connect (on_move_item_from_canvas);
         canvas.window.event_bus.item_deleted.connect (remove_item_from_selection);
         canvas.window.event_bus.request_add_item_to_selection.connect (add_item_to_selection);
+        canvas.window.event_bus.request_remove_item_from_selection.connect (remove_item_from_selection);
+        canvas.window.event_bus.request_reset_selection.connect (reset_selection);
         canvas.window.event_bus.item_locked.connect (remove_item_from_selection);
         canvas.window.event_bus.zoom.connect (on_canvas_zoom);
     }
@@ -329,6 +331,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     public void remove_item_from_selection (Items.CanvasItem item) {
         if (contains_item (item)) {
             selected_items.remove (item);
+            item.layer.selected = false;
         }
 
         canvas.window.event_bus.set_focus_on_canvas ();

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -187,6 +187,16 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
     private void update_selected_items () {
         canvas.window.event_bus.selected_items_changed (selected_items);
+
+        foreach (var item in selected_items) {
+            if (!(item is Items.CanvasArtboard)) {
+                continue;
+            }
+
+            Cairo.Matrix matrix;
+            item.get_transform (out matrix);
+            ((Items.CanvasArtboard) item).label.set_transform (matrix);
+        }
     }
 
     private void change_z_selected (bool raise, bool total) {
@@ -330,15 +340,15 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     private void move_from_event (double event_x, double event_y) {
         // If it's the first time we're moving this item, collect the original coordinates.
         if (!initial_drag_selection_registered) {
-            initial_drag_selection_x = selected_items.data.transform.x1;
-            initial_drag_selection_y = selected_items.data.transform.y1;
+            initial_drag_selection_x = selected_items.data.coordinates.x;
+            initial_drag_selection_y = selected_items.data.coordinates.y;
             initial_drag_selection_registered = true;
         }
 
         // Keep reset and delta values for future adjustments.
         // Calculate values needed to reset to the original position.
-        var reset_x = selected_items.data.transform.x - initial_drag_selection_x;
-        var reset_y = selected_items.data.transform.y - initial_drag_selection_y;
+        var reset_x = selected_items.data.coordinates.x - initial_drag_selection_x;
+        var reset_y = selected_items.data.coordinates.y - initial_drag_selection_y;
 
         // Calculate the change based on the event.
         var delta_x = event_x - initial_drag_press_x;
@@ -351,6 +361,12 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         // Loop through all the currently selected items to move them.
         foreach (var item in selected_items) {
+            // Skip this item if it belongs to an artboard and the artboard
+            // is part of the current selection.
+            if (item.artboard != null && contains_item (item.artboard)) {
+                continue;
+            }
+
             Cairo.Matrix matrix;
             item.get_transform (out matrix);
 
@@ -395,6 +411,12 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         // Loop again through all the selected items to apply the snap offset.
         foreach (var item in selected_items) {
+            // Skip this item if it belongs to an artboard and the artboard
+            // is part of the current selection.
+            if (item.artboard != null && contains_item (item.artboard)) {
+                continue;
+            }
+
             Cairo.Matrix matrix;
             item.get_transform (out matrix);
 

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -358,11 +358,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
             matrix.x0 += first_move_x;
             matrix.y0 += first_move_y;
             item.set_transform (matrix);
-
-            // If the item is an Artboard, move the label with it.
-            if (item is Lib.Items.CanvasArtboard) {
-                ((Lib.Items.CanvasArtboard) item).label.translate (first_move_x, first_move_y);
-            }
         }
 
         // Interrupt if the user disabled the snapping.
@@ -407,11 +402,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
             matrix.y0 += snap_offset_y;
 
             item.set_transform (matrix);
-
-            // If the item is an Artboard, move the label with it.
-            if (item is Lib.Items.CanvasArtboard) {
-                ((Lib.Items.CanvasArtboard) item).label.translate (snap_offset_x, snap_offset_y);
-            }
         }
 
         update_grid_decorators (true);

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -142,10 +142,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
             return;
         }
 
-        if (item.layer.locked) {
-            return;
-        }
-
         item.layer.selected = true;
         item.size.update_ratio ();
 

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -148,10 +148,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
             return;
         }
 
-        // Just 1 selected element at the same time
-        // TODO: allow for multi selection with shift pressed
-        reset_selection ();
-
         if (item.layer.locked) {
             return;
         }
@@ -178,7 +174,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
             canvas.window.event_bus.request_delete_item (item);
         }
 
-        // By emptying the selected_items list, the select_effect gets dropped
+        // By emptying the selected_items list, the select_effect gets dropped.
         selected_items = new List<Items.CanvasItem> ();
     }
 
@@ -209,7 +205,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         Items.CanvasItem selected_item = selected_items.nth_data (0);
 
-        // Cannot move artboard z-index wise
+        // Cannot move artboard z-index wise.
         if (selected_item is Items.CanvasArtboard) {
             return;
         }
@@ -218,7 +214,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         int pos_selected = -1;
 
         if (selected_item.artboard != null) {
-            // Inside an artboard
+            // Inside an artboard.
             items_count = (int) selected_item.artboard.items.get_n_items ();
             pos_selected = items_count - 1 - selected_item.artboard.items.index (selected_item);
         } else {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -145,6 +145,12 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
             return;
         }
 
+        // Don't add an item to the selection if it's part of an artboard
+        // that is already selected.
+        if (item.artboard != null && contains_item (item.artboard)) {
+            return;
+        }
+
         item.layer.selected = true;
         item.size.update_ratio ();
 
@@ -153,7 +159,24 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         selected_items.append (item);
 
+        // If the item is an artboard, remove all its children from the selection,
+        // in order to avoid strange translation outcomes.
+        if (item is Items.CanvasArtboard) {
+            foreach (var child in ((Items.CanvasArtboard) item).items) {
+                remove_item_from_selection (child);
+            }
+        }
+
         // Move focus back to the canvas.
+        canvas.window.event_bus.set_focus_on_canvas ();
+    }
+
+    public void remove_item_from_selection (Items.CanvasItem item) {
+        if (contains_item (item)) {
+            selected_items.remove (item);
+            item.layer.selected = false;
+        }
+
         canvas.window.event_bus.set_focus_on_canvas ();
     }
 
@@ -326,15 +349,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         }
 
         window.event_bus.update_state_coords (x, y);
-    }
-
-    public void remove_item_from_selection (Items.CanvasItem item) {
-        if (contains_item (item)) {
-            selected_items.remove (item);
-            item.layer.selected = false;
-        }
-
-        canvas.window.event_bus.set_focus_on_canvas ();
     }
 
     /**

--- a/src/Partials/ButtonImage.vala
+++ b/src/Partials/ButtonImage.vala
@@ -29,7 +29,7 @@ public class Akira.Partials.ButtonImage: Gtk.Image {
         size = icon_size;
         margin = 0;
 
-        settings.changed["use-symbolic"].connect ( () => {
+        settings.changed["use-symbolic"].connect (() => {
             update_image ();
         });
 

--- a/src/Partials/HeaderBarButton.vala
+++ b/src/Partials/HeaderBarButton.vala
@@ -48,15 +48,15 @@ public class Akira.Partials.HeaderBarButton : Gtk.Grid {
         valign = Gtk.Align.CENTER;
         sensitive = false;
 
-        udpate_label ();
+        update_label ();
         build_signals ();
 
-        settings.changed["show-label"].connect ( () => {
-            udpate_label ();
+        settings.changed["show-label"].connect (() => {
+            update_label ();
         });
     }
 
-    private void udpate_label () {
+    private void update_label () {
         label_btn.visible = settings.show_label;
         label_btn.no_show_all = !settings.show_label;
     }

--- a/src/Partials/MenuButton.vala
+++ b/src/Partials/MenuButton.vala
@@ -42,14 +42,14 @@ public class Akira.Partials.MenuButton : Gtk.Grid {
         attach (label_btn, 0, 1, 1, 1);
 
         valign = Gtk.Align.CENTER;
-        udpate_label ();
+        update_label ();
 
         settings.changed["show-label"].connect (() => {
-            udpate_label ();
+            update_label ();
         });
     }
 
-    private void udpate_label () {
+    private void update_label () {
         label_btn.visible = settings.show_label;
         label_btn.no_show_all = !settings.show_label;
     }

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -70,14 +70,14 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         label_btn.margin_top = 4;
 
         attach (label_btn, 0, 1, 3, 1);
-        udpate_label ();
+        update_label ();
 
-        settings.changed["show-label"].connect ( () => {
-            udpate_label ();
+        settings.changed["show-label"].connect (() => {
+            update_label ();
         });
     }
 
-    private void udpate_label () {
+    private void update_label () {
         label_btn.visible = settings.show_label;
         label_btn.no_show_all = !settings.show_label;
     }

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -63,6 +63,8 @@ public class Akira.Services.EventBus : Object {
     public signal void change_z_selected (bool raise, bool total);
     public signal void flip_item (bool vertical = false);
     public signal void request_add_item_to_selection (Lib.Items.CanvasItem item);
+    public signal void request_remove_item_from_selection (Lib.Items.CanvasItem item);
+    public signal void request_reset_selection ();
     public signal void request_delete_item (Lib.Items.CanvasItem item);
     public signal void selected_items_changed (List<Lib.Items.CanvasItem> selected_items);
     public signal void selected_items_list_changed (List<Lib.Items.CanvasItem> selected_items);

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -80,8 +80,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
      */
     private void on_init_state_coords (Lib.Items.CanvasItem item) {
         // Get the item X & Y coordinates.
-        double item_x = item.transform.x;
-        double item_y = item.transform.y;
+        double item_x = item.coordinates.x;
+        double item_y = item.coordinates.y;
 
         // Interrupt if no value has changed.
         if (item_x == x && item_y == y) {
@@ -114,8 +114,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         do_update = false;
 
         // Get the item X & Y coordinates.
-        double item_x = item.transform.x;
-        double item_y = item.transform.y;
+        double item_x = item.coordinates.x;
+        double item_y = item.coordinates.y;
 
         // Interrupt if no value has changed.
         if (item_x == x && item_y == y) {
@@ -128,8 +128,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
 
         // Set the same values we just fetched to the Transform attributes
         // in order to trigger the redraw of all the elements using them.
-        item.transform.x = item_x;
-        item.transform.y = item_y;
+        item.coordinates.x = item_x;
+        item.coordinates.y = item_y;
 
         do_update = true;
 
@@ -153,8 +153,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             }
 
             // Store the new coordinates in local variables so we can manipulate them.
-            double inc_x = x - item.transform.x;
-            double inc_y = y - item.transform.y;
+            double inc_x = x - item.coordinates.x;
+            double inc_y = y - item.coordinates.y;
 
             Cairo.Matrix matrix;
             item.get_transform (out matrix);
@@ -166,8 +166,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             item.set_transform (matrix);
 
             // Update the Transform component attributes.
-            item.transform.x += inc_x;
-            item.transform.y += inc_y;
+            item.coordinates.x += inc_x;
+            item.coordinates.y += inc_y;
         }
     }
 }

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -126,10 +126,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         x = item_x;
         y = item_y;
 
-        // Set the same values we just fetched to the Transform attributes
-        // in order to trigger the redraw of all the elements using them.
-        item.coordinates.x = item_x;
-        item.coordinates.y = item_y;
+        window.event_bus.item_value_changed ();
 
         do_update = true;
 
@@ -164,10 +161,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             matrix.y0 += inc_y;
 
             item.set_transform (matrix);
-
-            // Update the Transform component attributes.
-            item.coordinates.x += inc_x;
-            item.coordinates.y += inc_y;
+            window.event_bus.item_value_changed ();
         }
     }
 }

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -165,11 +165,6 @@ public class Akira.StateManagers.CoordinatesManager : Object {
 
             item.set_transform (matrix);
 
-            // If the item is an Artboard, move the label with it.
-            if (item is Lib.Items.CanvasArtboard) {
-                ((Lib.Items.CanvasArtboard) item).label.translate (inc_x, inc_y);
-            }
-
             // Update the Transform component attributes.
             item.transform.x += inc_x;
             item.transform.y += inc_y;

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -54,8 +54,8 @@ public class Akira.Utils.AffineTransform : Object {
 
         double item_width = item.size.width;
         double item_height = item.size.height;
-        double item_x = item.transform.x1;
-        double item_y = item.transform.y1;
+        double item_x = item.coordinates.x1;
+        double item_y = item.coordinates.y1;
         canvas.convert_to_item_space (item, ref item_x, ref item_y);
 
         double inc_width = 0;
@@ -343,8 +343,8 @@ public class Akira.Utils.AffineTransform : Object {
             canvas.convert_to_item_space (item.artboard, ref x, ref y);
             canvas.convert_to_item_space (item.artboard, ref initial_x, ref initial_y);
 
-            diff_x = item.transform.x1 - item.artboard.transform.x1;
-            diff_y = item.transform.y1 - item.artboard.transform.y1;
+            diff_x = item.coordinates.x1 - item.artboard.coordinates.x1;
+            diff_y = item.coordinates.y1 - item.artboard.coordinates.y1;
 
             x -= diff_x;
             y -= diff_y;

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -226,11 +226,6 @@ public class Akira.Utils.AffineTransform : Object {
         item.translate (inc_x, inc_y);
         // Update the item size.
         set_size (item, inc_width, inc_height);
-
-        // If the item is an Artboard, move the label with it.
-        if (item is Lib.Items.CanvasArtboard) {
-            ((Lib.Items.CanvasArtboard) item).label.translate (inc_x, inc_y);
-        }
     }
 
     // Width size constraints.

--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -151,15 +151,15 @@ public class Akira.Utils.Snapping : Object {
         Goo.CanvasBounds horizontal_filter = {0, 0, 0, 0};
 
         foreach (var item in selection) {
-            horizontal_filter.x1 = item.transform.x1 - sensitivity;
-            horizontal_filter.x2 = item.transform.x2 + sensitivity;
+            horizontal_filter.x1 = item.coordinates.x1 - sensitivity;
+            horizontal_filter.x2 = item.coordinates.x2 + sensitivity;
             horizontal_filter.y1 = canvas.y1;
             horizontal_filter.y2 = canvas.y2;
 
             vertical_filter.x1 = canvas.x1;
             vertical_filter.x2 = canvas.x2;
-            vertical_filter.y1 = item.transform.y1 - sensitivity;
-            vertical_filter.y2 = item.transform.y2 + sensitivity;
+            vertical_filter.y1 = item.coordinates.y1 - sensitivity;
+            vertical_filter.y2 = item.coordinates.y2 + sensitivity;
 
             vertical_candidates.concat (canvas.get_items_in_area (vertical_filter, true, true, true));
             horizontal_candidates.concat (canvas.get_items_in_area (horizontal_filter, true, true, true));
@@ -323,12 +323,12 @@ public class Akira.Utils.Snapping : Object {
      * Populates the horizontal snaps of an item.
      */
     private static void populate_horizontal_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
-        int x_1 = (int) item.transform.x1;
-        int x_2 = (int) item.transform.x2;
-        int y_1 = (int) item.transform.y1;
-        int y_2 = (int) item.transform.y2;
-        int center_x = (int) (Math.ceil ((item.transform.x2 - item.transform.x1) / 2.0) + item.transform.x1);
-        int center_y = (int) (Math.ceil ((item.transform.y2 - item.transform.y1) / 2.0) + item.transform.y1);
+        int x_1 = (int) item.coordinates.x1;
+        int x_2 = (int) item.coordinates.x2;
+        int y_1 = (int) item.coordinates.y1;
+        int y_2 = (int) item.coordinates.y2;
+        int center_x = (int) (Math.ceil ((item.coordinates.x2 - item.coordinates.x1) / 2.0) + item.coordinates.x1);
+        int center_y = (int) (Math.ceil ((item.coordinates.y2 - item.coordinates.y1) / 2.0) + item.coordinates.y1);
 
         add_to_map (x_1, y_1, y_2, center_y, -1, ref map);
         add_to_map (x_2, y_1, y_2, center_y, 1, ref map);
@@ -339,12 +339,12 @@ public class Akira.Utils.Snapping : Object {
      * Populates the vertical snaps of an item.
      */
     private static void populate_vertical_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
-        int x_1 = (int) item.transform.x1;
-        int x_2 = (int) item.transform.x2;
-        int y_1 = (int) item.transform.y1;
-        int y_2 = (int) item.transform.y2;
-        int center_x = (int) (Math.ceil ((item.transform.x2 - item.transform.x1) / 2.0) + item.transform.x1);
-        int center_y = (int) (Math.ceil ((item.transform.y2 - item.transform.y1) / 2.0) + item.transform.y1);
+        int x_1 = (int) item.coordinates.x1;
+        int x_2 = (int) item.coordinates.x2;
+        int y_1 = (int) item.coordinates.y1;
+        int y_2 = (int) item.coordinates.y2;
+        int center_x = (int) (Math.ceil ((item.coordinates.x2 - item.coordinates.x1) / 2.0) + item.coordinates.x1);
+        int center_y = (int) (Math.ceil ((item.coordinates.y2 - item.coordinates.y1) / 2.0) + item.coordinates.y1);
 
         add_to_map (y_1, x_1, x_2, center_x, -1, ref map);
         add_to_map (y_2, x_1, x_2, center_x, 1, ref map);

--- a/src/meson.build
+++ b/src/meson.build
@@ -84,6 +84,7 @@ sources = files(
     'Lib/Components/Border.vala',
     'Lib/Components/Borders.vala',
     'Lib/Components/BorderRadius.vala',
+    'Lib/Components/Coordinates.vala',
     'Lib/Components/Fill.vala',
     'Lib/Components/Fills.vala',
     'Lib/Components/Flipped.vala',
@@ -92,7 +93,6 @@ sources = files(
     'Lib/Components/Opacity.vala',
     'Lib/Components/Rotation.vala',
     'Lib/Components/Size.vala',
-    'Lib/Components/Transform.vala',
 
     'Lib/Items/CanvasArtboard.vala',
     'Lib/Items/CanvasEllipse.vala',


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implement items multiselect via Canvas clicks and allow moving the selected array of items.

## Steps to Test
- Create multiple items.
- Select them by holding down the <kdb>SHIFT</kbd> key.
- Move them around.
- Click on a selected item by holding down the <kdb>SHIFT</kbd> key to remove it from the selection.
- Click on a selected item to deselect all the others.

## Screenshots 
![group-move](https://user-images.githubusercontent.com/2527103/110901072-96c4b800-82b8-11eb-94d3-e866da21852b.gif)

## Known Issues / Things To Do
Scale and rotation don't work, but I'm probably gonna wait for the PRs from @mbfraga before implementing those.

~The initial dragging position is collected into an `HashMap`. I'm not sure that's the best approach as we keep fetching the coordinates from the map at every movement, and that might get expensive when dealing with many items.
We use the `item.name.id` as HashMap key, but currently that ID is not really unique. I need to change that.~ *Ignore this as a better method was implemented*.

## This PR fixes/implements the following bugs/features:
- Rename the `Transform` component to `Coordinates` to avoid overriding the built-in `transform` Matrix abstract attribute of the Goo.CanvasItem object.
- Reduce the number of attributes in the `Coordinates` component.
- Properly draw the select effect based on the amount of selected items.
- Enable layer multiselection in the layers panel.
