### PR TITLE
Convert a few private properties to private fields

### DIFF
--- a/src/Layouts/Partials/Artboard.vala
+++ b/src/Layouts/Partials/Artboard.vala
@@ -55,7 +55,7 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
     private Gtk.Revealer motion_revealer;
     public Gtk.Revealer motion_artboard_revealer;
 
-    private bool _editing { get; set; default = false; }
+    private bool _editing;
     public bool editing {
         get { return _editing; } set { _editing = value; }
     }

--- a/src/Layouts/Partials/Layer.vala
+++ b/src/Layouts/Partials/Layer.vala
@@ -64,12 +64,12 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
     public Gtk.Revealer revealer;
     public Gtk.ListBox container;
 
-    private bool _editing { get; set; default = false; }
+    private bool _editing;
     public bool editing {
         get { return _editing; } set { _editing = value; }
     }
 
-    private bool _grouped { get; set; default = false; }
+    private bool _grouped;
     public bool grouped {
         get { return _grouped; } set construct { _grouped = value; }
     }

--- a/src/Lib/Components/Rotation.vala
+++ b/src/Lib/Components/Rotation.vala
@@ -23,7 +23,7 @@
  * Rotation component to keep track of the item's rotation.
  */
 public class Akira.Lib.Components.Rotation : Component {
-    private double _rotation { get; set; }
+    private double _rotation;
     public double rotation {
         get {
             return _rotation;


### PR DESCRIPTION
These are invalid property names anyway (and valac 0.54 will complain
about them), and they don't need getters and setters.
