### PR TITLE
Rename Transform component to Coordinates

### DIFF
--- a/src/FileFormat/JsonObject.vala
+++ b/src/FileFormat/JsonObject.vala
@@ -109,12 +109,12 @@ public class Akira.FileFormat.JsonObject : GLib.Object {
             components.set_object_member ("Name", name);
         }
 
-        if (item.transform != null) {
-            var transform = new Json.Object ();
-            transform.set_double_member ("x", item.transform.x);
-            transform.set_double_member ("y", item.transform.y);
+        if (item.coordinates != null) {
+            var coordinates = new Json.Object ();
+            coordinates.set_double_member ("x", item.coordinates.x);
+            coordinates.set_double_member ("y", item.coordinates.y);
 
-            components.set_object_member ("Transform", transform);
+            components.set_object_member ("Coordinates", coordinates);
         }
 
         if (item.opacity != null) {

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -508,8 +508,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         if (show) {
             ghost = new Goo.CanvasRect (
                 null,
-                item.transform.x1, item.transform.y1,
-                item.transform.x2 - item.transform.x1, item.transform.y2 - item.transform.y1,
+                item.coordinates.x1, item.coordinates.y1,
+                item.coordinates.x2 - item.coordinates.x1, item.coordinates.y2 - item.coordinates.y1,
                 "line-width", 1.0 / current_scale,
                 "stroke-color", "#41c9fd",
                 null

--- a/src/Lib/Components/Coordinates.vala
+++ b/src/Lib/Components/Coordinates.vala
@@ -23,9 +23,15 @@
  * Coordinates component to keep track of the item's initial coordinates.
  */
 public class Akira.Lib.Components.Coordinates : Component {
-    private double _x;
     public double x {
         get {
+            // If the item is an artboard we need to get the bounds of the background since
+            // the artboard group will have its bounds changing based on the location of the
+            // child items.
+            if (item is Items.CanvasArtboard) {
+                return ((Items.CanvasArtboard) item).background.bounds.x1;
+            }
+
             double item_x = item.bounds.x1 + get_border ();
 
             if (item.artboard != null) {
@@ -33,54 +39,45 @@ public class Akira.Lib.Components.Coordinates : Component {
                 item.canvas.convert_to_item_space (item.artboard, ref item_x, ref temp_y);
             }
 
-            // If the item is an artboard we need to get the bounds of the background since
-            // the artboard group will have its bounds changing based on the location of the
-            // child items.
-            if (item is Items.CanvasArtboard) {
-                item_x = ((Items.CanvasArtboard) item).background.bounds.x1;
-            }
-
             return item_x;
-        }
-        set {
-            _x = value;
-            ((Lib.Canvas) item.canvas).window.event_bus.item_value_changed ();
         }
     }
 
     public double x1 {
         get {
-            double item_x1 = item.bounds.x1 + get_border ();
-
             // If the item is an artboard we need to get the bounds of the background since
             // the artboard group will have its bounds changing based on the location of the
             // child items.
             if (item is Items.CanvasArtboard) {
-                item_x1 = ((Items.CanvasArtboard) item).background.bounds.x1;
+                return ((Items.CanvasArtboard) item).background.bounds.x1;
             }
 
-            return item_x1;
+            return item.bounds.x1 + get_border ();
         }
     }
 
     public double x2 {
         get {
-            double item_x2 = item.bounds.x2 - get_border ();
-
             // If the item is an artboard we need to get the bounds of the background since
             // the artboard group will have its bounds changing based on the location of the
             // child items.
             if (item is Items.CanvasArtboard) {
-                item_x2 = ((Items.CanvasArtboard) item).background.bounds.x2;
+                return ((Items.CanvasArtboard) item).background.bounds.x2;
             }
 
-            return item_x2;
+            return item.bounds.x2 - get_border ();
         }
     }
 
-    private double _y;
     public double y {
         get {
+            // If the item is an artboard we need to get the bounds of the background since
+            // the artboard group will have its bounds changing based on the location of the
+            // child items.
+            if (item is Items.CanvasArtboard) {
+                return ((Items.CanvasArtboard) item).background.bounds.y1;
+            }
+
             double item_y = item.bounds.y1 + get_border ();
 
             if (item.artboard != null) {
@@ -88,48 +85,33 @@ public class Akira.Lib.Components.Coordinates : Component {
                 item.canvas.convert_to_item_space (item.artboard, ref temp_x, ref item_y);
             }
 
-            // If the item is an artboard we need to get the bounds of the background since
-            // the artboard group will have its bounds changing based on the location of the
-            // child items.
-            if (item is Items.CanvasArtboard) {
-                item_y = ((Items.CanvasArtboard) item).background.bounds.y1;
-            }
-
             return item_y;
-        }
-        set {
-            _y = value;
-            ((Lib.Canvas) item.canvas).window.event_bus.item_value_changed ();
         }
     }
 
     public double y1 {
         get {
-            double item_y1 = item.bounds.y1 + get_border ();
-
             // If the item is an artboard we need to get the bounds of the background since
             // the artboard group will have its bounds changing based on the location of the
             // child items.
             if (item is Items.CanvasArtboard) {
-                item_y1 = ((Items.CanvasArtboard) item).background.bounds.y1;
+                return ((Items.CanvasArtboard) item).background.bounds.y1;
             }
 
-            return item_y1;
+            return item.bounds.y1 + get_border ();
         }
     }
 
     public double y2 {
         get {
-            double item_y2 = item.bounds.y2 - get_border ();
-
             // If the item is an artboard we need to get the bounds of the background since
             // the artboard group will have its bounds changing based on the location of the
             // child items.
             if (item is Items.CanvasArtboard) {
-                item_y2 = ((Items.CanvasArtboard) item).background.bounds.y2;
+                return ((Items.CanvasArtboard) item).background.bounds.y2;
             }
 
-            return item_y2;
+            return item.bounds.y2 - get_border ();
         }
     }
 

--- a/src/Lib/Components/Coordinates.vala
+++ b/src/Lib/Components/Coordinates.vala
@@ -20,9 +20,9 @@
  */
 
 /**
- * Transform component to keep track of the item's initial coordinates.
+ * Coordinates component to keep track of the item's initial coordinates.
  */
-public class Akira.Lib.Components.Transform : Component {
+public class Akira.Lib.Components.Coordinates : Component {
     private double _x;
     public double x {
         get {
@@ -133,7 +133,7 @@ public class Akira.Lib.Components.Transform : Component {
         }
     }
 
-    public Transform (Items.CanvasItem _item) {
+    public Coordinates (Items.CanvasItem _item) {
         item = _item;
     }
 

--- a/src/Lib/Items/CanvasArtboard.vala
+++ b/src/Lib/Items/CanvasArtboard.vala
@@ -29,10 +29,10 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
 
    public Items.CanvasArtboard? artboard { get; set; }
 
-   // Override the list type from the CanvasGroup.
+   // Override the list type of the Goo.CanvasGroup.
    public new Akira.Models.ListModel<Lib.Items.CanvasItem> items;
 
-   // Private attributes of the Artboard.
+   // Unique attributes of the Artboard.
    public Goo.CanvasRect background;
    public Goo.CanvasText label;
 
@@ -122,11 +122,10 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
     * artboard's background, the artboard bounds will reflect the new group bounds.
     */
    public bool is_outside (Items.CanvasItem item) {
-      return item.bounds.x1 > background.bounds.x2 ||
-             item.bounds.y1 > background.bounds.y2 ||
-             item.bounds.x2 < background.bounds.x1 ||
-             item.bounds.y2 < background.bounds.y1;
-
+      return item.coordinates.x1 > background.bounds.x2 ||
+             item.coordinates.y1 > background.bounds.y2 ||
+             item.coordinates.x2 < background.bounds.x1 ||
+             item.coordinates.y2 < background.bounds.y1;
    }
 
    public uint get_items_length () {

--- a/src/Lib/Items/CanvasArtboard.vala
+++ b/src/Lib/Items/CanvasArtboard.vala
@@ -59,7 +59,7 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       // Add all the components that this item uses.
       components = new Gee.ArrayList<Component> ();
       components.add (new Name (this));
-      components.add (new Transform (this));
+      components.add (new Coordinates (this));
       components.add (new Opacity (this));
       // Artboards have fills that can be edited, but they always start
       // with a full white background.
@@ -95,7 +95,7 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
          "font", "Open Sans 10",
          "ellipsize", Pango.EllipsizeMode.END,
          null);
-      label.translate (transform.x, transform.y);
+      label.translate (coordinates.x, coordinates.y);
       label.can_focus = false;
       // Change the parent to allow mouse pointer selection.
       label.parent = this;

--- a/src/Lib/Items/CanvasEllipse.vala
+++ b/src/Lib/Items/CanvasEllipse.vala
@@ -58,7 +58,7 @@ public class Akira.Lib.Items.CanvasEllipse : Goo.CanvasEllipse, Akira.Lib.Items.
         // Add all the components that this item uses.
         components = new Gee.ArrayList<Component> ();
         components.add (new Name (this));
-        components.add (new Transform (this));
+        components.add (new Coordinates (this));
         components.add (new Opacity (this));
         components.add (new Rotation (this));
         components.add (new Fills (this, fill_color));

--- a/src/Lib/Items/CanvasImage.vala
+++ b/src/Lib/Items/CanvasImage.vala
@@ -65,7 +65,7 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
         // Add all the components that this item uses.
         components = new Gee.ArrayList<Component> ();
         components.add (new Name (this));
-        components.add (new Transform (this));
+        components.add (new Coordinates (this));
         components.add (new Opacity (this));
         components.add (new Rotation (this));
         components.add (new Size (this));

--- a/src/Lib/Items/CanvasItem.vala
+++ b/src/Lib/Items/CanvasItem.vala
@@ -78,10 +78,10 @@ public interface Akira.Lib.Items.CanvasItem : Goo.CanvasItemSimple, Goo.CanvasIt
         }
     }
 
-    public Components.Transform? transform {
+    public Components.Coordinates? coordinates {
         get {
-            Component? component = this.get_component (typeof (Components.Transform));
-            return (Components.Transform) component;
+            Component? component = this.get_component (typeof (Components.Coordinates));
+            return (Components.Coordinates) component;
         }
     }
 

--- a/src/Lib/Items/CanvasRect.vala
+++ b/src/Lib/Items/CanvasRect.vala
@@ -57,7 +57,7 @@ public class Akira.Lib.Items.CanvasRect : Goo.CanvasRect, Akira.Lib.Items.Canvas
         // Add all the components that this item uses.
         components = new Gee.ArrayList<Component> ();
         components.add (new Name (this));
-        components.add (new Transform (this));
+        components.add (new Coordinates (this));
         components.add (new Opacity (this));
         components.add (new Rotation (this));
         components.add (new Fills (this, fill_color));

--- a/src/Lib/Items/CanvasText.vala
+++ b/src/Lib/Items/CanvasText.vala
@@ -61,7 +61,7 @@ public class Akira.Lib.Items.CanvasText : Goo.CanvasText, Akira.Lib.Items.Canvas
         // Add all the components that this item uses.
         components = new Gee.ArrayList<Component> ();
         components.add (new Name (this));
-        components.add (new Transform (this));
+        components.add (new Coordinates (this));
         components.add (new Opacity (this));
         components.add (new Rotation (this));
         components.add (new Size (this));

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -352,9 +352,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         Items.CanvasArtboard? artboard = null;
 
         var components = obj.get_member ("Components").get_object ();
-        var transform = components.get_member ("Transform").get_object ();
-        var pos_x = transform.get_double_member ("x");
-        var pos_y = transform.get_double_member ("y");
+        var coordinates = components.get_member ("Coordinates").get_object ();
+        var pos_x = coordinates.get_double_member ("x");
+        var pos_y = coordinates.get_double_member ("y");
 
         // If item is inside an artboard update the coordinates accordingly.
         if (obj.has_member ("artboard")) {

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -122,10 +122,10 @@ public class Akira.Lib.Managers.NobManager : Object {
         double bb_left = 1e6, bb_top = 1e6, bb_right = 0, bb_bottom = 0;
 
         foreach (var item in selected_items) {
-            bb_left = double.min (bb_left, item.transform.x1);
-            bb_top = double.min (bb_top, item.transform.y1);
-            bb_right = double.max (bb_right, item.transform.x2);
-            bb_bottom = double.max (bb_bottom, item.transform.y2);
+            bb_left = double.min (bb_left, item.coordinates.x1);
+            bb_top = double.min (bb_top, item.coordinates.y1);
+            bb_right = double.max (bb_right, item.coordinates.x2);
+            bb_bottom = double.max (bb_bottom, item.coordinates.y2);
         }
 
         select_bb = Goo.CanvasBounds () {

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -337,15 +337,15 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     private void move_from_event (Lib.Items.CanvasItem item, double event_x, double event_y) {
         if (!initial_drag_registered) {
             initial_drag_registered = true;
-            initial_drag_item_x = item.transform.x;
-            initial_drag_item_y = item.transform.y;
+            initial_drag_item_x = item.coordinates.x;
+            initial_drag_item_y = item.coordinates.y;
         }
 
         // Keep reset and delta values for future adjustments.
 
         // Calculate values needed to reset to the original position.
-        var reset_x = item.transform.x - initial_drag_item_x;
-        var reset_y = item.transform.y - initial_drag_item_y;
+        var reset_x = item.coordinates.x - initial_drag_item_x;
+        var reset_y = item.coordinates.y - initial_drag_item_y;
 
         // Calculate the change based on the event.
         var delta_x = event_x - initial_drag_press_x;
@@ -430,8 +430,8 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         if (!initial_drag_registered) {
             item.get_transform (out initial_item_transform);
             initial_drag_registered = true;
-            initial_drag_item_x = item.transform.x1;
-            initial_drag_item_y = item.transform.y1;
+            initial_drag_item_x = item.coordinates.x1;
+            initial_drag_item_y = item.coordinates.y1;
             scale_item_x_adj = 0;
             scale_item_y_adj = 0;
 

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -80,8 +80,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
      */
     private void on_init_state_coords (Lib.Items.CanvasItem item) {
         // Get the item X & Y coordinates.
-        double item_x = item.transform.x;
-        double item_y = item.transform.y;
+        double item_x = item.coordinates.x;
+        double item_y = item.coordinates.y;
 
         // Interrupt if no value has changed.
         if (item_x == x && item_y == y) {
@@ -114,8 +114,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         do_update = false;
 
         // Get the item X & Y coordinates.
-        double item_x = item.transform.x;
-        double item_y = item.transform.y;
+        double item_x = item.coordinates.x;
+        double item_y = item.coordinates.y;
 
         // Interrupt if no value has changed.
         if (item_x == x && item_y == y) {
@@ -128,8 +128,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
 
         // Set the same values we just fetched to the Transform attributes
         // in order to trigger the redraw of all the elements using them.
-        item.transform.x = item_x;
-        item.transform.y = item_y;
+        item.coordinates.x = item_x;
+        item.coordinates.y = item_y;
 
         do_update = true;
 
@@ -153,8 +153,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             }
 
             // Store the new coordinates in local variables so we can manipulate them.
-            double inc_x = x - item.transform.x;
-            double inc_y = y - item.transform.y;
+            double inc_x = x - item.coordinates.x;
+            double inc_y = y - item.coordinates.y;
 
             Cairo.Matrix matrix;
             item.get_transform (out matrix);
@@ -171,8 +171,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             }
 
             // Update the Transform component attributes.
-            item.transform.x += inc_x;
-            item.transform.y += inc_y;
+            item.coordinates.x += inc_x;
+            item.coordinates.y += inc_y;
         }
     }
 }

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -126,13 +126,9 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         x = item_x;
         y = item_y;
 
-        // Set the same values we just fetched to the Transform attributes
-        // in order to trigger the redraw of all the elements using them.
-        item.coordinates.x = item_x;
-        item.coordinates.y = item_y;
-
         do_update = true;
 
+        window.event_bus.item_value_changed ();
         window.event_bus.file_edited ();
     }
 
@@ -170,9 +166,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
                 ((Lib.Items.CanvasArtboard) item).label.translate (inc_x, inc_y);
             }
 
-            // Update the Transform component attributes.
-            item.coordinates.x += inc_x;
-            item.coordinates.y += inc_y;
+            window.event_bus.item_value_changed ();
         }
     }
 }

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -244,8 +244,8 @@ public class Akira.Utils.AffineTransform : Object {
             canvas.convert_to_item_space (item.artboard, ref x, ref y);
             canvas.convert_to_item_space (item.artboard, ref initial_x, ref initial_y);
 
-            diff_x = item.transform.x1 - item.artboard.transform.x1;
-            diff_y = item.transform.y1 - item.artboard.transform.y1;
+            diff_x = item.coordinates.x1 - item.artboard.coordinates.x1;
+            diff_y = item.coordinates.y1 - item.artboard.coordinates.y1;
 
             x -= diff_x;
             y -= diff_y;

--- a/src/Utils/Snapping.vala
+++ b/src/Utils/Snapping.vala
@@ -149,15 +149,15 @@ public class Akira.Utils.Snapping : Object {
         Goo.CanvasBounds horizontal_filter = {0, 0, 0, 0};
 
         foreach (var item in selection) {
-            horizontal_filter.x1 = item.transform.x1 - sensitivity;
-            horizontal_filter.x2 = item.transform.x2 + sensitivity;
+            horizontal_filter.x1 = item.coordinates.x1 - sensitivity;
+            horizontal_filter.x2 = item.coordinates.x2 + sensitivity;
             horizontal_filter.y1 = canvas.y1;
             horizontal_filter.y2 = canvas.y2;
 
             vertical_filter.x1 = canvas.x1;
             vertical_filter.x2 = canvas.x2;
-            vertical_filter.y1 = item.transform.y1 - sensitivity;
-            vertical_filter.y2 = item.transform.y2 + sensitivity;
+            vertical_filter.y1 = item.coordinates.y1 - sensitivity;
+            vertical_filter.y2 = item.coordinates.y2 + sensitivity;
 
             vertical_candidates.concat (canvas.get_items_in_area (vertical_filter, true, true, true));
             horizontal_candidates.concat (canvas.get_items_in_area (horizontal_filter, true, true, true));
@@ -321,12 +321,12 @@ public class Akira.Utils.Snapping : Object {
      * Populates the horizontal snaps of an item.
      */
     private static void populate_horizontal_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
-        int x_1 = (int) item.transform.x1;
-        int x_2 = (int) item.transform.x2;
-        int y_1 = (int) item.transform.y1;
-        int y_2 = (int) item.transform.y2;
-        int center_x = (int) (Math.ceil ((item.transform.x2 - item.transform.x1) / 2.0) + item.transform.x1);
-        int center_y = (int) (Math.ceil ((item.transform.y2 - item.transform.y1) / 2.0) + item.transform.y1);
+        int x_1 = (int) item.coordinates.x1;
+        int x_2 = (int) item.coordinates.x2;
+        int y_1 = (int) item.coordinates.y1;
+        int y_2 = (int) item.coordinates.y2;
+        int center_x = (int) (Math.ceil ((item.coordinates.x2 - item.coordinates.x1) / 2.0) + item.coordinates.x1);
+        int center_y = (int) (Math.ceil ((item.coordinates.y2 - item.coordinates.y1) / 2.0) + item.coordinates.y1);
 
         add_to_map (x_1, y_1, y_2, center_y, -1, ref map);
         add_to_map (x_2, y_1, y_2, center_y, 1, ref map);
@@ -337,12 +337,12 @@ public class Akira.Utils.Snapping : Object {
      * Populates the vertical snaps of an item.
      */
     private static void populate_vertical_snaps (Lib.Items.CanvasItem item, ref Gee.HashMap<int, SnapMeta> map) {
-        int x_1 = (int) item.transform.x1;
-        int x_2 = (int) item.transform.x2;
-        int y_1 = (int) item.transform.y1;
-        int y_2 = (int) item.transform.y2;
-        int center_x = (int) (Math.ceil ((item.transform.x2 - item.transform.x1) / 2.0) + item.transform.x1);
-        int center_y = (int) (Math.ceil ((item.transform.y2 - item.transform.y1) / 2.0) + item.transform.y1);
+        int x_1 = (int) item.coordinates.x1;
+        int x_2 = (int) item.coordinates.x2;
+        int y_1 = (int) item.coordinates.y1;
+        int y_2 = (int) item.coordinates.y2;
+        int center_x = (int) (Math.ceil ((item.coordinates.x2 - item.coordinates.x1) / 2.0) + item.coordinates.x1);
+        int center_y = (int) (Math.ceil ((item.coordinates.y2 - item.coordinates.y1) / 2.0) + item.coordinates.y1);
 
         add_to_map (y_1, x_1, x_2, center_x, -1, ref map);
         add_to_map (y_2, x_1, x_2, center_x, 1, ref map);

--- a/src/meson.build
+++ b/src/meson.build
@@ -80,10 +80,11 @@ sources = files(
 
     'Lib/Canvas.vala',
 
-    'Lib/Components/Component.vala',
     'Lib/Components/Border.vala',
     'Lib/Components/Borders.vala',
     'Lib/Components/BorderRadius.vala',
+    'Lib/Components/Component.vala',
+    'Lib/Components/Coordinates.vala',
     'Lib/Components/Fill.vala',
     'Lib/Components/Fills.vala',
     'Lib/Components/Flipped.vala',
@@ -92,7 +93,6 @@ sources = files(
     'Lib/Components/Opacity.vala',
     'Lib/Components/Rotation.vala',
     'Lib/Components/Size.vala',
-    'Lib/Components/Transform.vala',
 
     'Lib/Items/CanvasArtboard.vala',
     'Lib/Items/CanvasEllipse.vala',


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
This is only a task PR, nothing is getting fixed.

I'm renaming the `Transform` component to `Coordinates` since `transform` is an existing abstract property of the `Goo.CanvasItem` and we were overriding it.
