### PR TITLE
Implement editable zoom value

### DIFF
--- a/data/css/headerbar.css
+++ b/data/css/headerbar.css
@@ -17,9 +17,8 @@
 }
 
 entry.input-zoom {
-    border-radius: 0;
-    margin: 0;
     padding: 3px 8px 4px;
+    margin: 6px;
 }
 
 .linked-flat button {

--- a/data/css/headerbar.css
+++ b/data/css/headerbar.css
@@ -7,13 +7,18 @@
 }
 
 .button-zoom-start {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
 }
 
 .button-zoom-end {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+}
+
+.input-zoom {
+    border-radius: 0;
+    margin: 0
 }
 
 .linked-flat button {

--- a/data/css/headerbar.css
+++ b/data/css/headerbar.css
@@ -16,9 +16,10 @@
     border-bottom-left-radius: 0px;
 }
 
-.input-zoom {
+entry.input-zoom {
     border-radius: 0;
-    margin: 0
+    margin: 0;
+    padding: 3px 8px 4px;
 }
 
 .linked-flat button {

--- a/data/css/headerbar.css
+++ b/data/css/headerbar.css
@@ -6,6 +6,16 @@
     padding: 0 6px;
 }
 
+.button-zoom-start {
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
+}
+
+.button-zoom-end {
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
+}
+
 .linked-flat button {
     background-color: shade (@bg_color, 1);
 }

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -401,12 +401,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         window.event_bus.selected_items_list_changed.connect (on_selected_items_changed);
         window.event_bus.selected_items_changed.connect (on_selected_items_changed);
         window.event_bus.z_selected_changed.connect (update_button_sensitivity);
-        window.event_bus.set_scale.connect (on_set_scale);
         window.event_bus.update_recent_files_list.connect (fetch_recent_files);
-    }
-
-    private void on_set_scale (double scale) {
-        zoom.zoom_default_button.label = "%.0f%%".printf (scale * 100);
     }
 
     private void toggle () {

--- a/src/Lib/Managers/GridManager.vala
+++ b/src/Lib/Managers/GridManager.vala
@@ -20,7 +20,7 @@
  */
 
 /**
- * Manages the Canvas Pixel grid. This class take case of generating and updating
+ * Manages the Canvas Pixel grid. This class takes care of generating and updating
  * the global pixel grid whenever the user requires it. It also listens to the scale
  * variation of the main Canvas in order to return a properly usable grid with decently
  * spaced columns and rows, and a decently rendered grid thickness.

--- a/src/Partials/HeaderBarButton.vala
+++ b/src/Partials/HeaderBarButton.vala
@@ -27,7 +27,7 @@ public class Akira.Partials.HeaderBarButton : Gtk.Grid {
     public string? sensitive_type;
 
     public HeaderBarButton (Akira.Window _window, string icon_name, string name,
-        string[]? accels = null,string? type = null) {
+        string[]? accels = null, string? type = null) {
         window = _window;
         sensitive_type = type;
         label_btn = new Gtk.Label (name);

--- a/src/Partials/InputField.vala
+++ b/src/Partials/InputField.vala
@@ -20,7 +20,6 @@
 */
 
 public class Akira.Partials.InputField : Gtk.EventBox {
-    //  private Akira.Window window;
     public Gtk.SpinButton entry { get; construct set; }
 
     public int chars { get; construct set; }

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -1,26 +1,26 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
-*
-* This file is part of Akira.
-*
-* Akira is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
 
-* Akira is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
 
-* You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
-*
-* Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
-*/
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+ */
 
 public class Akira.Partials.ZoomButton : Gtk.Grid {
-    public weak Akira.Window window { get; construct; }
+    public weak Akira.Window window { get; set construct; }
 
     private Gtk.Label label_btn;
     public Gtk.Button zoom_out_button;
@@ -28,14 +28,10 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
     public Gtk.Button zoom_in_button;
 
     public ZoomButton (Akira.Window window) {
-        Object (
-            window: window
-        );
-    }
+        this.window = window;
 
-    construct {
         get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
-        get_style_context ().add_class ("linked-flat");
+        get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         valign = Gtk.Align.CENTER;
         column_homogeneous = false;
         width_request = 140;
@@ -43,8 +39,8 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
 
         zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", Gtk.IconSize.MENU);
         zoom_out_button.clicked.connect (zoom_out);
-        zoom_out_button.get_style_context ().add_class ("raised");
         zoom_out_button.get_style_context ().add_class ("button-zoom");
+        zoom_out_button.get_style_context ().add_class ("button-zoom-start");
         zoom_out_button.can_focus = false;
         zoom_out_button.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>minus"}, _("Zoom Out"));
 
@@ -56,8 +52,8 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
 
         zoom_in_button = new Gtk.Button.from_icon_name ("zoom-in-symbolic", Gtk.IconSize.MENU);
         zoom_in_button.clicked.connect (zoom_in);
-        zoom_in_button.get_style_context ().add_class ("raised");
         zoom_in_button.get_style_context ().add_class ("button-zoom");
+        zoom_in_button.get_style_context ().add_class ("button-zoom-end");
         zoom_in_button.can_focus = false;
         zoom_in_button.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>plus"}, _("Zoom In"));
 

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -25,7 +25,7 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
     private Gtk.Label label_btn;
     private Gtk.Button zoom_out_button;
     private Gtk.Button zoom_in_button;
-    public Gtk.Button zoom_default_button;
+    private Gtk.Button zoom_default_button;
     private Gtk.Entry zoom_input;
 
     public ZoomButton (Akira.Window window) {
@@ -57,7 +57,16 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
 
         // The zoom input field.
         zoom_input = new Gtk.Entry ();
+        zoom_input.text = "100";
         zoom_input.input_purpose = Gtk.InputPurpose.NUMBER;
+        zoom_input.get_style_context ().add_class ("input-zoom");
+        zoom_input.get_style_context ().add_class ("input-icon-right");
+        zoom_input.secondary_icon_name = "input-percentage-symbolic";
+        zoom_input.secondary_icon_sensitive = false;
+        zoom_input.secondary_icon_activatable = false;
+        zoom_input.xalign = 1.0f;
+        zoom_input.width_chars = 9;
+        // Hide the input by default.
         zoom_input.visible = false;
         zoom_input.no_show_all = true;
 
@@ -70,8 +79,8 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
 
         attach (zoom_out_button, 0, 0, 1, 1);
         attach (zoom_default_button, 1, 0, 1, 1);
-        // attach (zoom_input, 2, 0, 1, 1);
-        attach (zoom_in_button, 2, 0, 1, 1);
+        attach (zoom_input, 2, 0, 1, 1);
+        attach (zoom_in_button, 3, 0, 1, 1);
 
         // Headerbar button label.
         label_btn = new Gtk.Label (_("Zoom"));
@@ -82,12 +91,20 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
 
         // Mouse click signals.
         zoom_out_button.clicked.connect (zoom_out);
-        zoom_default_button.clicked.connect (zoom_reset);
+        zoom_default_button.button_press_event.connect (zoom_reset);
         zoom_in_button.clicked.connect (zoom_in);
+
+        // Keyboard press signals.
+        zoom_input.key_press_event.connect (handle_key_press);
+        zoom_input.focus_in_event.connect (handle_focus_in);
+        zoom_input.focus_out_event.connect (handle_focus_out);
 
         // Bind the visibility of the button label to the gsetting attribute.
         settings.bind("show-label", label_btn, "visible", SettingsBindFlags.DEFAULT);
         settings.bind("show-label", label_btn, "no-show-all", SettingsBindFlags.INVERT_BOOLEAN);
+
+        // Event listeners.
+        window.event_bus.set_scale.connect (on_set_scale);
     }
 
     /*
@@ -104,11 +121,108 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         window.event_bus.update_scale (0.5);
     }
 
+    /*
+     * Reset the zoom to 100%, or replaces the central button
+     * with a numeric input field for manual inputing if the user
+     * pressed the CTRL key while clicking on the button.
+     */
+    public bool zoom_reset (Gdk.EventButton event) {
+        // If the CTRL key was pressed, show the input field.
+        if ((event.state & Gdk.ModifierType.CONTROL_MASK) > 0) {
+            zoom_default_button.visible = false;
+            zoom_default_button.no_show_all = true;
+            zoom_input.visible = true;
+            zoom_input.no_show_all = false;
+            zoom_input.grab_focus ();
 
-    public void zoom_reset () {
+            return true;
+        }
+
+        // Otherwise reset the zoom to 100%.
         zoom_in_button.sensitive = true;
         zoom_out_button.sensitive = true;
-
         window.event_bus.set_scale (1);
+
+        return true;
+    }
+
+    private void on_set_scale (double scale) {
+        var perc_scale = scale * 100;
+        zoom_default_button.label = "%.0f%%".printf (perc_scale);
+        zoom_input.text = perc_scale.to_string ();
+    }
+
+    private bool handle_key_press (Gdk.EventKey event) {
+        // Arrow UP pressed, increase value by 1.
+        if (event.keyval == Gdk.Key.Up) {
+            var text_value = double.parse (zoom_input.text) + 1;
+            window.event_bus.set_scale (text_value / 100);
+            return true;
+        }
+
+        // Arrow DOWN pressed, decreased value by 1.
+        if (event.keyval == Gdk.Key.Down) {
+            var text_value = double.parse (zoom_input.text) - 1;
+            window.event_bus.set_scale (text_value / 100);
+            return true;
+        }
+
+        // Enter pressed, update the scale and move the focus back to the canvas.
+        if (event.keyval == Gdk.Key.Return) {
+            var text_value = double.parse (zoom_input.text);
+
+            // Be sure to stay within the canvas zoom in and out limits of 2% and 5000%.
+            if (text_value < 2) {
+                text_value = 2;
+            }
+            if (text_value > 5000) {
+                text_value = 5000;
+            }
+
+            window.event_bus.set_scale (text_value / 100);
+            window.event_bus.set_focus_on_canvas ();
+            return true;
+        }
+
+        // Escape pressed, reset to the old value held by the zoom button.
+        if (event.keyval == Gdk.Key.Escape) {
+            zoom_input.text = zoom_default_button.label.replace ("%", "");
+            window.event_bus.set_focus_on_canvas ();
+            return true;
+        }
+
+        // Only allow arrows, delete, and backspace keys other than numbers.
+        if (
+            event.keyval == Gdk.Key.Left ||
+            event.keyval == Gdk.Key.Right ||
+            event.keyval == Gdk.Key.Delete ||
+            event.keyval == Gdk.Key.BackSpace
+        ) {
+            return false;
+        }
+
+        // Gtk.Entry doesn't currently support the "number only" filter, so
+        // we need to intercept the keypress and prevent typing if the value
+        // is not a number.
+        if (!(event.keyval >= Gdk.Key.@0 && event.keyval <= Gdk.Key.@9)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool handle_focus_in (Gdk.EventFocus event) {
+        window.event_bus.disconnect_typing_accel ();
+        return false;
+    }
+
+    private bool handle_focus_out (Gdk.EventFocus event) {
+        window.event_bus.connect_typing_accel ();
+        zoom_input.visible = false;
+        zoom_input.no_show_all = true;
+
+        zoom_default_button.visible = true;
+        zoom_default_button.no_show_all = false;
+        return false;
     }
 }

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -65,7 +65,7 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         zoom_input.secondary_icon_sensitive = false;
         zoom_input.secondary_icon_activatable = false;
         zoom_input.xalign = 1.0f;
-        zoom_input.width_chars = 9;
+        zoom_input.width_chars = 8;
         // Hide the input by default.
         zoom_input.visible = false;
         zoom_input.no_show_all = true;

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -23,13 +23,15 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
     public weak Akira.Window window { get; set construct; }
 
     private Gtk.Label label_btn;
-    public Gtk.Button zoom_out_button;
+    private Gtk.Button zoom_out_button;
+    private Gtk.Button zoom_in_button;
     public Gtk.Button zoom_default_button;
-    public Gtk.Button zoom_in_button;
+    private Gtk.Entry zoom_input;
 
     public ZoomButton (Akira.Window window) {
         this.window = window;
 
+        // Grid specific attributes.
         get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
         get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         valign = Gtk.Align.CENTER;
@@ -37,12 +39,14 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         width_request = 140;
         hexpand = false;
 
+        // Zoom out button.
         zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", Gtk.IconSize.MENU);
         zoom_out_button.get_style_context ().add_class ("button-zoom");
         zoom_out_button.get_style_context ().add_class ("button-zoom-start");
         zoom_out_button.can_focus = false;
         zoom_out_button.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>minus"}, _("Zoom Out"));
 
+        // Default centered zoom button.
         zoom_default_button = new Gtk.Button.with_label ("100%");
         zoom_default_button.hexpand = true;
         zoom_default_button.can_focus = false;
@@ -51,6 +55,13 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
             _("Reset Zoom. Ctrl+click to input value")
         );
 
+        // The zoom input field.
+        zoom_input = new Gtk.Entry ();
+        zoom_input.input_purpose = Gtk.InputPurpose.NUMBER;
+        zoom_input.visible = false;
+        zoom_input.no_show_all = true;
+
+        // Zoom in button.
         zoom_in_button = new Gtk.Button.from_icon_name ("zoom-in-symbolic", Gtk.IconSize.MENU);
         zoom_in_button.get_style_context ().add_class ("button-zoom");
         zoom_in_button.get_style_context ().add_class ("button-zoom-end");
@@ -59,29 +70,40 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
 
         attach (zoom_out_button, 0, 0, 1, 1);
         attach (zoom_default_button, 1, 0, 1, 1);
+        // attach (zoom_input, 2, 0, 1, 1);
         attach (zoom_in_button, 2, 0, 1, 1);
 
+        // Headerbar button label.
         label_btn = new Gtk.Label (_("Zoom"));
         label_btn.get_style_context ().add_class ("headerbar-label");
         label_btn.margin_top = 4;
 
         attach (label_btn, 0, 1, 3, 1);
 
+        // Mouse click signals.
         zoom_out_button.clicked.connect (zoom_out);
         zoom_default_button.clicked.connect (zoom_reset);
         zoom_in_button.clicked.connect (zoom_in);
 
+        // Bind the visibility of the button label to the gsetting attribute.
         settings.bind("show-label", label_btn, "visible", SettingsBindFlags.DEFAULT);
         settings.bind("show-label", label_btn, "no-show-all", SettingsBindFlags.INVERT_BOOLEAN);
     }
 
+    /*
+     * Decrease the canvas scale by 50%.
+     */
     public void zoom_out () {
         window.event_bus.update_scale (-0.5);
     }
 
+    /*
+     * Increase the canvas scale by 50%.
+     */
     public void zoom_in () {
         window.event_bus.update_scale (0.5);
     }
+
 
     public void zoom_reset () {
         zoom_in_button.sensitive = true;

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -38,7 +38,6 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         hexpand = false;
 
         zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", Gtk.IconSize.MENU);
-        zoom_out_button.clicked.connect (zoom_out);
         zoom_out_button.get_style_context ().add_class ("button-zoom");
         zoom_out_button.get_style_context ().add_class ("button-zoom-start");
         zoom_out_button.can_focus = false;
@@ -46,12 +45,13 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
 
         zoom_default_button = new Gtk.Button.with_label ("100%");
         zoom_default_button.hexpand = true;
-        zoom_default_button.clicked.connect (zoom_reset);
         zoom_default_button.can_focus = false;
-        zoom_default_button.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>0"}, _("Reset Zoom"));
+        zoom_default_button.tooltip_markup = Granite.markup_accel_tooltip (
+            {"<Ctrl>0"},
+            _("Reset Zoom. Ctrl+click to input value")
+        );
 
         zoom_in_button = new Gtk.Button.from_icon_name ("zoom-in-symbolic", Gtk.IconSize.MENU);
-        zoom_in_button.clicked.connect (zoom_in);
         zoom_in_button.get_style_context ().add_class ("button-zoom");
         zoom_in_button.get_style_context ().add_class ("button-zoom-end");
         zoom_in_button.can_focus = false;
@@ -66,16 +66,13 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         label_btn.margin_top = 4;
 
         attach (label_btn, 0, 1, 3, 1);
-        update_label ();
 
-        settings.changed["show-label"].connect ( () => {
-            update_label ();
-        });
-    }
+        zoom_out_button.clicked.connect (zoom_out);
+        zoom_default_button.clicked.connect (zoom_reset);
+        zoom_in_button.clicked.connect (zoom_in);
 
-    private void update_label () {
-        label_btn.visible = settings.show_label;
-        label_btn.no_show_all = !settings.show_label;
+        settings.bind("show-label", label_btn, "visible", SettingsBindFlags.DEFAULT);
+        settings.bind("show-label", label_btn, "no-show-all", SettingsBindFlags.INVERT_BOOLEAN);
     }
 
     public void zoom_out () {

--- a/src/Partials/ZoomButton.vala
+++ b/src/Partials/ZoomButton.vala
@@ -100,8 +100,8 @@ public class Akira.Partials.ZoomButton : Gtk.Grid {
         zoom_input.focus_out_event.connect (handle_focus_out);
 
         // Bind the visibility of the button label to the gsetting attribute.
-        settings.bind("show-label", label_btn, "visible", SettingsBindFlags.DEFAULT);
-        settings.bind("show-label", label_btn, "no-show-all", SettingsBindFlags.INVERT_BOOLEAN);
+        settings.bind ("show-label", label_btn, "visible", SettingsBindFlags.DEFAULT);
+        settings.bind ("show-label", label_btn, "no-show-all", SettingsBindFlags.INVERT_BOOLEAN);
 
         // Event listeners.
         window.event_bus.set_scale.connect (on_set_scale);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Allow writing the zoom level in an input field that can be revealed by holding <kbd>Ctrl</kbd> when clicking on the center zoom button

## Steps to Test
- <kbd>Ctrl</kbd> click on the center zoom button.
- Enter a value (confirm that letters and any other character is not allowed).
- Presse <kbd>Enter</kbd> and confirm the canvas zooms to the defined scale value.

## Screenshots
![zoom-input](https://user-images.githubusercontent.com/2527103/118348836-b323e180-b501-11eb-8abe-a9b6d0b308ef.gif)

## Known Issues / Things To Do
This feature makes it very clear that we need to force the zoom to be centered on the currently selected item, or the center of the current viewport.
Right now the zoom is a bit all over the place.

## This PR fixes/implements the following **bugs/features**:
- Fixes the styling of the linked zoom buttons.
- Implement manual zoom input field.
- Some code clean up and comments.
