### PR TITLE
Remove check of one  item when snapping to grid

### DIFF
--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -376,7 +376,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
 
         // Interrupt if the user disabled the snapping or we don't have any
         // adjacent item to snap to.
-        if (!settings.enable_snaps || window.items_manager.get_items_count () == 1) {
+        if (!settings.enable_snaps) {
             return;
         }
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
A check for only one item in the canvas blocking snapping was causing confusion when adding items to a single artboard.

## Steps to Test
Add an artboard, add two items to the artboard.
If you move the items around, they won't snap to each other. With this fix, they should.