### PR TITLE
Improve the Artboard label translation

### DIFF
--- a/src/Lib/Items/CanvasArtboard.vala
+++ b/src/Lib/Items/CanvasArtboard.vala
@@ -47,8 +47,6 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       width = height = 1;
       init_position (this, _x, _y);
 
-      create_background ();
-
       // Add the newly created item to the Canvas.
       parent.add_child (this, -1);
 
@@ -61,12 +59,16 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       components.add (new Name (this));
       components.add (new Coordinates (this));
       components.add (new Opacity (this));
+      components.add (new Size (this));
+
+      // Create the background element before adding the Fills component.
+      create_background ();
+
       // Artboards have fills that can be edited, but they always start
       // with a full white background.
       var fill_color = Gdk.RGBA ();
       fill_color.parse ("#fff");
       components.add (new Fills (this, fill_color));
-      components.add (new Size (this));
       components.add (new Layer ());
 
       // Init the items list.
@@ -83,8 +85,8 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       // since users should be able to click on the artboard's background to drag
       // the artboard around when the artboard is selected.
 
-      this.bind_property ("width", background, "width", BindingFlags.SYNC_CREATE);
-      this.bind_property ("height", background, "height", BindingFlags.SYNC_CREATE);
+      this.size.bind_property ("width", background, "width", BindingFlags.SYNC_CREATE);
+      this.size.bind_property ("height", background, "height", BindingFlags.SYNC_CREATE);
    }
 
    private void create_label () {
@@ -95,14 +97,13 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
          "font", "Open Sans 10",
          "ellipsize", Pango.EllipsizeMode.END,
          null);
-      label.translate (coordinates.x, coordinates.y);
       label.can_focus = false;
       // Change the parent to allow mouse pointer selection.
       label.parent = this;
 
-      this.bind_property ("width", label, "width", BindingFlags.SYNC_CREATE);
       this.bind_property ("visibility", label, "visibility", BindingFlags.SYNC_CREATE);
       this.name.bind_property ("name", label, "text", BindingFlags.SYNC_CREATE);
+      this.size.bind_property ("width", label, "width", BindingFlags.SYNC_CREATE);
    }
 
    /**

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -194,6 +194,16 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
     private void update_selected_items () {
         canvas.window.event_bus.selected_items_changed (selected_items);
+
+        foreach (var item in selected_items) {
+            if (!(item is Items.CanvasArtboard)) {
+                continue;
+            }
+
+            Cairo.Matrix matrix;
+            item.get_transform (out matrix);
+            ((Items.CanvasArtboard) item).label.set_transform (matrix);
+        }
     }
 
     private void change_z_selected (bool raise, bool total) {
@@ -203,7 +213,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         Items.CanvasItem selected_item = selected_items.nth_data (0);
 
-        // Cannot move artboard z-index wise
+        // Cannot move artboard z-index wise.
         if (selected_item is Items.CanvasArtboard) {
             return;
         }
@@ -212,7 +222,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         int pos_selected = -1;
 
         if (selected_item.artboard != null) {
-            // Inside an artboard
+            // Inside an artboard.
             items_count = (int) selected_item.artboard.items.get_n_items ();
             pos_selected = items_count - 1 - selected_item.artboard.items.index (selected_item);
         } else {
@@ -364,11 +374,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         matrix.y0 += first_move_y;
         item.set_transform (matrix);
 
-        // If the item is an Artboard, move the label with it.
-        if (item is Lib.Items.CanvasArtboard) {
-            ((Lib.Items.CanvasArtboard) item).label.translate (first_move_x, first_move_y);
-        }
-
         // Interrupt if the user disabled the snapping or we don't have any
         // adjacent item to snap to.
         if (!settings.enable_snaps || window.items_manager.get_items_count () == 1) {
@@ -401,11 +406,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         item.set_transform (matrix);
         update_grid_decorators (true);
-
-        // If the item is an Artboard, move the label with it.
-        if (item is Lib.Items.CanvasArtboard) {
-            ((Lib.Items.CanvasArtboard) item).label.translate (snap_offset_x, snap_offset_y);
-        }
     }
 
     private void on_canvas_zoom () {

--- a/src/Partials/HeaderBarButton.vala
+++ b/src/Partials/HeaderBarButton.vala
@@ -48,15 +48,15 @@ public class Akira.Partials.HeaderBarButton : Gtk.Grid {
         valign = Gtk.Align.CENTER;
         sensitive = false;
 
-        udpate_label ();
+        update_label ();
         build_signals ();
 
         settings.changed["show-label"].connect ( () => {
-            udpate_label ();
+            update_label ();
         });
     }
 
-    private void udpate_label () {
+    private void update_label () {
         label_btn.visible = settings.show_label;
         label_btn.no_show_all = !settings.show_label;
     }

--- a/src/Partials/MenuButton.vala
+++ b/src/Partials/MenuButton.vala
@@ -42,14 +42,14 @@ public class Akira.Partials.MenuButton : Gtk.Grid {
         attach (label_btn, 0, 1, 1, 1);
 
         valign = Gtk.Align.CENTER;
-        udpate_label ();
+        update_label ();
 
         settings.changed["show-label"].connect (() => {
-            udpate_label ();
+            update_label ();
         });
     }
 
-    private void udpate_label () {
+    private void update_label () {
         label_btn.visible = settings.show_label;
         label_btn.no_show_all = !settings.show_label;
     }

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -70,14 +70,14 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         label_btn.margin_top = 4;
 
         attach (label_btn, 0, 1, 3, 1);
-        udpate_label ();
+        update_label ();
 
         settings.changed["show-label"].connect ( () => {
-            udpate_label ();
+            update_label ();
         });
     }
 
-    private void udpate_label () {
+    private void update_label () {
         label_btn.visible = settings.show_label;
         label_btn.no_show_all = !settings.show_label;
     }

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -161,11 +161,6 @@ public class Akira.StateManagers.CoordinatesManager : Object {
 
             item.set_transform (matrix);
 
-            // If the item is an Artboard, move the label with it.
-            if (item is Lib.Items.CanvasArtboard) {
-                ((Lib.Items.CanvasArtboard) item).label.translate (inc_x, inc_y);
-            }
-
             window.event_bus.item_value_changed ();
         }
     }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
This is a task PR as it doesn't fix any bug or add any features.
Improves the translation of the Artboard label to remove visual delay and avoid always checking for it during various transformations.

## Steps to Test
- Move and resize an artboard around and confirm that the label tags along.

