### PR TITLE
Improve pixel grid

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -25,10 +25,6 @@
 public class Akira.Lib.Canvas : Goo.Canvas {
     public weak Akira.Window window { get; construct; }
 
-    private const int MIN_SIZE = 1;
-    private const int MIN_POS = 10;
-    private const int GRID_THRESHOLD = 3;
-
     // List of accepted dragged targets.
     private const Gtk.TargetEntry[] TARGETS = {
         {"text/uri-list", 0, 0}
@@ -40,6 +36,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     public Managers.ExportManager export_manager;
     public Managers.SelectedBoundManager selected_bound_manager;
     public Managers.NobManager nob_manager;
+    private Managers.GridManager grid_manager;
     private Managers.HoverManager hover_manager;
     private Managers.ModeManager mode_manager;
     private Managers.SnapManager snap_manager;
@@ -52,11 +49,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
 
     // Used to show the canvas bounds of selected items.
     private Goo.CanvasRect ghost;
-
-    // Used to show a pixel grid on the whole canvas.
-    private Goo.CanvasItem root;
-    private Goo.CanvasGrid pixel_grid;
-    private bool is_grid_visible;
 
     public Canvas (Akira.Window window) {
         Object (window: window);
@@ -72,23 +64,19 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         events |= Gdk.EventMask.TOUCHPAD_GESTURE_MASK;
         events |= Gdk.EventMask.TOUCH_MASK;
 
-        root = get_root_item ();
         export_manager = new Managers.ExportManager (this);
         selected_bound_manager = new Managers.SelectedBoundManager (this);
         nob_manager = new Managers.NobManager (this);
 
+        grid_manager = new Managers.GridManager (this);
         hover_manager = new Managers.HoverManager (this);
         mode_manager = new Managers.ModeManager (this);
         snap_manager = new Managers.SnapManager (this);
-
-        create_pixel_grid ();
 
         // Make the canvas a destination for drag actions.
         Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, TARGETS, Gdk.DragAction.COPY);
         drag_data_received.connect (on_drag_data_received);
 
-        window.event_bus.toggle_pixel_grid.connect (on_toggle_pixel_grid);
-        window.event_bus.update_pixel_grid.connect (on_update_pixel_grid);
         window.event_bus.update_scale.connect (on_update_scale);
         window.event_bus.set_scale.connect (on_set_scale);
         window.event_bus.set_focus_on_canvas.connect (on_set_focus_on_canvas);
@@ -131,36 +119,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         Gtk.drag_finish (drag_context, true, false, time);
 
         update_canvas ();
-    }
-
-    private void create_pixel_grid () {
-        pixel_grid = new Goo.CanvasGrid (
-            null,
-            0, 0,
-            Layouts.MainCanvas.CANVAS_SIZE,
-            Layouts.MainCanvas.CANVAS_SIZE,
-            1, 1, 0, 0);
-
-        var grid_rgba = Gdk.RGBA ();
-        grid_rgba.parse (settings.grid_color);
-
-        pixel_grid.horz_grid_line_width = pixel_grid.vert_grid_line_width = 0.02;
-        pixel_grid.horz_grid_line_color_gdk_rgba = pixel_grid.vert_grid_line_color_gdk_rgba = grid_rgba;
-        pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
-        pixel_grid.set ("parent", root);
-        pixel_grid.can_focus = false;
-        pixel_grid.pointer_events = Goo.CanvasPointerEvents.NONE;
-        is_grid_visible = false;
-    }
-
-    /**
-     * Trigger the update of the pixel grid after the settings color have been changed.
-     */
-    private void on_update_pixel_grid () {
-        var grid_rgba = Gdk.RGBA ();
-        grid_rgba.parse (settings.grid_color);
-
-        pixel_grid.horz_grid_line_color_gdk_rgba = pixel_grid.vert_grid_line_color_gdk_rgba = grid_rgba;
     }
 
     public void interaction_mode_changed () {
@@ -325,12 +283,10 @@ public class Akira.Lib.Canvas : Goo.Canvas {
      * Perform a series of updates after an item is created.
      */
     public void update_canvas () {
-        // Update the pixel grid if it's visible in order to move it to the foreground.
-        if (is_grid_visible) {
-            update_pixel_grid_visibility ();
-        }
         // Synchronous update to make sure item is initialized before any other event.
         update ();
+
+        grid_manager.on_canvas_update ();
     }
 
     /*
@@ -354,7 +310,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     }
 
     public void focus_canvas () {
-        grab_focus (root);
+        grab_focus (get_root_item ());
     }
 
     private bool press_event_on_selection (Gdk.EventButton event) {
@@ -441,13 +397,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         window.event_bus.zoom ();
 
         window.event_bus.update_snap_decorators ();
-
-        // Check if the user requested the pixel grid and if is not already visible.
-        if (!is_grid_visible) {
-            return;
-        }
-
-        update_pixel_grid_visibility ();
     }
 
     private void set_cursor (Gdk.CursorType? cursor_type) {
@@ -479,7 +428,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 "stroke-color", "#41c9fd",
                 null
             );
-            ghost.set ("parent", root);
+            ghost.set ("parent", get_root_item ());
             ghost.can_focus = false;
             ghost.pointer_events = Goo.CanvasPointerEvents.NONE;
             return;
@@ -500,49 +449,6 @@ public class Akira.Lib.Canvas : Goo.Canvas {
                 ((Lib.Modes.TransformMode.TransformExtraContext) extra_context).snap_guide_data);
         } else if (snap_manager.is_active ()) {
             snap_manager.reset_decorators ();
-        }
-    }
-
-    /*
-     * Show or hide the pixel grid based on its state.
-     */
-    private void on_toggle_pixel_grid () {
-        if (!is_grid_visible) {
-            update_pixel_grid_visibility ();
-            is_grid_visible = true;
-            return;
-        }
-
-        pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
-        is_grid_visible = false;
-    }
-
-    /*
-     * Updates pixel grid if visible, useful to guarantee z-order in paint composition.
-     */
-    private void update_pixel_grid_visibility () {
-        // If the pixel grid is visible, hide it based on the canvas scale
-        // in order to avoid a visually jarring canvas.
-        if (current_scale < GRID_THRESHOLD) {
-            pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
-            return;
-        }
-
-        // Show the pixel grid if is currently hidden.
-        if (pixel_grid.visibility == Goo.CanvasItemVisibility.HIDDEN) {
-            pixel_grid.visibility = Goo.CanvasItemVisibility.VISIBLE;
-        }
-
-        var current_position = root.find_child (pixel_grid);
-        var top_position = root.get_n_children ();
-        // The grid should always be below the select effect and nobs,
-        // so we decrease the count to account for that, otherwise we
-        // decrease by 1 to ignore the grid current position.
-        top_position -= selected_bound_manager.selected_items.length () > 0 ? 11 : 1;
-
-        // Always move the grid to the top of the stack if necessary.
-        if (current_position < top_position) {
-            root.move_child (current_position, top_position);
         }
     }
 }

--- a/src/Lib/Managers/GridManager.vala
+++ b/src/Lib/Managers/GridManager.vala
@@ -103,20 +103,22 @@
      * as well as number of columns and rows based on the canvas current scale.
      */
     private void recalculate () {
-        double thickness = 1;
+        double thickness = 0.02;
         double steps = 1;
         var scale = canvas.current_scale;
 
-        // -20%
+        // Hide the pixel grid if the zoom is below or equal to 20%.
         if (scale < 0.2) {
             pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
             return;
         }
 
-        pixel_grid.visibility = Goo.CanvasItemVisibility.VISIBLE;
+        if (pixel_grid.visibility == Goo.CanvasItemVisibility.HIDDEN) {
+            pixel_grid.visibility = Goo.CanvasItemVisibility.VISIBLE;
+        }
 
-        // 20% - 50%
-        if (scale >= 0.2 && scale < 0.5) {
+        // -50%
+        if (scale < 0.5) {
             thickness = 1;
             steps = 40;
         }
@@ -127,81 +129,35 @@
             steps = 20;
         }
 
-        // 150% - 200%
-        if (scale >= 1.4 && scale < 2) {
-            thickness = 0.2;
+        // 150% - 250%
+        if (scale >= 1.5 && scale < 2.5) {
+            thickness = 0.25;
             steps = 10;
         }
 
-        // 200% - 250%
-        if (scale >= 2 && scale < 2.5) {
-            thickness = 0.15;
-            steps = 9;
-        }
-
-        // 250% - 300%
-        if (scale >= 2.5 && scale < 3) {
-            thickness = 0.1;
-            steps = 8;
-        }
-
-        // 300% - 350%
-        if (scale >= 3 && scale < 3.5) {
-            thickness = 0.09;
-            steps = 7;
-        }
-
-        // 350% - 400%
-        if (scale >= 3.5 && scale < 4) {
-            thickness = 0.08;
-            steps = 7;
-        }
-
-        // 400% - 450%
-        if (scale >= 4 && scale < 4.5) {
-            thickness = 0.08;
-            steps = 7;
-        }
-
-        // 450% - 500%
-        if (scale >= 4.5 && scale < 5) {
-            thickness = 0.08;
-            steps = 6;
-        }
-
-        // 500% - 550%
-        if (scale >= 5 && scale < 5.5) {
-            thickness = 0.07;
+        // 250% - 350%
+        if (scale >= 2.5 && scale < 3.5) {
+            thickness = 0.125;
             steps = 5;
         }
 
-        // 550% - 600%
-        if (scale >= 5.5 && scale < 6) {
-            thickness = 0.07;
-            steps = 4;
+        // 350% - 450%
+        if (scale >= 3.5 && scale < 4.5) {
+            thickness = 0.06;
+            steps = 2.5;
         }
 
-        // 600% - 650%
-        if (scale >= 6 && scale < 6.5) {
-            thickness = 0.05;
-            steps = 3;
-        }
-
-        // 650% - 700%
-        if (scale >= 6.5 && scale < 7) {
-            thickness = 0.05;
-            steps = 2;
-        }
-
-        // 700%+
-        if (scale >= 7) {
-            thickness = 0.02;
+        // 450% - 600%
+        if (scale >= 4.5 && scale < 6) {
+            thickness = 0.04;
             steps = 1;
         }
 
-        // Update line thickness.
+        // Update the grid offset to always be half of the line thickness
+        // in order to guarantee a sharp line rendering.
+        pixel_grid.x_offset = pixel_grid.y_offset = thickness / 2;
+        // Update the line thickness.
         pixel_grid.horz_grid_line_width = pixel_grid.vert_grid_line_width = thickness;
-
         // Update the steps between columns and rows.
         pixel_grid.x_step = pixel_grid.y_step = steps;
     }

--- a/src/Lib/Managers/GridManager.vala
+++ b/src/Lib/Managers/GridManager.vala
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+ */
+
+/**
+ * Manages the Canvas Pixel grid. This class take case of generating and updating
+ * the global pixel grid whenever the user requires it. It also listens to the scale
+ * variation of the main Canvas in order to return a properly usable grid with decently
+ * spaced columns and rows, and a decently rendered grid thickness.
+ */
+ public class Akira.Lib.Managers.GridManager : Object {
+    public weak Lib.Canvas canvas { get; set construct; }
+
+    private Goo.CanvasGrid pixel_grid;
+    private bool is_grid_visible;
+
+    public GridManager (Lib.Canvas canvas) {
+        this.canvas = canvas;
+
+        create_pixel_grid ();
+
+        canvas.window.event_bus.toggle_pixel_grid.connect (on_toggle_pixel_grid);
+        canvas.window.event_bus.update_pixel_grid.connect (on_update_pixel_grid);
+        canvas.window.event_bus.set_scale.connect (on_set_scale);
+    }
+
+    /*
+     * Generate the default pixel grid.
+     */
+    private void create_pixel_grid () {
+        pixel_grid = new Goo.CanvasGrid (
+            null,
+            0, 0,
+            Layouts.MainCanvas.CANVAS_SIZE,
+            Layouts.MainCanvas.CANVAS_SIZE,
+            1, 1, 0, 0);
+
+        var grid_rgba = Gdk.RGBA ();
+        grid_rgba.parse (settings.grid_color);
+
+        pixel_grid.horz_grid_line_width = pixel_grid.vert_grid_line_width = 0.02;
+        pixel_grid.horz_grid_line_color_gdk_rgba = pixel_grid.vert_grid_line_color_gdk_rgba = grid_rgba;
+        pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
+        pixel_grid.set ("parent", canvas.get_root_item ());
+        pixel_grid.can_focus = false;
+        pixel_grid.pointer_events = Goo.CanvasPointerEvents.NONE;
+        is_grid_visible = false;
+    }
+
+    /*
+     * Trigger the update of the pixel grid after the settings color have been changed.
+     */
+    private void on_update_pixel_grid () {
+        var grid_rgba = Gdk.RGBA ();
+        grid_rgba.parse (settings.grid_color);
+
+        pixel_grid.horz_grid_line_color_gdk_rgba = pixel_grid.vert_grid_line_color_gdk_rgba = grid_rgba;
+    }
+
+    /*
+     * Show or hide the pixel grid based on its state.
+     */
+    private void on_toggle_pixel_grid () {
+        if (!is_grid_visible) {
+            is_grid_visible = true;
+            raise ();
+            recalculate ();
+            return;
+        }
+
+        pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
+        is_grid_visible = false;
+    }
+
+    private void on_set_scale (double scale) {
+        // Check if the user requested the pixel grid and if is not already visible.
+        if (!is_grid_visible) {
+            return;
+        }
+
+        recalculate ();
+    }
+
+    /*
+     * Update the pixel grid to always show the most optimal line thickness,
+     * as well as number of columns and rows based on the canvas current scale.
+     */
+    private void recalculate () {
+        double thickness = 1;
+        double steps = 1;
+        var scale = canvas.current_scale;
+
+        // -20%
+        if (scale < 0.2) {
+            pixel_grid.visibility = Goo.CanvasItemVisibility.HIDDEN;
+            return;
+        }
+
+        pixel_grid.visibility = Goo.CanvasItemVisibility.VISIBLE;
+
+        // 20% - 50%
+        if (scale >= 0.2 && scale < 0.5) {
+            thickness = 1;
+            steps = 40;
+        }
+
+        // 50% - 150%
+        if (scale >= 0.5 && scale < 1.5) {
+            thickness = 0.5;
+            steps = 20;
+        }
+
+        // 150% - 200%
+        if (scale >= 1.4 && scale < 2) {
+            thickness = 0.2;
+            steps = 10;
+        }
+
+        // 200% - 250%
+        if (scale >= 2 && scale < 2.5) {
+            thickness = 0.15;
+            steps = 9;
+        }
+
+        // 250% - 300%
+        if (scale >= 2.5 && scale < 3) {
+            thickness = 0.1;
+            steps = 8;
+        }
+
+        // 300% - 350%
+        if (scale >= 3 && scale < 3.5) {
+            thickness = 0.09;
+            steps = 7;
+        }
+
+        // 350% - 400%
+        if (scale >= 3.5 && scale < 4) {
+            thickness = 0.08;
+            steps = 7;
+        }
+
+        // 400% - 450%
+        if (scale >= 4 && scale < 4.5) {
+            thickness = 0.08;
+            steps = 7;
+        }
+
+        // 450% - 500%
+        if (scale >= 4.5 && scale < 5) {
+            thickness = 0.08;
+            steps = 6;
+        }
+
+        // 500% - 550%
+        if (scale >= 5 && scale < 5.5) {
+            thickness = 0.07;
+            steps = 5;
+        }
+
+        // 550% - 600%
+        if (scale >= 5.5 && scale < 6) {
+            thickness = 0.07;
+            steps = 4;
+        }
+
+        // 600% - 650%
+        if (scale >= 6 && scale < 6.5) {
+            thickness = 0.05;
+            steps = 3;
+        }
+
+        // 650% - 700%
+        if (scale >= 6.5 && scale < 7) {
+            thickness = 0.05;
+            steps = 2;
+        }
+
+        // 700%+
+        if (scale >= 7) {
+            thickness = 0.02;
+            steps = 1;
+        }
+
+        // Update line thickness.
+        pixel_grid.horz_grid_line_width = pixel_grid.vert_grid_line_width = thickness;
+
+        // Update the steps between columns and rows.
+        pixel_grid.x_step = pixel_grid.y_step = steps;
+    }
+
+    /*
+     * Called when the canvas is updated after the creation of a new item.
+     */
+    public void on_canvas_update () {
+        if (is_grid_visible) {
+            raise ();
+        }
+    }
+
+    /*
+     * Move the pixel grid to the top of the stack.
+     */
+    private void raise () {
+        // Update the pixel grid if it's visible in order to move it to the foreground.
+        var root = canvas.get_root_item ();
+        var current_position = root.find_child (pixel_grid);
+        var top_position = root.get_n_children ();
+
+        // The grid should always be below the select effect and nobs,
+        // so we decrease the count to account for that, otherwise we
+        // decrease by 1 to ignore the grid current position.
+        top_position -= canvas.selected_bound_manager.selected_items.length () > 0 ? 11 : 1;
+
+        // Always move the grid to the top of the stack if necessary.
+        if (current_position < top_position) {
+            root.move_child (current_position, top_position);
+        }
+    }
+}

--- a/src/Lib/Managers/GridManager.vala
+++ b/src/Lib/Managers/GridManager.vala
@@ -38,7 +38,7 @@
 
         canvas.window.event_bus.toggle_pixel_grid.connect (on_toggle_pixel_grid);
         canvas.window.event_bus.update_pixel_grid.connect (on_update_pixel_grid);
-        canvas.window.event_bus.set_scale.connect (on_set_scale);
+        canvas.window.event_bus.zoom.connect (on_canvas_zoom);
     }
 
     /*
@@ -89,7 +89,7 @@
         is_grid_visible = false;
     }
 
-    private void on_set_scale (double scale) {
+    private void on_canvas_zoom () {
         // Check if the user requested the pixel grid and if is not already visible.
         if (!is_grid_visible) {
             return;
@@ -103,7 +103,7 @@
      * as well as number of columns and rows based on the canvas current scale.
      */
     private void recalculate () {
-        double thickness = 0.02;
+        double thickness = 0.04;
         double steps = 1;
         var scale = canvas.current_scale;
 
@@ -143,14 +143,18 @@
 
         // 350% - 450%
         if (scale >= 3.5 && scale < 4.5) {
-            thickness = 0.06;
-            steps = 2.5;
+            thickness = 0.1;
+            steps = 3;
         }
 
         // 450% - 600%
         if (scale >= 4.5 && scale < 6) {
-            thickness = 0.04;
-            steps = 1;
+            thickness = 0.08;
+            steps = 2;
+        }
+
+        if (scale > 14) {
+            thickness = 0.02;
         }
 
         // Update the grid offset to always be half of the line thickness

--- a/src/meson.build
+++ b/src/meson.build
@@ -101,6 +101,7 @@ sources = files(
     'Lib/Items/CanvasText.vala',
 
     'Lib/Managers/ExportManager.vala',
+    'Lib/Managers/GridManager.vala',
     'Lib/Managers/HoverManager.vala',
     'Lib/Managers/ImageManager.vala',
     'Lib/Managers/ItemsManager.vala',


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Code clean up and creation of a dedicated Grid manager to streamline the Canvas.
This also fixes the issue of the Grid not always being on top when new items are drawn.

## Steps to Test
- Show the pixel grid
- Zoom in and out
- Create items

## Known Issues / Things To Do
Since the pixel grid now adapts its density (amount of columns and rows) based on the canvas scale, items might appear not aligned to the grid, even tho they actually are. This might be misleading at first.
We should implement an option to enable/disable snap to the visible pixel grid.  

## This PR fixes/implements the following **bugs/features**:
- The pixel grid adapts its thickness and density based on the zoom level.
- The pixel grid is always drawn above all items, except for the selection or hover effect.
- Reduced the call for updating the grid only when a new item is created.
