### PR TITLE
Fix Theme not loading on non-elementary distros if opened from files manager

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -41,7 +41,7 @@ public class Akira.Application : Gtk.Application {
 
         weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
         default_theme.add_resource_path ("/com/github/akiraux/akira");
-            
+
         foreach (var file in files) {
             if (is_file_opened (file)) {
                 // Present active window with currently opened file.

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -36,6 +36,12 @@ public class Akira.Application : Gtk.Application {
     }
 
     public override void open (File[] files, string hint) {
+        Gtk.Settings.get_default ().set_property ("gtk-icon-theme-name", "elementary");
+        Gtk.Settings.get_default ().set_property ("gtk-theme-name", "io.elementary.stylesheet.blueberry");
+
+        weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
+        default_theme.add_resource_path ("/com/github/akiraux/akira");
+            
         foreach (var file in files) {
             if (is_file_opened (file)) {
                 // Present active window with currently opened file.


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
This problem only occurs with non-elementary distros if you open a `.akira` file from the files manager akira will load without the elementary theme and icons

## Steps to Test
Use any distro that is not Elementary OS open a `.akira` file from the files manager

## This PR fixes/implements the following **bugs/features**:
This fixes theme not loading on non elementary distros when opening a file