### PR TITLE
Improve the layers panel handling of click events

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -320,13 +320,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 }
 
                 if (clicked_item is Items.CanvasItem) {
-                    Items.CanvasItem item = clicked_item as Items.CanvasItem;
-
-                    if (item.layer.locked) {
-                        selected_bound_manager.reset_selection ();
-                        holding = false;
-                        return true;
-                    }
+                    var item = clicked_item as Items.CanvasItem;
 
                     // Item has been selected.
                     selected_bound_manager.add_item_to_selection (item);

--- a/src/Lib/Items/CanvasArtboard.vala
+++ b/src/Lib/Items/CanvasArtboard.vala
@@ -102,6 +102,7 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       label.parent = this;
 
       this.bind_property ("visibility", label, "visibility", BindingFlags.SYNC_CREATE);
+      this.bind_property ("pointer_events", label, "pointer_events", BindingFlags.SYNC_CREATE);
       this.name.bind_property ("name", label, "text", BindingFlags.SYNC_CREATE);
       this.size.bind_property ("width", label, "width", BindingFlags.SYNC_CREATE);
    }

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -99,7 +99,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
 
         create_hover_effect (item);
 
-        if (!item.layer.selected && !item.layer.locked) {
+        if (!item.layer.selected) {
             canvas.window.event_bus.hover_over_item (item);
         }
 
@@ -117,7 +117,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
     }
 
     private void create_hover_effect (Items.CanvasItem item) {
-        if (item.layer.locked || item.layer.selected) {
+        if (item.layer.selected) {
             return;
         }
 

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -146,10 +146,6 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         // TODO: allow for multi selection with shift pressed
         reset_selection ();
 
-        if (item.layer.locked) {
-            return;
-        }
-
         item.layer.selected = true;
         item.size.update_ratio ();
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Make the `Layer` and `Artboard` rows of the Layers Panel behave identically, and fix some click issues when locking/unlocking a selected item.

## This PR fixes/implements the following **bugs/features**:
- Use `Goo.CanvasPointerEvents` to handle locked/unlocked items.
- Properly deselect the layer row when locking a layer.
- Remove dead commented code we won't use.
- Let GooCanvas ignore items with no pointer events instead of checking for locked layers.
- Ignore hover effects on locked layers.
