### PR TITLE
Add Size State Manager

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -250,11 +250,11 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             "locked", lock_changes, "active",
             BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
-        width_bind = selected_item.size.bind_property (
+        width_bind = window.size_manager.bind_property (
             "width", width, "value",
             BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
-        height_bind = selected_item.size.bind_property (
+        height_bind = window.size_manager.bind_property (
             "height", height, "value",
             BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -344,15 +344,15 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     public override bool button_release_event (Gdk.EventButton event) {
+        // This is a temporary approach to end operations.
+        // In the future we may want to have more specific method.
+        selected_bound_manager.alert_held_button_release ();
+
         if (!holding) {
             return true;
         }
 
         holding = false;
-
-        // This is a temporary approach to end operations. In the future we may want to have more specific
-        // methods.
-        selected_bound_manager.alert_held_button_release ();
 
         if (event.button == Gdk.BUTTON_MIDDLE) {
             edit_mode = EditMode.MODE_SELECTION;

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -55,7 +55,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     public Managers.ExportManager export_manager;
     public Managers.SelectedBoundManager selected_bound_manager;
-    private Managers.NobManager nob_manager;
+    public Managers.NobManager nob_manager;
     private Managers.HoverManager hover_manager;
 
     public bool ctrl_is_pressed = false;
@@ -394,7 +394,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
 
         if (!holding) {
-            // Only motion_hover_effect
+            // Only motion_hover_effect.
             return false;
         }
 

--- a/src/Lib/Components/Coordinates.vala
+++ b/src/Lib/Components/Coordinates.vala
@@ -23,6 +23,7 @@
  * Coordinates component to keep track of the item's initial coordinates.
  */
 public class Akira.Lib.Components.Coordinates : Component {
+    // Returns the bounds.x1 value updated if the item is inside an artboard.
     public double x {
         get {
             // If the item is an artboard we need to get the bounds of the background since
@@ -43,6 +44,7 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
+    // Returns the global bounds.x1 value.
     public double x1 {
         get {
             // If the item is an artboard we need to get the bounds of the background since
@@ -56,6 +58,7 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
+    // Returns the global bounds.x2 value.
     public double x2 {
         get {
             // If the item is an artboard we need to get the bounds of the background since
@@ -69,6 +72,7 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
+    // Returns the bounds.y1 value updated if the item is inside an artboard.
     public double y {
         get {
             // If the item is an artboard we need to get the bounds of the background since
@@ -89,6 +93,7 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
+    // Returns the global bounds.y1 value.
     public double y1 {
         get {
             // If the item is an artboard we need to get the bounds of the background since
@@ -102,6 +107,7 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
+    // Returns the global bounds.y2 value.
     public double y2 {
         get {
             // If the item is an artboard we need to get the bounds of the background since

--- a/src/Lib/Components/Coordinates.vala
+++ b/src/Lib/Components/Coordinates.vala
@@ -23,7 +23,7 @@
  * Coordinates component to keep track of the item's initial coordinates.
  */
 public class Akira.Lib.Components.Coordinates : Component {
-    // Returns the bounds.x1 value updated if the item is inside an artboard.
+    // LEFT item position, converted to artboard's coordinates if the item is inside an artboard.
     public double x {
         get {
             // If the item is an artboard we need to get the bounds of the background since
@@ -44,7 +44,7 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
-    // Returns the global bounds.x1 value.
+    // Global LEFT item position relative to the Canvas, ignoring potential parent's artboard.
     public double x1 {
         get {
             // If the item is an artboard we need to get the bounds of the background since
@@ -58,7 +58,8 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
-    // Returns the global bounds.x2 value.
+    // Global RIGHT (LEFT + WIDTH) item position relative to the Canvas,
+    // ignoring potential parent's artboard.
     public double x2 {
         get {
             // If the item is an artboard we need to get the bounds of the background since
@@ -72,7 +73,7 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
-    // Returns the bounds.y1 value updated if the item is inside an artboard.
+    // TOP item position, converted to artboard's coordinates if the item is inside an artboard.
     public double y {
         get {
             // If the item is an artboard we need to get the bounds of the background since
@@ -93,7 +94,7 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
-    // Returns the global bounds.y1 value.
+    // Global TOP item position relative to the Canvas, ignoring potential parent's artboard.
     public double y1 {
         get {
             // If the item is an artboard we need to get the bounds of the background since
@@ -107,7 +108,8 @@ public class Akira.Lib.Components.Coordinates : Component {
         }
     }
 
-    // Returns the global bounds.y2 value.
+    // Global BOTTOM (TOP + HEIGHT) item position relative to the Canvas,
+    // ignoring potential parent's artboard.
     public double y2 {
         get {
             // If the item is an artboard we need to get the bounds of the background since

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -66,7 +66,13 @@ public class Akira.Lib.Managers.NobManager : Object {
     private double height_offset_y;
     private double bb_width;
     private double bb_height;
-    Cairo.Matrix bb_matrix;
+    private Cairo.Matrix bb_matrix;
+
+    // Values for the Transform Panel fields.
+    public double selected_x;
+    public double selected_y;
+    public double selected_width;
+    public double selected_height;
 
     // Tracks if an artboard is part of the current selection.
     private bool is_artboard;
@@ -145,7 +151,9 @@ public class Akira.Lib.Managers.NobManager : Object {
         ref double height_offset_x,
         ref double height_offset_y,
         ref double width,
-        ref double height
+        ref double height,
+        ref double selected_x,
+        ref double selected_y
     ) {
         top_left_x = 0;
         top_left_y = 0;
@@ -154,6 +162,11 @@ public class Akira.Lib.Managers.NobManager : Object {
         if (items.length () == 1) {
             var item = items.first ().data;
             item.get_transform (out matrix);
+
+            // Set the coordinates for the transform panel.
+            // Use x and y coordinates to account for the item being inside artboard.
+            selected_x = item.coordinates.x;
+            selected_y = item.coordinates.y;
 
             Cairo.Matrix nob_matrix = matrix;
             if (item.artboard != null) {
@@ -178,17 +191,27 @@ public class Akira.Lib.Managers.NobManager : Object {
         matrix = Cairo.Matrix.identity ();
 
         bool first = true;
+        double x = 0;
+        double y = 0;
         double x1 = 0;
         double y1 = 0;
         double x2 = 0;
         double y2 = 0;
         foreach (var item in items) {
+            // Store the coordinates accounting for items inside artboards.
+            x = first ? item.coordinates.x : double.min (x, item.coordinates.x);
+            y = first ? item.coordinates.y : double.min (y, item.coordinates.y);
+
             x1 = first ? item.coordinates.x1 : double.min (x1, item.coordinates.x1);
             x2 = double.max (x2, item.coordinates.x2);
             y1 = first ? item.coordinates.y1 : double.min (y1, item.coordinates.y1);
             y2 = double.max (y2, item.coordinates.y2);
             first = false;
         }
+
+        // Set the coordinates for the transform panel.
+        selected_x = x;
+        selected_y = y;
 
         width = x2 - x1;
         height = y2 - y1;
@@ -258,47 +281,47 @@ public class Akira.Lib.Managers.NobManager : Object {
     /**
      * Calculates the position of a nob based on a selection of items and the nob id.
      */
-    public static void nob_position_from_items (
-        List<Items.CanvasItem> items,
-        Nob nob_name,
-        ref double pos_x,
-        ref double pos_y
-    ) {
-        Cairo.Matrix dummy_matrix = Cairo.Matrix.identity ();
-        double dummy_top_left_x = 0;
-        double dummy_top_left_y = 0;
-        double dummy_width_offset_x = 0;
-        double dummy_width_offset_y = 0;
-        double dummy_height_offset_x = 0;
-        double dummy_height_offset_y = 0;
-        double dummy_width = 0;
-        double dummy_height = 0;
+    // public static void nob_position_from_items (
+    //     List<Items.CanvasItem> items,
+    //     Nob nob_name,
+    //     ref double pos_x,
+    //     ref double pos_y
+    // ) {
+    //     Cairo.Matrix dummy_matrix = Cairo.Matrix.identity ();
+    //     double dummy_top_left_x = 0;
+    //     double dummy_top_left_y = 0;
+    //     double dummy_width_offset_x = 0;
+    //     double dummy_width_offset_y = 0;
+    //     double dummy_height_offset_x = 0;
+    //     double dummy_height_offset_y = 0;
+    //     double dummy_width = 0;
+    //     double dummy_height = 0;
 
-        populate_nob_bounds_from_items (
-            items,
-            ref dummy_matrix,
-            ref dummy_top_left_x,
-            ref dummy_top_left_y,
-            ref dummy_width_offset_x,
-            ref dummy_width_offset_y,
-            ref dummy_height_offset_x,
-            ref dummy_height_offset_y,
-            ref dummy_width,
-            ref dummy_height
-        );
+    //     populate_nob_bounds_from_items (
+    //         items,
+    //         ref dummy_matrix,
+    //         ref dummy_top_left_x,
+    //         ref dummy_top_left_y,
+    //         ref dummy_width_offset_x,
+    //         ref dummy_width_offset_y,
+    //         ref dummy_height_offset_x,
+    //         ref dummy_height_offset_y,
+    //         ref dummy_width,
+    //         ref dummy_height
+    //     );
 
-        calculate_nob_position (
-            nob_name,
-            dummy_top_left_x,
-            dummy_top_left_y,
-            dummy_width_offset_x,
-            dummy_width_offset_y,
-            dummy_height_offset_x,
-            dummy_height_offset_y,
-            ref pos_x,
-            ref pos_y
-         );
-    }
+    //     calculate_nob_position (
+    //         nob_name,
+    //         dummy_top_left_x,
+    //         dummy_top_left_y,
+    //         dummy_width_offset_x,
+    //         dummy_width_offset_y,
+    //         dummy_height_offset_x,
+    //         dummy_height_offset_y,
+    //         ref pos_x,
+    //         ref pos_y
+    //      );
+    // }
 
     /**
      * What happens when the canvas is zoomed in.
@@ -329,7 +352,9 @@ public class Akira.Lib.Managers.NobManager : Object {
             ref height_offset_x,
             ref height_offset_y,
             ref bb_width,
-            ref bb_height
+            ref bb_height,
+            ref selected_x,
+            ref selected_y
         );
 
         update_select_effect (selected_items);

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -153,7 +153,9 @@ public class Akira.Lib.Managers.NobManager : Object {
         ref double width,
         ref double height,
         ref double selected_x,
-        ref double selected_y
+        ref double selected_y,
+        ref double selected_width,
+        ref double selected_height
     ) {
         top_left_x = 0;
         top_left_y = 0;
@@ -175,8 +177,8 @@ public class Akira.Lib.Managers.NobManager : Object {
                 nob_matrix.multiply (matrix, artboard_matrix);
             }
 
-            width = item.size.width;
-            height = item.size.height;
+            width = selected_width = item.size.width;
+            height = selected_height = item.size.height;
 
             width_offset_x = width;
             width_offset_y = 0;
@@ -354,7 +356,9 @@ public class Akira.Lib.Managers.NobManager : Object {
             ref bb_width,
             ref bb_height,
             ref selected_x,
-            ref selected_y
+            ref selected_y,
+            ref selected_width,
+            ref selected_height
         );
 
         update_select_effect (selected_items);

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -215,8 +215,8 @@ public class Akira.Lib.Managers.NobManager : Object {
         selected_x = x;
         selected_y = y;
 
-        width = x2 - x1;
-        height = y2 - y1;
+        width = selected_width = x2 - x1;
+        height = selected_height = y2 - y1;
 
         top_left_x = x1;
         top_left_y = y1;
@@ -283,47 +283,55 @@ public class Akira.Lib.Managers.NobManager : Object {
     /**
      * Calculates the position of a nob based on a selection of items and the nob id.
      */
-    // public static void nob_position_from_items (
-    //     List<Items.CanvasItem> items,
-    //     Nob nob_name,
-    //     ref double pos_x,
-    //     ref double pos_y
-    // ) {
-    //     Cairo.Matrix dummy_matrix = Cairo.Matrix.identity ();
-    //     double dummy_top_left_x = 0;
-    //     double dummy_top_left_y = 0;
-    //     double dummy_width_offset_x = 0;
-    //     double dummy_width_offset_y = 0;
-    //     double dummy_height_offset_x = 0;
-    //     double dummy_height_offset_y = 0;
-    //     double dummy_width = 0;
-    //     double dummy_height = 0;
+    public static void nob_position_from_items (
+        List<Items.CanvasItem> items,
+        Nob nob_name,
+        ref double pos_x,
+        ref double pos_y
+    ) {
+        Cairo.Matrix dummy_matrix = Cairo.Matrix.identity ();
+        double dummy_top_left_x = 0;
+        double dummy_top_left_y = 0;
+        double dummy_width_offset_x = 0;
+        double dummy_width_offset_y = 0;
+        double dummy_height_offset_x = 0;
+        double dummy_height_offset_y = 0;
+        double dummy_width = 0;
+        double dummy_height = 0;
+        double dummy_selected_x = 0;
+        double dummy_selected_y = 0;
+        double dummy_selected_width = 0;
+        double dummy_selected_height = 0;
 
-    //     populate_nob_bounds_from_items (
-    //         items,
-    //         ref dummy_matrix,
-    //         ref dummy_top_left_x,
-    //         ref dummy_top_left_y,
-    //         ref dummy_width_offset_x,
-    //         ref dummy_width_offset_y,
-    //         ref dummy_height_offset_x,
-    //         ref dummy_height_offset_y,
-    //         ref dummy_width,
-    //         ref dummy_height
-    //     );
+        populate_nob_bounds_from_items (
+            items,
+            ref dummy_matrix,
+            ref dummy_top_left_x,
+            ref dummy_top_left_y,
+            ref dummy_width_offset_x,
+            ref dummy_width_offset_y,
+            ref dummy_height_offset_x,
+            ref dummy_height_offset_y,
+            ref dummy_width,
+            ref dummy_height,
+            ref dummy_selected_x,
+            ref dummy_selected_y,
+            ref dummy_selected_width,
+            ref dummy_selected_height
+        );
 
-    //     calculate_nob_position (
-    //         nob_name,
-    //         dummy_top_left_x,
-    //         dummy_top_left_y,
-    //         dummy_width_offset_x,
-    //         dummy_width_offset_y,
-    //         dummy_height_offset_x,
-    //         dummy_height_offset_y,
-    //         ref pos_x,
-    //         ref pos_y
-    //      );
-    // }
+        calculate_nob_position (
+            nob_name,
+            dummy_top_left_x,
+            dummy_top_left_y,
+            dummy_width_offset_x,
+            dummy_width_offset_y,
+            dummy_height_offset_x,
+            dummy_height_offset_y,
+            ref pos_x,
+            ref pos_y
+         );
+    }
 
     /**
      * What happens when the canvas is zoomed in.

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -64,15 +64,15 @@ public class Akira.Lib.Managers.NobManager : Object {
     private double width_offset_y;
     private double height_offset_x;
     private double height_offset_y;
-    private double bb_width;
-    private double bb_height;
+    // bb_width and bb_height are also used by the SizeManager to represent
+    // the width and height of selected items in the Transform Panel.
+    public double bb_width;
+    public double bb_height;
     private Cairo.Matrix bb_matrix;
 
     // Values for the Transform Panel fields.
-    public double selected_x;
-    public double selected_y;
-    public double selected_width;
-    public double selected_height;
+    private double selected_x;
+    private double selected_y;
 
     // Tracks if an artboard is part of the current selection.
     private bool is_artboard;
@@ -153,9 +153,7 @@ public class Akira.Lib.Managers.NobManager : Object {
         ref double width,
         ref double height,
         ref double selected_x,
-        ref double selected_y,
-        ref double selected_width,
-        ref double selected_height
+        ref double selected_y
     ) {
         top_left_x = 0;
         top_left_y = 0;
@@ -177,8 +175,8 @@ public class Akira.Lib.Managers.NobManager : Object {
                 nob_matrix.multiply (matrix, artboard_matrix);
             }
 
-            width = selected_width = item.size.width;
-            height = selected_height = item.size.height;
+            width = item.size.width;
+            height = item.size.height;
 
             width_offset_x = width;
             width_offset_y = 0;
@@ -215,8 +213,8 @@ public class Akira.Lib.Managers.NobManager : Object {
         selected_x = x;
         selected_y = y;
 
-        width = selected_width = x2 - x1;
-        height = selected_height = y2 - y1;
+        width = x2 - x1;
+        height = y2 - y1;
 
         top_left_x = x1;
         top_left_y = y1;
@@ -300,8 +298,6 @@ public class Akira.Lib.Managers.NobManager : Object {
         double dummy_height = 0;
         double dummy_selected_x = 0;
         double dummy_selected_y = 0;
-        double dummy_selected_width = 0;
-        double dummy_selected_height = 0;
 
         populate_nob_bounds_from_items (
             items,
@@ -315,9 +311,7 @@ public class Akira.Lib.Managers.NobManager : Object {
             ref dummy_width,
             ref dummy_height,
             ref dummy_selected_x,
-            ref dummy_selected_y,
-            ref dummy_selected_width,
-            ref dummy_selected_height
+            ref dummy_selected_y
         );
 
         calculate_nob_position (
@@ -364,9 +358,7 @@ public class Akira.Lib.Managers.NobManager : Object {
             ref bb_width,
             ref bb_height,
             ref selected_x,
-            ref selected_y,
-            ref selected_width,
-            ref selected_height
+            ref selected_y
         );
 
         update_select_effect (selected_items);

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -66,8 +66,8 @@ public class Akira.Lib.Managers.NobManager : Object {
     private double height_offset_y;
     // bb_width and bb_height are also used by the SizeManager to represent
     // the width and height of selected items in the Transform Panel.
-    public double bb_width;
-    public double bb_height;
+    private double bb_width;
+    private double bb_height;
     private Cairo.Matrix bb_matrix;
 
     // Values for the Transform Panel fields.

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -429,7 +429,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         }
     }
 
-    private void scale_from_event (
+    public void scale_from_event (
         Lib.Items.CanvasItem item,
         Managers.NobManager.Nob selected_nob,
         double event_x,

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -133,7 +133,7 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         }
 
         // Notify the X & Y values in the state manager.
-        canvas.window.event_bus.reset_state_coords (selected_item);
+        canvas.window.event_bus.reset_state_coords ();
     }
 
     public void add_item_to_selection (Items.CanvasItem item) {
@@ -149,10 +149,9 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         item.layer.selected = true;
         item.size.update_ratio ();
 
-        // Initialize the state manager coordinates before adding the item to the selection.
-        canvas.window.event_bus.init_state_coords (item);
-
         selected_items.append (item);
+        // Initialize the state manager coordinates.
+        canvas.window.event_bus.init_state_coords ();
 
         // Move focus back to the canvas.
         canvas.window.event_bus.set_focus_on_canvas ();

--- a/src/Lib/Managers/SelectedBoundManager.vala
+++ b/src/Lib/Managers/SelectedBoundManager.vala
@@ -339,7 +339,12 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
     /**
      * Move the item based on the mouse click and drag event.
      */
-    private void move_from_event (Lib.Items.CanvasItem item, double event_x, double event_y) {
+    public void move_from_event (
+        Lib.Items.CanvasItem item,
+        double event_x,
+        double event_y,
+        bool ignore_offset = false
+    ) {
         if (!initial_drag_registered) {
             initial_drag_registered = true;
             initial_drag_item_x = item.coordinates.x;
@@ -356,8 +361,8 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         var delta_x = event_x - initial_drag_press_x;
         var delta_y = event_y - initial_drag_press_y;
 
-        // Keep reset and delta values for future adjustments. fix_size should.
-        // be called right before a transform.
+        // Keep reset and delta values for future adjustments.
+        // fix_size should be called right before a transform.
         var first_move_x = Utils.AffineTransform.fix_size (delta_x - reset_x);
         var first_move_y = Utils.AffineTransform.fix_size (delta_y - reset_y);
 
@@ -388,6 +393,14 @@ public class Akira.Lib.Managers.SelectedBoundManager : Object {
         int snap_offset_x = 0;
         int snap_offset_y = 0;
         var matches = Utils.Snapping.generate_snap_matches (snap_grid, selected_items, sensitivity);
+
+        // Don't force the offset translation on items. This is mostly
+        // used when moving items from the Transform Panel where we want to show
+        // the snapping guides but ignore the magnetic effect.
+        if (ignore_offset) {
+            update_grid_decorators (true);
+            return;
+        }
 
         if (matches.h_data.snap_found ()) {
             snap_offset_x = matches.h_data.snap_offset ();

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -54,8 +54,8 @@ public class Akira.Services.EventBus : Object {
 
     // Options panel signals.
     public signal void align_items (string align_action);
-    public signal void init_state_coords (Lib.Items.CanvasItem item);
-    public signal void reset_state_coords (Lib.Items.CanvasItem item);
+    public signal void init_state_coords ();
+    public signal void reset_state_coords ();
     public signal void update_state_coords (double moved_x, double moved_y);
     public signal void item_value_changed ();
 

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
  *
  * This file is part of Akira.
@@ -19,7 +19,7 @@
  * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
- /*
+ /**
   * State manager handling the currently selected objects coordinates.
   * This is used to guarantee correct values in the Transform Panel no matter
   * if one or multiple items are selected.
@@ -80,7 +80,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         window.event_bus.update_state_coords.connect (on_update_state_coords);
     }
 
-    /*
+    /**
      * Initialize the manager coordinates with the selected items coordinates.
      * The coordinates change comes from a canvas action that already moved the items,
      * therefore we set the do_update to false to prevent updating the selected
@@ -96,7 +96,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         do_update = true;
     }
 
-    /*
+    /**
      * Update the coordinates to trigger the shapes transformation.
      * This action comes from an arrow keypress event from the Canvas.
      */
@@ -107,7 +107,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         window.event_bus.file_edited ();
     }
 
-    /*
+    /**
      * Reset the coordinates to get the newly updated coordinates from the selected items.
      * This method is called when items are moved from the canvas, so we only need to update
      * the X and Y values for the Transform Panel without triggering the update_items_*().
@@ -119,7 +119,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         window.event_bus.file_edited ();
     }
 
-    /*
+    /**
      * Update the position of all selected items.
      */
      private void update_items_x () {
@@ -146,7 +146,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         window.event_bus.item_value_changed ();
     }
 
-    /*
+    /**
      * Update the position of all selected items.
      */
     private void update_items_y () {

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -1,24 +1,29 @@
 /*
-* Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
-*
-* This file is part of Akira.
-*
-* Akira is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
 
-* Akira is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
 
-* You should have received a copy of the GNU General Public License
-* along with Akira. If not, see <https://www.gnu.org/licenses/>.
-*
-* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
-*/
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+ */
 
+ /*
+  * State manager handling the currently selected objects coordinates.
+  * This is used to guarantee correct values in the Transform Panel no matter
+  * if one or multiple items are selected.
+  */
 public class Akira.StateManagers.CoordinatesManager : Object {
     public weak Akira.Window window { get; construct; }
     private weak Akira.Lib.Canvas canvas;
@@ -75,27 +80,25 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         window.event_bus.update_state_coords.connect (on_update_state_coords);
     }
 
-    /**
-     * Initialize the manager coordinates with the newly created or selected item.
+    /*
+     * Initialize the manager coordinates with the selected items coordinates.
+     * The coordinates change comes from a canvas action that already moved the items,
+     * therefore we set the do_update to false to prevent updating the selected
+     * items' Cairo Matrix.
      */
-    private void on_init_state_coords (Lib.Items.CanvasItem item) {
+    private void on_init_state_coords () {
+        do_update = false;
+
         // Get the item X & Y coordinates.
-        double item_x = item.coordinates.x;
-        double item_y = item.coordinates.y;
+        x = canvas.nob_manager.selected_x;
+        y = canvas.nob_manager.selected_y;
 
-        // Interrupt if no value has changed.
-        if (item_x == x && item_y == y) {
-            return;
-        }
-
-        // Update the private attributes and not the public as we don't want to trigger the
-        // update_items_coordinates () when a new item is created.
-        _x = item_x;
-        _y = item_y;
+        do_update = true;
     }
 
-    /**
+    /*
      * Update the coordinates to trigger the shapes transformation.
+     * This action comes from an arrow keypress event from the Canvas.
      */
     private void on_update_state_coords (double moved_x, double moved_y) {
         x += moved_x;
@@ -104,39 +107,23 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         window.event_bus.file_edited ();
     }
 
-    /**
-     * Reset the coordinates to get the newly updated coordinates from the item.
-     * The coordinates change came from a canvas action that already moved the items
-     * therefore we set the d_update to false to prevent updating  the selected
-     * items Cairo transform.
+    /*
+     * Reset the coordinates to get the newly updated coordinates from the selected items.
+     * This method is called when items are moved from the canvas, so we only need to update
+     * the X and Y values for the Transform Panel without triggering the update_items_coordinates().
      */
-    private void on_reset_state_coords (Lib.Items.CanvasItem item) {
-        do_update = false;
-
-        // Get the item X & Y coordinates.
-        double item_x = item.coordinates.x;
-        double item_y = item.coordinates.y;
-
-        // Interrupt if no value has changed.
-        if (item_x == x && item_y == y) {
-            do_update = true;
-            return;
-        }
-
-        x = item_x;
-        y = item_y;
-
-        do_update = true;
+    private void on_reset_state_coords () {
+        on_init_state_coords ();
 
         window.event_bus.item_value_changed ();
         window.event_bus.file_edited ();
     }
 
-    /**
-     * Get the newly updated coordinates update the position of all the selected items.
+    /*
+     * Get the newly updated coordinates and update the position of all selected items.
      */
     private void update_items_coordinates () {
-        if (_x == null || _y == null) {
+        if (_x == null || _y == null || !do_update) {
             return;
         }
 
@@ -144,20 +131,12 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         // since we currently support only 1 selected item per time. In the future, we will need
         // to account for multiple items and their relative position between each other.
         foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
-            if (!do_update) {
-                continue;
-            }
-
-            // Store the new coordinates in local variables so we can manipulate them.
-            double inc_x = x - item.coordinates.x;
-            double inc_y = y - item.coordinates.y;
-
             Cairo.Matrix matrix;
             item.get_transform (out matrix);
 
             // Increment the cairo matrix coordinates so we can ignore the item's rotation.
-            matrix.x0 += inc_x;
-            matrix.y0 += inc_y;
+            matrix.x0 += Utils.AffineTransform.fix_size (x - item.coordinates.x);
+            matrix.y0 += Utils.AffineTransform.fix_size (y - item.coordinates.y);
 
             item.set_transform (matrix);
 

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -28,8 +28,10 @@ public class Akira.StateManagers.CoordinatesManager : Object {
     public weak Akira.Window window { get; construct; }
     private weak Akira.Lib.Canvas canvas;
 
-    private double selected_x;
-    private double selected_y;
+    // Store the initial coordinates of the item before the values are edited by
+    // the user interacting with the Transform Panel fields.
+    private double initial_x;
+    private double initial_y;
 
     // These attributes represent only the primary X & Y coordinates of the selected shapes.
     // These are not the origin points of each selected shape, but only the TOP-LEFT values
@@ -95,8 +97,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         double dummy_height = 0;
 
         // Reset the selected coordinates to always get correct values.
-        selected_x = 0;
-        selected_y = 0;
+        initial_x = 0;
+        initial_y = 0;
 
         Lib.Managers.NobManager.populate_nob_bounds_from_items (
             canvas.selected_bound_manager.selected_items,
@@ -109,8 +111,8 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             ref dummy_height_offset_y,
             ref dummy_width,
             ref dummy_height,
-            ref selected_x,
-            ref selected_y
+            ref initial_x,
+            ref initial_y
         );
     }
 
@@ -123,11 +125,11 @@ public class Akira.StateManagers.CoordinatesManager : Object {
     private void on_init_state_coords () {
         do_update = false;
 
-        // Get the item X & Y coordinates.
+        // Get the items X & Y coordinates.
         get_coordinates_from_items ();
 
-        x = selected_x;
-        y = selected_y;
+        x = initial_x;
+        y = initial_y;
 
         do_update = true;
     }
@@ -166,7 +168,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
         // Get the current item X & Y coordinates before translating.
         get_coordinates_from_items ();
         // Reset the SelectedBoundManager initial coordinates.
-        canvas.selected_bound_manager.set_initial_coordinates (selected_x, selected_y);
+        canvas.selected_bound_manager.set_initial_coordinates (initial_x, initial_y);
 
         // Loop through all the selected items to update their position.
         foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -127,17 +127,23 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             return;
         }
 
+        // Get the correct moved amount in order to translate all the selected items equally.
+        var delta_x = x - canvas.nob_manager.selected_x;
+
         // Loop through all the selected items to update their position.
         foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
             Cairo.Matrix matrix;
             item.get_transform (out matrix);
 
             // Increment the cairo matrix coordinates so we can ignore the item's rotation.
-            matrix.x0 += Utils.AffineTransform.fix_size (x - item.coordinates.x);
+            matrix.x0 += Utils.AffineTransform.fix_size (delta_x);
             item.set_transform (matrix);
 
-            window.event_bus.item_value_changed ();
+            // GooCanvasItem issue! This is necessary to properly update the CanvasBounds.
+            item.ensure_updated ();
         }
+
+        window.event_bus.item_value_changed ();
     }
 
     /*
@@ -148,16 +154,22 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             return;
         }
 
+        // Get the correct moved amount in order to translate all the selected items equally.
+        var delta_y = y - canvas.nob_manager.selected_y;
+
         // Loop through all the selected items to update their position.
         foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
             Cairo.Matrix matrix;
             item.get_transform (out matrix);
 
             // Increment the cairo matrix coordinates so we can ignore the item's rotation.
-            matrix.y0 += Utils.AffineTransform.fix_size (y - item.coordinates.y);
+            matrix.y0 += Utils.AffineTransform.fix_size (delta_y);
             item.set_transform (matrix);
 
-            window.event_bus.item_value_changed ();
+            // GooCanvasItem issue! This is necessary to properly update the CanvasBounds.
+            item.ensure_updated ();
         }
+
+        window.event_bus.item_value_changed ();
     }
 }

--- a/src/StateManagers/CoordinatesManager.vala
+++ b/src/StateManagers/CoordinatesManager.vala
@@ -30,7 +30,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
 
     // These attributes represent only the primary X & Y coordinates of the selected shapes.
     // These are not the origin points of each selected shape, but only the TOP-LEFT values
-    // of the selection bounding box.
+    // of the bounding box selection.
     private double? _x = null;
     public double x {
         get {
@@ -42,7 +42,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             }
 
             _x = Utils.AffineTransform.fix_size (value);
-            update_items_coordinates ();
+            update_items_x ();
         }
     }
 
@@ -57,7 +57,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
             }
 
             _y = Utils.AffineTransform.fix_size (value);
-            update_items_coordinates ();
+            update_items_y ();
         }
     }
 
@@ -110,7 +110,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
     /*
      * Reset the coordinates to get the newly updated coordinates from the selected items.
      * This method is called when items are moved from the canvas, so we only need to update
-     * the X and Y values for the Transform Panel without triggering the update_items_coordinates().
+     * the X and Y values for the Transform Panel without triggering the update_items_*().
      */
     private void on_reset_state_coords () {
         on_init_state_coords ();
@@ -120,24 +120,41 @@ public class Akira.StateManagers.CoordinatesManager : Object {
     }
 
     /*
-     * Get the newly updated coordinates and update the position of all selected items.
+     * Update the position of all selected items.
      */
-    private void update_items_coordinates () {
-        if (_x == null || _y == null || !do_update) {
+     private void update_items_x () {
+        if (_x == null || !do_update) {
             return;
         }
 
-        // Loop through all the selected items to update their position. This is temporary
-        // since we currently support only 1 selected item per time. In the future, we will need
-        // to account for multiple items and their relative position between each other.
+        // Loop through all the selected items to update their position.
         foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
             Cairo.Matrix matrix;
             item.get_transform (out matrix);
 
             // Increment the cairo matrix coordinates so we can ignore the item's rotation.
             matrix.x0 += Utils.AffineTransform.fix_size (x - item.coordinates.x);
-            matrix.y0 += Utils.AffineTransform.fix_size (y - item.coordinates.y);
+            item.set_transform (matrix);
 
+            window.event_bus.item_value_changed ();
+        }
+    }
+
+    /*
+     * Update the position of all selected items.
+     */
+    private void update_items_y () {
+        if (_y == null || !do_update) {
+            return;
+        }
+
+        // Loop through all the selected items to update their position.
+        foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
+            Cairo.Matrix matrix;
+            item.get_transform (out matrix);
+
+            // Increment the cairo matrix coordinates so we can ignore the item's rotation.
+            matrix.y0 += Utils.AffineTransform.fix_size (y - item.coordinates.y);
             item.set_transform (matrix);
 
             window.event_bus.item_value_changed ();

--- a/src/StateManagers/SizeManager.vala
+++ b/src/StateManagers/SizeManager.vala
@@ -89,8 +89,8 @@ public class Akira.StateManagers.SizeManager : Object {
         do_update = false;
 
         // Get the item WIDTH & HEIGHT.
-        width = canvas.nob_manager.selected_width;
-        height = canvas.nob_manager.selected_height;
+        width = canvas.nob_manager.bb_width;
+        height = canvas.nob_manager.bb_height;
 
         do_update = true;
     }
@@ -125,7 +125,7 @@ public class Akira.StateManagers.SizeManager : Object {
         }
 
         // Get the correct modified amount in order to resize all the selected items equally.
-        var delta_w = width - canvas.nob_manager.selected_width;
+        var delta_w = width - canvas.nob_manager.bb_width;
 
         // Loop through all the selected items to update their width.
         foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
@@ -142,7 +142,7 @@ public class Akira.StateManagers.SizeManager : Object {
         }
 
         // Get the correct modified amount in order to resize all the selected items equally.
-        var delta_h = height - canvas.nob_manager.selected_height;
+        var delta_h = height - canvas.nob_manager.bb_height;
 
         // Loop through all the selected items to update their height.
         foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {

--- a/src/StateManagers/SizeManager.vala
+++ b/src/StateManagers/SizeManager.vala
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2021 Alecaddd (https://alecaddd.com)
  *
  * This file is part of Akira.
@@ -19,7 +19,7 @@
  * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
- /*
+ /**
   * State manager handling the currently selected objects sizings.
   * This is used to guarantee correct values in the Transform Panel no matter
   * if one or multiple items are selected.
@@ -79,7 +79,7 @@ public class Akira.StateManagers.SizeManager : Object {
         window.event_bus.reset_state_coords.connect (on_reset_state_coords);
     }
 
-    /*
+    /**
      * Initialize the manager sizes with the selected items sizes.
      * The sizes change comes from a canvas action that already moved the items,
      * therefore we set the do_update to false to prevent updating the selected
@@ -95,7 +95,7 @@ public class Akira.StateManagers.SizeManager : Object {
         do_update = true;
     }
 
-    /*
+    /**
      * Reset the sizes to get the newly updated sizes from the selected items.
      * This method is called when items are resized from the canvas, so we only need to update
      * the WIDTH & HEIGHT values for the Transform Panel without triggering the update_items_size().
@@ -107,7 +107,7 @@ public class Akira.StateManagers.SizeManager : Object {
         window.event_bus.file_edited ();
     }
 
-    /*
+    /**
      * =========== INFO ===========
      * We don't update width and height in the same method for 2 reasons:
      * 1. It's impossible for the user to update both values when interacting with
@@ -116,7 +116,7 @@ public class Akira.StateManagers.SizeManager : Object {
      *    as the locked size will be properly updated when one of the values changes.
      */
 
-    /*
+    /**
      * Update the width of all selected items.
      */
      private void update_items_width () {
@@ -124,14 +124,16 @@ public class Akira.StateManagers.SizeManager : Object {
             return;
         }
 
+        // Get the correct modified amount in order to resize all the selected items equally.
+        var delta_w = width - canvas.nob_manager.selected_width;
+
         // Loop through all the selected items to update their width.
         foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
-            var delta_w = width - item.size.width;
             item.size.width += delta_w;
         }
     }
 
-    /*
+    /**
      * Update the height of all selected items.
      */
      private void update_items_height () {
@@ -139,9 +141,11 @@ public class Akira.StateManagers.SizeManager : Object {
             return;
         }
 
+        // Get the correct modified amount in order to resize all the selected items equally.
+        var delta_h = height - canvas.nob_manager.selected_height;
+
         // Loop through all the selected items to update their height.
         foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
-            var delta_h = height - item.size.height;
             item.size.height += delta_h;
         }
     }

--- a/src/StateManagers/SizeManager.vala
+++ b/src/StateManagers/SizeManager.vala
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+ */
+
+ /*
+  * State manager handling the currently selected objects sizings.
+  * This is used to guarantee correct values in the Transform Panel no matter
+  * if one or multiple items are selected.
+  */
+public class Akira.StateManagers.SizeManager : Object {
+    public weak Akira.Window window { get; construct; }
+    private weak Akira.Lib.Canvas canvas;
+
+    // Allow or deny updating the items size.
+    private bool do_update = true;
+
+    // These attributes represent only the primary WIDTH & HEIGHT coordinates of the selected shapes.
+    // These are not the original sizes of each selected shape, but only the BOTTOM-RIGHT values
+    // of the bounding box selection.
+    private double? _width = null;
+    public double width {
+        get {
+            return _width != null ? _width : 0;
+        }
+        set {
+            if (value == _width) {
+                return;
+            }
+
+            _width = Utils.AffineTransform.fix_size (value);
+            update_items_width ();
+        }
+    }
+
+    private double? _height = null;
+    public double height {
+        get {
+            return _height != null ? _height : 0;
+        }
+        set {
+            if (value == _height) {
+                return;
+            }
+
+            _height = Utils.AffineTransform.fix_size (value);
+            update_items_height ();
+        }
+    }
+
+    public SizeManager (Akira.Window window) {
+        Object (
+            window: window
+        );
+    }
+
+    construct {
+        // Get the canvas on construct as we will need to use its methods.
+        canvas = window.main_window.main_canvas.canvas;
+
+        // Initialize event listeners.
+        window.event_bus.init_state_coords.connect (on_init_state_coords);
+        window.event_bus.reset_state_coords.connect (on_reset_state_coords);
+    }
+
+    /*
+     * Initialize the manager sizes with the selected items sizes.
+     * The sizes change comes from a canvas action that already moved the items,
+     * therefore we set the do_update to false to prevent updating the selected
+     * items' Cairo Matrix.
+     */
+     private void on_init_state_coords () {
+        do_update = false;
+
+        // Get the item WIDTH & HEIGHT.
+        width = canvas.nob_manager.selected_width;
+        height = canvas.nob_manager.selected_height;
+
+        do_update = true;
+    }
+
+    /*
+     * Reset the sizes to get the newly updated sizes from the selected items.
+     * This method is called when items are resized from the canvas, so we only need to update
+     * the WIDTH & HEIGHT values for the Transform Panel without triggering the update_items_size().
+     */
+    private void on_reset_state_coords () {
+        on_init_state_coords ();
+
+        window.event_bus.item_value_changed ();
+        window.event_bus.file_edited ();
+    }
+
+    /*
+     * =========== INFO ===========
+     * We don't update width and height in the same method for 2 reasons:
+     * 1. It's impossible for the user to update both values when interacting with
+     *    the Transform panel as only once field cna be edited at the time.
+     * 2. We need to let the Size component handle the locked ratio independently
+     *    as the locked size will be properly updated when one of the values changes.
+     */
+
+    /*
+     * Update the width of all selected items.
+     */
+     private void update_items_width () {
+        if (_width == null || !do_update) {
+            return;
+        }
+
+        // Loop through all the selected items to update their width.
+        foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
+            var delta_w = width - item.size.width;
+            item.size.width += delta_w;
+        }
+    }
+
+    /*
+     * Update the height of all selected items.
+     */
+     private void update_items_height () {
+        if (_height == null || !do_update) {
+            return;
+        }
+
+        // Loop through all the selected items to update their height.
+        foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
+            var delta_h = height - item.size.height;
+            item.size.height += delta_h;
+        }
+    }
+}

--- a/src/StateManagers/SizeManager.vala
+++ b/src/StateManagers/SizeManager.vala
@@ -153,19 +153,16 @@ public class Akira.StateManagers.SizeManager : Object {
             return;
         }
 
-        // Get the current item WIDTH & HEIGHT before translating.
-        get_size_from_items ();
-        // Reset the SelectedBoundManager initial coordinates.
-        canvas.selected_bound_manager.set_initial_coordinates (initial_width, initial_height);
-
-        // Simulate the proper Nob selection based on the resized value.
-        var nob = width != initial_width ?
-            Lib.Managers.NobManager.Nob.RIGHT_CENTER :
-            Lib.Managers.NobManager.Nob.BOTTOM_CENTER;
-
-        // Loop through all the selected items to update their width.
+        // Loop through all the selected items to update their size.
         foreach (Lib.Items.CanvasItem item in canvas.selected_bound_manager.selected_items) {
-            canvas.selected_bound_manager.scale_from_event (item, nob, width, height);
+            // TODO: We're temporarily applying the exact same size to all selected items.
+            // This will change once we implement the multi select and the ability to resize
+            // and translate multiple items relative to their position.
+            var delta_h = height - item.size.height;
+            var delta_w = width - item.size.width;
+
+            item.size.width += delta_w;
+            item.size.height += delta_h;
         }
     }
 }

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -33,6 +33,7 @@ public class Akira.Window : Gtk.ApplicationWindow {
     public Akira.Utils.Dialogs dialogs;
 
     public Akira.StateManagers.CoordinatesManager coords_manager;
+    public Akira.StateManagers.SizeManager size_manager;
 
     public SimpleActionGroup actions { get; construct; }
     public Gtk.AccelGroup accel_group { get; construct; }
@@ -58,6 +59,7 @@ public class Akira.Window : Gtk.ApplicationWindow {
         headerbar = new Akira.Layouts.HeaderBar (this);
         main_window = new Akira.Layouts.MainWindow (this);
         coords_manager = new Akira.StateManagers.CoordinatesManager (this);
+        size_manager = new Akira.StateManagers.SizeManager (this);
         dialogs = new Akira.Utils.Dialogs (this);
 
         build_ui ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -112,6 +112,7 @@ sources = files(
     'Lib/Selection/Nob.vala',
 
     'StateManagers/CoordinatesManager.vala',
+    'StateManagers/SizeManager.vala',
 )
 
 deps = [


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
This PR adds a `SizeManager` in order to properly handle sizing for multiple selected items when interacting with the Transform Panel. It also updates the `CoordinatesManager` in order to follow the same approach, as well as removing unnecessary methods, and reducing the calls to update attributes when not necessary.

## Steps to Test
Create a bunch of items and try to move them around and resize them exclusively via the Transform Panel fields.
**DISCLAIMER**: The Rotation field is not properly hooked yet, so rotating via the Transform Panel doesn't properly update the X & Y coordinates like it happens when rotating from the canvas.

## Known Issues / Things To Do
- Implement remaining managers for rotation, flipping, and opacity.

## This PR fixes/implements the following **bugs/features**:
- Limit the number of calls to update attributes by only triggering the update of each single field when edited.
- Remove attributes from some events to simplify the code.
- Translate and Resize via the Transform Panel is done via absolute values instead of relative, in preparation of multi selection.
