### PR TITLE
Fix artboard label issues

### DIFF
--- a/src/Lib/Items/CanvasArtboard.vala
+++ b/src/Lib/Items/CanvasArtboard.vala
@@ -37,8 +37,8 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
    public Goo.CanvasText label;
 
    private const int FONT_SIZE = 10;
-   private uint LIGHT_COLOR;
-   private uint DARK_COLOR;
+   private uint light_color;
+   private uint dark_color;
 
    public CanvasArtboard (double _x, double _y, Goo.CanvasItem? _parent) {
       parent = _parent;
@@ -95,8 +95,8 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
 
    private void create_label () {
       // Define the label colors for dark/light theme variation.
-      LIGHT_COLOR = Utils.Color.color_string_to_uint ("rgba(255, 255, 255, 0.75)");
-      DARK_COLOR = Utils.Color.color_string_to_uint ("rgba(0, 0, 0, 0.75)");
+      light_color = Utils.Color.color_string_to_uint ("rgba(255, 255, 255, 0.75)");
+      dark_color = Utils.Color.color_string_to_uint ("rgba(0, 0, 0, 0.75)");
 
       // Type cast the akira canvas to gain access to its attributes.
       var akira_canvas = canvas as Lib.Canvas;
@@ -107,7 +107,7 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
          Goo.CanvasAnchorType.SW,
          "font", "Open Sans " + (FONT_SIZE / akira_canvas.current_scale).to_string (),
          "ellipsize", Pango.EllipsizeMode.END,
-         "fill-color-rgba", settings.dark_theme ? LIGHT_COLOR : DARK_COLOR,
+         "fill-color-rgba", settings.dark_theme ? light_color : dark_color,
          null);
       label.can_focus = false;
       // Change the parent to allow mouse pointer selection.
@@ -120,7 +120,7 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
 
       // Listen to the theme changing event to update the label color.
       akira_canvas.window.event_bus.change_theme.connect (() => {
-         label.set ("fill-color-rgba", settings.dark_theme ? LIGHT_COLOR : DARK_COLOR);
+         label.set ("fill-color-rgba", settings.dark_theme ? light_color : dark_color);
       });
 
       // Update the label font size when the canvas zoom changes.

--- a/src/Utils/Color.vala
+++ b/src/Utils/Color.vala
@@ -105,4 +105,11 @@ public class Akira.Utils.Color : Object {
 
         return rgba;
     }
+
+    public static uint color_string_to_uint (string color) {
+        var rgba = Gdk.RGBA ();
+        rgba.parse (color);
+
+        return rgba_to_uint (rgba);
+    }
 }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Fix visual inconsistencies with the Artboard label not reaction to UI or canvas changes.

## Steps to Test
Create a bunch of Artboards, zoom in and out and change the theme from dark to light and confirm the label remains readable and of the correct size.

## This PR fixes/implements the following **bugs/features**:
- Use the `change_theme ()` event to update the label color when the dark/light theme changes.
- Use the `set_scale ()` event to update the label size based on the canvas current zoom.

---

- Fixes #568
