### PR TITLE
Fix left and right not being absorbed

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -218,6 +218,8 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             case Gdk.Key.Left:
                 window.event_bus.move_item_from_canvas (event);
                 window.event_bus.detect_artboard_change ();
+                return true;
+            default:
                 break;
         }
 


### PR DESCRIPTION

<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
The left and right key were not being absorbed after moving the time, so focus change was being triggered. I returned true to absorb the event.

## Steps to Test
Create an item, and press left twice. The item should move twice and there should be no focus change.
