### PR TITLE
Fix pixel grid z-index stack

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -54,6 +54,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     private Goo.CanvasRect ghost;
 
     // Used to show a pixel grid on the whole canvas.
+    private Goo.CanvasItem root;
     private Goo.CanvasGrid pixel_grid;
     private bool is_grid_visible;
 
@@ -71,6 +72,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         events |= Gdk.EventMask.TOUCHPAD_GESTURE_MASK;
         events |= Gdk.EventMask.TOUCH_MASK;
 
+        root = get_root_item ();
         export_manager = new Managers.ExportManager (this);
         selected_bound_manager = new Managers.SelectedBoundManager (this);
         nob_manager = new Managers.NobManager (this);
@@ -145,7 +147,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         pixel_grid.horz_grid_line_width = pixel_grid.vert_grid_line_width = 0.02;
         pixel_grid.horz_grid_line_color_gdk_rgba = pixel_grid.vert_grid_line_color_gdk_rgba = grid_rgba;
         pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
-        pixel_grid.set ("parent", get_root_item ());
+        pixel_grid.set ("parent", root);
         pixel_grid.can_focus = false;
         pixel_grid.pointer_events = Goo.CanvasPointerEvents.NONE;
         is_grid_visible = false;
@@ -325,7 +327,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     public void update_canvas () {
         // Update the pixel grid if it's visible in order to move it to the foreground.
         if (is_grid_visible) {
-            update_pixel_grid ();
+            update_pixel_grid_visibility ();
         }
         // Synchronous update to make sure item is initialized before any other event.
         update ();
@@ -352,7 +354,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     public void focus_canvas () {
-        grab_focus (get_root_item ());
+        grab_focus (root);
     }
 
     private bool press_event_on_selection (Gdk.EventButton event) {
@@ -405,8 +407,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             if (mode_manager.button_press_event (event)) {
                 return true;
             }
-        }
-        else {
+        } else {
             nob_manager.set_selected_by_name (Akira.Lib.Managers.NobManager.Nob.NONE);
         }
 
@@ -446,16 +447,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             return;
         }
 
-        // If the pixel grid is visible, hide it based on the canvas scale
-        // in order to avoid a visually jarring canvas.
-        if (current_scale < GRID_THRESHOLD) {
-            pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
-        } else {
-            pixel_grid.visibility = Goo.CanvasItemVisibility.VISIBLE;
-            // Always move the grid to the top of the stack.
-            var root = get_root_item ();
-            root.move_child (root.find_child (pixel_grid), window.items_manager.get_items_count ());
-        }
+        update_pixel_grid_visibility ();
     }
 
     private void set_cursor (Gdk.CursorType? cursor_type) {
@@ -487,7 +479,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 "stroke-color", "#41c9fd",
                 null
             );
-            ghost.set ("parent", get_root_item ());
+            ghost.set ("parent", root);
             ghost.can_focus = false;
             ghost.pointer_events = Goo.CanvasPointerEvents.NONE;
             return;
@@ -516,7 +508,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
      */
     private void on_toggle_pixel_grid () {
         if (!is_grid_visible) {
-            update_pixel_grid ();
+            update_pixel_grid_visibility ();
             is_grid_visible = true;
             return;
         }
@@ -525,22 +517,29 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         is_grid_visible = false;
     }
 
