### PR TITLE
Improve build time and responsiveness with language server

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 # project name and programming language
-project('com.github.akiraux.akira', 'vala', 'c')
+project('com.github.akiraux.akira', 'vala', 'c',
+  default_options: 'default_library=static')
 
 akira_prefix = get_option('prefix')
 akira_datadir = join_paths(akira_prefix, get_option('datadir'))

--- a/src/Dialogs/SettingsDialog.vala
+++ b/src/Dialogs/SettingsDialog.vala
@@ -304,7 +304,7 @@ public class Akira.Dialogs.SettingsDialog : Gtk.Dialog {
         app_icon.pixel_size = 64;
         app_icon.margin_top = 12;
 
-        var app_name = new Gtk.Label (APP_NAME);
+        var app_name = new Gtk.Label (Constants.APP_NAME);
         app_name.get_style_context ().add_class ("h2");
         app_name.margin_top = 6;
 

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -19,16 +19,13 @@
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
 
-public const string APP_NAME = "Akira";
-public const string TERMINAL_NAME = "akira";
-
 public static bool verbose = false;
 
 public static int main (string[] args) {
     verbose = "-d" in args;
 
-    Environment.set_application_name (APP_NAME);
-    Environment.set_prgname (APP_NAME);
+    Environment.set_application_name (Constants.APP_NAME);
+    Environment.set_prgname (Constants.APP_NAME);
 
     var application = new Akira.Application ();
 

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -1,10 +1,13 @@
 namespace Constants {
-   public const string DATADIR = "@DATADIR@";
-   public const string PKGDATADIR = "@PKGDATADIR@";
-   public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
-   public const string PROJECT_NAME = "@PROJECT_NAME@";
-   public const string VERSION = "@VERSION@";
-   public const string INSTALL_PREFIX = "@PREFIX@";
-   public const string APP_ID = "@APP_ID@";
-   public const string PROFILE = "@PROFILE@";
+    public const string DATADIR = "@DATADIR@";
+    public const string PKGDATADIR = "@PKGDATADIR@";
+    public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+    public const string PROJECT_NAME = "@PROJECT_NAME@";
+    public const string VERSION = "@VERSION@";
+    public const string INSTALL_PREFIX = "@PREFIX@";
+    public const string APP_ID = "@APP_ID@";
+    public const string PROFILE = "@PROFILE@";
+
+    public const string APP_NAME = "Akira";
+    public const string TERMINAL_NAME = "akira";
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,7 +15,6 @@ config_header = configure_file(
 )
 
 sources = files(
-    'Main.vala',
     'Application.vala',
     'Window.vala',
 
@@ -134,7 +133,7 @@ deps = [
     m_dep
 ]
 
-akira_library = shared_library(
+akira_library = library(
     'akira-library-1.0',
     sources,
     asresources,
@@ -151,9 +150,8 @@ akira_dep = declare_dependency(
 # Create a new executable, list the files we want to compile, list the dependencies we need, and install
 executable(
     application_id,
-    sources,
+    'Main.vala',
     asresources,
-    config_header,
-    dependencies: deps,
+    dependencies: deps + [akira_dep],
     install: true
 )


### PR DESCRIPTION
Instead of essentially building the entire project twice, we can reduce build time by only building src/Main.vala and then statically linking it with akira-library. Not only does this reduce build time, it also makes [VLS](https://github.com/Prince781/vala-language-server) more responsive (although still not responsive enough—there's much to improve on the VLS side to get it to a satisfactory level).
