### PR TITLE
Fix Errors when trying to add an image with long width and short height

### DIFF
--- a/src/Lib/Items/CanvasImage.vala
+++ b/src/Lib/Items/CanvasImage.vala
@@ -92,7 +92,7 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
                 // the Size component properly calculate the correct size ratio.
                 size.locked = true;
 
-                // Reset the size to a 2px initial value after the size ratio was properly defined
+                // Reset the size to a 4px initial value after the size ratio was properly defined
                 // in order to allow the user to decide the initial image size. We use 2px in order
                 // to avoid issues when dividing by the ratio in case of narrow images.
                 size.width = 4;

--- a/src/Lib/Items/CanvasImage.vala
+++ b/src/Lib/Items/CanvasImage.vala
@@ -95,7 +95,7 @@ public class Akira.Lib.Items.CanvasImage : Goo.CanvasImage, Akira.Lib.Items.Canv
                 // Reset the size to a 2px initial value after the size ratio was properly defined
                 // in order to allow the user to decide the initial image size. We use 2px in order
                 // to avoid issues when dividing by the ratio in case of narrow images.
-                size.width = 2;
+                size.width = 4;
             } catch (Error e) {
                 warning (e.message);
                 ((Lib.Canvas) canvas).window.event_bus.canvas_notification (e.message);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
When the user inserts an image with a big width it will not break

## Steps to Test
Download this:
![115983573-d4269180-a556-11eb-9f69-81f35c314b57](https://user-images.githubusercontent.com/77546233/116819276-b5845400-ab6f-11eb-8108-3aebf245306a.png)

insert it using image tool and it will get inserted without errors

## Before:
![before](https://user-images.githubusercontent.com/77546233/116819280-bcab6200-ab6f-11eb-90b1-529f317b34c3.gif)
## After:
![after](https://user-images.githubusercontent.com/77546233/116819271-aa312880-ab6f-11eb-8953-5d7801d908d2.gif)