-    /*
-     * Updates pixel grid if visible, useful to guarantee z-order in paint composition.
-     */
-    public void update_pixel_grid_if_visible () {
-        if (is_grid_visible) {
-            update_pixel_grid ();
+    private void update_pixel_grid_visibility () {
+        // If the pixel grid is visible, hide it based on the canvas scale
+        // in order to avoid a visually jarring canvas.
+        if (current_scale < GRID_THRESHOLD) {
+            pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
+            return;
         }
-    }
 
-    private void update_pixel_grid () {
-        // Show the grid only if we're zoomed in enough.
-        if (current_scale >= GRID_THRESHOLD) {
+        // Show the pixel grid if is currently hidden.
+        if (pixel_grid.visibility == Goo.CanvasItemVisibility.HIDDEN) {
             pixel_grid.visibility = Goo.CanvasItemVisibility.VISIBLE;
-            // Always move the grid to the top of the stack.
-            var root = get_root_item ();
-            root.move_child (root.find_child (pixel_grid), window.items_manager.get_items_count ());
+        }
+
+        var current_position = root.find_child (pixel_grid);
+        var top_position = root.get_n_children ();
+        // The grid should always be below the select effect and nobs,
+        // so we decrease the count to account for that, otherwise we
+        // decrease by 1 to ignore the grid current position.
+        top_position -= selected_bound_manager.selected_items.length () > 0 ? 11 : 1;
+
+        // Always move the grid to the top of the stack if necessary.
+        if (current_position < top_position) {
+            root.move_child (current_position, top_position);
         }
     }
 }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -517,6 +517,9 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         is_grid_visible = false;
     }
 
+    /*
+     * Updates pixel grid if visible, useful to guarantee z-order in paint composition.
+     */
     private void update_pixel_grid_visibility () {
         // If the pixel grid is visible, hide it based on the canvas scale
         // in order to avoid a visually jarring canvas.

--- a/src/Lib/Items/CanvasArtboard.vala
+++ b/src/Lib/Items/CanvasArtboard.vala
@@ -119,14 +119,24 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
       this.size.bind_property ("width", label, "width", BindingFlags.SYNC_CREATE);
 
       // Listen to the theme changing event to update the label color.
-      akira_canvas.window.event_bus.change_theme.connect (() => {
-         label.set ("fill-color-rgba", settings.dark_theme ? light_color : dark_color);
-      });
+      akira_canvas.window.event_bus.change_theme.connect (on_theme_changed);
 
       // Update the label font size when the canvas zoom changes.
-      akira_canvas.window.event_bus.set_scale.connect ((scale) => {
-         label.set ("font", "Open Sans " + (FONT_SIZE / scale).to_string ());
-      });
+      akira_canvas.window.event_bus.set_scale.connect (on_canvas_scaled);
+   }
+
+   /*
+    * Update the color of the artboard label based on the light/dark theme.
+    */
+   private void on_theme_changed () {
+      label.set ("fill-color-rgba", settings.dark_theme ? light_color : dark_color);
+   }
+
+   /*
+    * Update the artboard label font size based on the current scale.
+    */
+   private void on_canvas_scaled (double scale) {
+      label.set ("font", "Open Sans " + (FONT_SIZE / scale).to_string ());
    }
 
    /**
@@ -167,6 +177,13 @@ public class Akira.Lib.Items.CanvasArtboard : Goo.CanvasGroup, Akira.Lib.Items.C
 
    public void delete () {
       background.remove ();
+
+      // Type cast the akira canvas to gain access to its attributes.
+      var akira_canvas = canvas as Lib.Canvas;
+      // Disconnect previously set events.
+      akira_canvas.window.event_bus.change_theme.disconnect (on_theme_changed);
+      akira_canvas.window.event_bus.set_scale.disconnect (on_canvas_scaled);
+
       // Reassign the Canvas as parent to the label in order to remove it.
       label.parent = parent;
       label.remove ();

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -153,6 +153,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         item.parent.add_child (item, -1);
         free_items.add_item.begin (item);
         window.event_bus.file_edited ();
+        ((Lib.Canvas) item.canvas).update_canvas ();
     }
 
     /**
@@ -191,8 +192,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             free_items.remove_item.begin (item);
         }
 
-        item.delete ();
+        // Let the app know we're deleting an item.
         window.event_bus.item_deleted (item);
+        item.delete ();
         window.event_bus.file_edited ();
     }
 
@@ -688,14 +690,5 @@ public class Akira.Lib.Managers.ItemsManager : Object {
 
             return;
         }
-    }
-
-    /**
-     * Helper method to get the count of all the created items in the canvas.
-     * This count excludes pseudo items like the select effect, hover effect,
-     * or grids items.
-     */
-    public int get_items_count () {
-        return (int) free_items.get_n_items () + (int) artboards.get_n_items ();
     }
 }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Properly update the pixel grid position in the z-index stack to account for newly created items.

## Steps to Test
- Create items and artboards with the pixel grid visible.
- Move items around to trigger the snap decorators.
- Ensure the grid is always above the items but below the selection nobs when creating new items.

## Known Issues / Things To Do
I'm going to do a follow up to emulate what Inkscape does which is decreasing the number of rows and columns of the pixel grid when zooming out, as that it's way more useful than what we currently do.

## This PR fixes/implements the following **bugs/features**:
Improves the Pixel grid code.
I also fixed #578 by disconnecting the events on the label when the artboard is deleted. This is a quick fix to remove the error for a new release, but this should happen on destruction and we should be sure that deleted items are actually discarded and properly destroyed, and not hanging in the cache or the Vala garbage collection.

- Fixes #578
