### PR TITLE
Use the new elementary OS 6 stylesheet

### DIFF
--- a/data/css/headerbar.css
+++ b/data/css/headerbar.css
@@ -13,3 +13,14 @@
 .export-titlebar {
     padding: 0;
 }
+
+/* Temporary elementary OS 6 stylesheet fixes */
+button.flat:disabled {
+    background-color: transparent;
+    box-shadow: none;
+    border: none;
+}
+
+popover.menu stack {
+    padding: 6px 10px;
+}

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -108,7 +108,7 @@ public class Akira.Application : Gtk.Application {
 
     protected override void activate () {
         Gtk.Settings.get_default ().set_property ("gtk-icon-theme-name", "elementary");
-        Gtk.Settings.get_default ().set_property ("gtk-theme-name", "elementary");
+        Gtk.Settings.get_default ().set_property ("gtk-theme-name", "io.elementary.stylesheet.blueberry");
 
         weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
         default_theme.add_resource_path ("/com/github/akiraux/akira");


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
elementary OS 6 just updated their stylesheet in preparation of their beta release and removed the previously named `elementary` Gtk Theme.

This is a temporary fix as they will soon release an update SDK we can embed in the application.
The new default theme is now called `io.elementary.stylesheet.blueberry`

Pinging @bilelmoussaoui on this to see if we need to do anything on our flatpak file.