### PR TITLE
Rename State Managers to Middleware

### DIFF
--- a/src/Layouts/Partials/TransformPanel.vala
+++ b/src/Layouts/Partials/TransformPanel.vala
@@ -238,11 +238,11 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
     private void enable () {
         canvas = selected_item.canvas as Akira.Lib.Canvas;
 
-        x_bind = window.coords_manager.bind_property (
+        x_bind = window.coords_middleware.bind_property (
             "x", x, "value", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL
         );
 
-        y_bind = window.coords_manager.bind_property (
+        y_bind = window.coords_middleware.bind_property (
             "y", y, "value", BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL
         );
 
@@ -250,11 +250,11 @@ public class Akira.Layouts.Partials.TransformPanel : Gtk.Grid {
             "locked", lock_changes, "active",
             BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
-        width_bind = window.size_manager.bind_property (
+        width_bind = window.size_middleware.bind_property (
             "width", width, "value",
             BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 
-        height_bind = window.size_manager.bind_property (
+        height_bind = window.size_middleware.bind_property (
             "height", height, "value",
             BindingFlags.SYNC_CREATE | BindingFlags.BIDIRECTIONAL);
 

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -64,7 +64,7 @@ public class Akira.Lib.Managers.NobManager : Object {
     private double width_offset_y;
     private double height_offset_x;
     private double height_offset_y;
-    // bb_width and bb_height are also used by the SizeManager to represent
+    // bb_width and bb_height are also used by the SizeMiddleware to represent
     // the width and height of selected items in the Transform Panel.
     private double bb_width;
     private double bb_height;

--- a/src/Middlewares/CoordinatesMiddleware.vala
+++ b/src/Middlewares/CoordinatesMiddleware.vala
@@ -19,12 +19,13 @@
  * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
- /**
-  * State manager handling the currently selected objects coordinates.
-  * This is used to guarantee correct values in the Transform Panel no matter
-  * if one or multiple items are selected.
-  */
-public class Akira.StateManagers.CoordinatesManager : Object {
+/**
+ * Middleware handling the currently selected objects coordinates with the Transform Panel.
+ * This is used to guarantee correct values in the Transform Panel no matter if one or
+ * multiple items are selected, and to always return the true items' coordinates which
+ * are held by the GooCanvasItem.
+ */
+public class Akira.StateManagers.CoordinatesMiddleware : Object {
     public weak Akira.Window window { get; construct; }
     private weak Akira.Lib.Canvas canvas;
 
@@ -69,7 +70,7 @@ public class Akira.StateManagers.CoordinatesManager : Object {
     // Allow or deny updating the items position.
     private bool do_update = true;
 
-    public CoordinatesManager (Akira.Window window) {
+    public CoordinatesMiddleware (Akira.Window window) {
         Object (
             window: window
         );

--- a/src/Middlewares/SizeMiddleware.vala
+++ b/src/Middlewares/SizeMiddleware.vala
@@ -19,12 +19,13 @@
  * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
- /**
-  * State manager handling the currently selected objects sizings.
-  * This is used to guarantee correct values in the Transform Panel no matter
-  * if one or multiple items are selected.
-  */
-public class Akira.StateManagers.SizeManager : Object {
+/**
+ * Middleware handling the currently selected objects sizes with the Transform Panel.
+ * This is used to guarantee correct values in the Transform Panel no matter if one or
+ * multiple items are selected, and to always return the true items' sizes which
+ * are held by the GooCanvasItem.
+ */
+public class Akira.StateManagers.SizeMiddleware : Object {
     public weak Akira.Window window { get; construct; }
     private weak Akira.Lib.Canvas canvas;
 
@@ -69,7 +70,7 @@ public class Akira.StateManagers.SizeManager : Object {
         }
     }
 
-    public SizeManager (Akira.Window window) {
+    public SizeMiddleware (Akira.Window window) {
         Object (
             window: window
         );

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -32,8 +32,8 @@ public class Akira.Window : Gtk.ApplicationWindow {
     public Akira.Layouts.MainWindow main_window;
     public Akira.Utils.Dialogs dialogs;
 
-    public Akira.StateManagers.CoordinatesManager coords_manager;
-    public Akira.StateManagers.SizeManager size_manager;
+    public Akira.StateManagers.CoordinatesMiddleware coords_middleware;
+    public Akira.StateManagers.SizeMiddleware size_middleware;
 
     public SimpleActionGroup actions { get; construct; }
     public Gtk.AccelGroup accel_group { get; construct; }
@@ -58,8 +58,8 @@ public class Akira.Window : Gtk.ApplicationWindow {
         file_manager = new Akira.FileFormat.FileManager (this);
         headerbar = new Akira.Layouts.HeaderBar (this);
         main_window = new Akira.Layouts.MainWindow (this);
-        coords_manager = new Akira.StateManagers.CoordinatesManager (this);
-        size_manager = new Akira.StateManagers.SizeManager (this);
+        coords_middleware = new Akira.StateManagers.CoordinatesMiddleware (this);
+        size_middleware = new Akira.StateManagers.SizeMiddleware (this);
         dialogs = new Akira.Utils.Dialogs (this);
 
         build_ui ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -111,8 +111,8 @@ sources = files(
 
     'Lib/Selection/Nob.vala',
 
-    'StateManagers/CoordinatesManager.vala',
-    'StateManagers/SizeManager.vala',
+    'Middlewares/CoordinatesMiddleware.vala',
+    'Middlewares/SizeMiddleware.vala',
 )
 
 deps = [


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
This PR doesn't fix any issue or introduces any new features.
It renames `StateManagers` to `Middlewares` as it's more accurate, and improves some comments describing those classes.

Those files don't hold any real state but are actually a connection between the coordinate and size values held by the items.
Renaming them `Middlewares` helps better identifying their purpose.


