### PR TITLE
Implement snapping sensitivity threshold option in Settings

### DIFF
--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -84,6 +84,12 @@
             <description>The default color of the snapping guides.</description>
         </key>
 
+        <key name="snaps-sensitivity" type="i">
+            <default>4</default>
+            <summary>Default Snaps Sensitivity.</summary>
+            <description>The default sensitivity of the snapping threshold.</description>
+        </key>
+
         <key name="fill-color" type="s">
             <default>'#CCCCCC'</default>
             <summary>Default Shape Color.</summary>

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -194,7 +194,15 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
             window.event_bus.update_snaps_color ();
         });
 
+        grid.attach (new SettingsLabel (_("Snapping Sensitivity Threshold:")), 0, 7, 1, 1);
+        var snaps_sensitivity = new Gtk.SpinButton.with_range (0, 9999, 1);
+        snaps_sensitivity.halign = Gtk.Align.START;
+        grid.attach (snaps_sensitivity, 1, 7, 1, 1);
+
+        settings.bind ("snaps-sensitivity", snaps_sensitivity, "value", SettingsBindFlags.DEFAULT);
+
         snaps_switch.bind_property ("active", snaps_color, "sensitive", BindingFlags.SYNC_CREATE);
+        snaps_switch.bind_property ("active", snaps_sensitivity, "sensitive", BindingFlags.SYNC_CREATE);
 
         return grid;
     }

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -197,6 +197,11 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         grid.attach (new SettingsLabel (_("Snapping Sensitivity Threshold:")), 0, 7, 1, 1);
         var snaps_sensitivity = new Gtk.SpinButton.with_range (0, 9999, 1);
         snaps_sensitivity.halign = Gtk.Align.START;
+        snaps_sensitivity.width_chars = 6;
+        snaps_sensitivity.get_style_context ().add_class ("input-icon-right");
+        snaps_sensitivity.secondary_icon_name = "input-pixel-symbolic";
+        snaps_sensitivity.secondary_icon_sensitive = false;
+        snaps_sensitivity.secondary_icon_activatable = false;
         grid.attach (snaps_sensitivity, 1, 7, 1, 1);
 
         settings.bind ("snaps-sensitivity", snaps_sensitivity, "value", SettingsBindFlags.DEFAULT);
@@ -273,6 +278,11 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         grid.attach (new SettingsLabel (_("Border Width:")), 0, 5, 1, 1);
         border_size = new Gtk.SpinButton.with_range (1, 9999, 1);
         border_size.halign = Gtk.Align.START;
+        border_size.width_chars = 6;
+        border_size.get_style_context ().add_class ("input-icon-right");
+        border_size.secondary_icon_name = "input-pixel-symbolic";
+        border_size.secondary_icon_sensitive = false;
+        border_size.secondary_icon_activatable = false;
         grid.attach (border_size, 1, 5, 1, 1);
 
         settings.bind ("border-size", border_size, "value", SettingsBindFlags.DEFAULT);

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -336,7 +336,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     /**
      * Move the item based on the mouse click and drag event.
      */
-    private void move_from_event ( Lib.Items.CanvasItem item, double event_x, double event_y ) {
+    private void move_from_event (Lib.Items.CanvasItem item, double event_x, double event_y) {
         if (!initial_drag_registered) {
             initial_drag_registered = true;
             initial_drag_item_x = item.transform.x;
@@ -371,8 +371,9 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
             ((Lib.Items.CanvasArtboard) item).label.translate (first_move_x, first_move_y);
         }
 
-        // Interrupt if the user disabled the snapping.
-        if (!settings.enable_snaps) {
+        // Interrupt if the user disabled the snapping or we don't have any
+        // adjacent item to snap to.
+        if (!settings.enable_snaps || window.items_manager.get_items_count () == 1) {
             return;
         }
 

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019-2020 Alecaddd (https://alecaddd.com)
+* Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -77,6 +77,10 @@ public class Akira.Services.Settings : GLib.Settings {
     public string snaps_color {
         owned get { return get_string ("snaps-color"); }
         set { set_string ("snaps-color", value); }
+    }
+    public int snaps_sensitivity {
+        get { return get_int ("snaps-sensitivity"); }
+        set { set_int ("snaps-sensitivity", value); }
     }
 
     // Default shape settings.

--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -23,8 +23,6 @@
  * Utility providing snap functionality between objects.
  */
 public class Akira.Utils.Snapping : Object {
-    private const double SENSITIVITY = 4.0;
-
     /**
      * Metadata used in the cosmetic aspects of snap lines and dots.
      */
@@ -100,12 +98,12 @@ public class Akira.Utils.Snapping : Object {
      */
     public static int adjusted_sensitivity (double canvas_scale) {
         // Limit the sensitivity. This seems like a sensible default for now.
-        if (canvas_scale > SENSITIVITY) {
+        if (canvas_scale > settings.snaps_sensitivity) {
             return 1;
         }
 
         // Beyond 0.002, the snapping breaks down. Arguably, it does before.
-        return (int) (SENSITIVITY / double.max (0.002, canvas_scale));
+        return (int) (settings.snaps_sensitivity / double.max (0.002, canvas_scale));
     }
 
     /**


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Allow users to control the threshold sensitivity of the snapping guides.

## Steps to Test
- Create various items and move them around.
- Open the settings and change the snapping sensitivity value.
- Move items around to confirm the change.

## Screenshots 
![Screenshot from 2021-03-14 12-42-04](https://user-images.githubusercontent.com/2527103/111081947-f1c9fb00-84c2-11eb-8656-f4c007af3f57.png)

## This PR fixes/implements the following **bugs/features**:
- Add snapping sensitivity setting.
- Avoid running the snapping if only 1 item is currently present in the canvas.
