### PR TITLE
Avoid open cmd terminal running on windows

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -155,5 +155,6 @@ executable(
     'Main.vala',
     asresources,
     dependencies: deps + [akira_dep],
-    install: true
+    install: true,
+    gui_app: true
 )


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Property for meson build system to run as GUI on windows 

## Steps to Test
Execute exe on windows and see it doesn't open a cmd terminal to show the logs

## Screenshots 
N/A

## Known Issues / Things To Do
N/A

## This PR fixes/implements the following **bugs/features**:
N/A