### PR TITLE
Make serialization objects into utilities

### DIFF
--- a/src/FileFormat/AkiraFile.vala
+++ b/src/FileFormat/AkiraFile.vala
@@ -44,7 +44,8 @@ public class Akira.FileFormat.AkiraFile : Akira.FileFormat.ZipArchiveHandler {
             open_archive ();
 
             var content_json = get_content_as_json (content_file);
-            new FileFormat.JsonLoader (window, content_json);
+
+            FileFormat.JsonDeserializer.json_object_to_world (content_json, window);
 
             update_recent_list.begin ();
 
@@ -57,11 +58,9 @@ public class Akira.FileFormat.AkiraFile : Akira.FileFormat.ZipArchiveHandler {
     public void save_file () {
         try {
             save_images.begin ();
-            var content = new FileFormat.JsonContent (window);
 
-            content.save_content ();
-            var json = content.finalize_content ();
-            write_content_to_file (content_file, json);
+            var world_json = FileFormat.JsonSerializer.world_to_json_node (window);
+            write_content_to_file (content_file, FileFormat.JsonSerializer.json_to_string (world_json, true));
 
             write_to_archive ();
             update_recent_list.begin ();

--- a/src/FileFormat/JsonDeserializer.vala
+++ b/src/FileFormat/JsonDeserializer.vala
@@ -19,22 +19,23 @@
  * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
-public class Akira.FileFormat.JsonLoader : Object {
-    public weak Akira.Window window { get; construct; }
-    public Json.Object obj { get; construct; }
+public class Akira.FileFormat.JsonDeserializer {
 
-    public JsonLoader (Akira.Window window, Json.Object obj) {
-        Object (
-            window: window,
-            obj: obj
-        );
+    /*
+     * Deserialize a Json.Node and apply it to the current world state.
+     * This deserializes a node, which is symmetric with the output of JsonSerializer.
+     */
+    public static void json_node_to_world (Json.Node node, Akira.Window window, bool items_only = false) {
+        var obj = node.get_object ();
+        if (obj != null) {
+            json_object_to_world(obj, window, items_only);
+        }
     }
 
-    construct {
-        load_content ();
-    }
-
-    public void load_content () {
+    /*
+     * Deserialize a Json.Node and apply it to the current world state.
+     */
+    public static void json_object_to_world (Json.Object obj, Akira.Window window, bool items_only = false) {
         // Se the canvas to simulate a click + holding state to avoid triggering
         // redrawing methods connected to that state.
         window.main_window.main_canvas.canvas.holding = true;
@@ -46,7 +47,7 @@ public class Akira.FileFormat.JsonLoader : Object {
             artboards_list.reverse ();
 
             foreach (unowned Json.Node node in artboards_list) {
-                load_item (node.get_object (), "artboard");
+                load_item (window, node.get_object (), "artboard");
             }
         }
 
@@ -57,22 +58,33 @@ public class Akira.FileFormat.JsonLoader : Object {
             items_list.reverse ();
 
             foreach (unowned Json.Node node in items_list) {
-                load_item (node.get_object (), "item");
+                load_item (window, node.get_object (), "item");
             }
         }
 
-        window.event_bus.set_scale (obj.get_double_member ("scale"));
-        window.main_window.main_canvas.main_scroll.hadjustment.value = obj.get_double_member ("hadjustment");
-        window.main_window.main_canvas.main_scroll.vadjustment.value = obj.get_double_member ("vadjustment");
+        if (!items_only) {
+            load_window_states (window, obj);
+        }
 
         // Reset the holding state at the end of it.
         window.main_window.main_canvas.canvas.holding = false;
     }
 
-    private void load_item (Json.Object obj, string type) {
+    /*
+     * Deserialize window states and apply them to the window.
+     */
+    private static void load_window_states (Akira.Window window, Json.Object obj) {
+        window.event_bus.set_scale (obj.get_double_member ("scale"));
+        window.main_window.main_canvas.main_scroll.hadjustment.value = obj.get_double_member ("hadjustment");
+        window.main_window.main_canvas.main_scroll.vadjustment.value = obj.get_double_member ("vadjustment");
+    }
+
+    /*
+     * Deserialize item states and apply them to the window.
+     */
+    private static void load_item (Akira.Window window, Json.Object obj, string type) {
         var item = obj.get_member (type).get_object ();
         if (item != null) {
-            //  debug ("loading %s", type);
             window.items_manager.load_item (item);
         }
     }

--- a/src/FileFormat/JsonSerializer.vala
+++ b/src/FileFormat/JsonSerializer.vala
@@ -19,94 +19,99 @@
  * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
-public class Akira.FileFormat.JsonContent : Object {
-    public weak Akira.Window window { get; construct; }
+public class Akira.FileFormat.JsonSerializer {
 
-    private Akira.Lib.Canvas canvas;
-    private Json.Generator generator;
-    private Json.Builder builder;
-
-    public JsonContent (Akira.Window window) {
-        Object (window: window);
-    }
-
-    construct {
-        generator = new Json.Generator ();
-        generator.pretty = true;
-
-        builder = new Json.Builder ();
+    /*
+     * Converts the world (window, and canvas item information) to a Json.Node.
+     * Use this and json_to_string to save Akira's file state.
+     */
+    public static Json.Node world_to_json_node (Akira.Window window, bool items_only = false) {
+        var builder = new Json.Builder ();
         builder.begin_object ();
 
-        canvas = window.main_window.main_canvas.canvas;
+        if (!items_only) {
+            serialize_window_state (window, ref builder);
+        }
+
+        // Convert Artboards to JSON.
+        serialize_artboards (window, ref builder);
+
+        // Convert Items to JSON.
+        serialize_items (window, ref builder);
+
+        builder.end_object ();
+
+        return builder.get_root ();
     }
 
-    public void save_content () {
+    /*
+     * Converts a Json.Node to a string
+     */
+    public static string json_to_string (Json.Node node, bool pretty) {
+        var generator = new Json.Generator ();
+        generator.pretty = pretty;
+        generator.set_root (node);
+        return generator.to_data (null);
+    }
+
+    /*
+     * Serialize window states to the builder.
+     */
+    public static void serialize_window_state ( Akira.Window window, ref Json.Builder builder) {
         // Save the current version of Akira.
         builder.set_member_name ("version");
         builder.add_string_value (Constants.VERSION);
 
         // Save the current Canvas status.
         builder.set_member_name ("scale");
-        builder.add_double_value (canvas.get_scale ());
+        builder.add_double_value (window.main_window.main_canvas.canvas.get_scale ());
         builder.set_member_name ("hadjustment");
         builder.add_double_value (window.main_window.main_canvas.main_scroll.hadjustment.value);
         builder.set_member_name ("vadjustment");
         builder.add_double_value (window.main_window.main_canvas.main_scroll.vadjustment.value);
-
-        // Convert Artboards to JSON.
-        save_artboards ();
-
-        // Convert Items to JSON.
-        save_items ();
     }
 
-    private void save_artboards () {
+    /*
+     * Serialize canvas artboards to the builder.
+     */
+    public static void serialize_artboards ( Akira.Window window, ref Json.Builder builder) {
         builder.set_member_name ("artboards");
         builder.begin_array ();
 
         foreach (var artboard in window.items_manager.artboards) {
-            var item = new JsonObject (artboard);
             builder.begin_object ();
             builder.set_member_name ("artboard");
-            builder.add_value (item.get_node ());
+            builder.add_value (JsonItemSerializer.serialize_item (artboard));
             builder.end_object ();
         }
 
         builder.end_array ();
     }
 
-    private void save_items () {
+    /*
+     * Serialize canvas items to the builder.
+     */
+    public static void serialize_items ( Akira.Window window, ref Json.Builder builder) {
         builder.set_member_name ("items");
         builder.begin_array ();
 
         foreach (var _item in window.items_manager.free_items) {
-            var item = new JsonObject (_item);
             builder.begin_object ();
             builder.set_member_name ("item");
-            builder.add_value (item.get_node ());
+            builder.add_value (JsonItemSerializer.serialize_item (_item));
             builder.end_object ();
         }
 
         // Save all the items inside this Artboard.
         foreach (var artboard in window.items_manager.artboards) {
             foreach (var _item in artboard.items) {
-                var child_item = new JsonObject (_item);
                 builder.begin_object ();
                 builder.set_member_name ("item");
-                builder.add_value (child_item.get_node ());
+                builder.add_value (JsonItemSerializer.serialize_item (_item));
                 builder.end_object ();
             }
         }
 
         builder.end_array ();
-    }
-
-    public string finalize_content () {
-        builder.end_object ();
-
-        Json.Node root = builder.get_root ();
-        generator.set_root (root);
-
-        return generator.to_data (null);
     }
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,9 +21,9 @@ sources = files(
 
     'FileFormat/AkiraFile.vala',
     'FileFormat/FileManager.vala',
-    'FileFormat/JsonContent.vala',
-    'FileFormat/JsonLoader.vala',
-    'FileFormat/JsonObject.vala',
+    'FileFormat/JsonSerializer.vala',
+    'FileFormat/JsonItemSerializer.vala',
+    'FileFormat/JsonDeserializer.vala',
     'FileFormat/ZipArchiveHandler.vala',
 
     'Services/Settings.vala',


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
This PR moves seralization and deseralization into utilities. It is a first step into making the code more reusable and easier to understand. I did not look into improving the API too much, so there is some improvements that could be made there.

