### PR TITLE
Fix application not properly activating if opened via saved file

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -36,6 +36,11 @@ public class Akira.Application : Gtk.Application {
     }
 
     public override void open (File[] files, string hint) {
+        // The application was requested to open some files. Be sure to activate
+        // it in case it wasn't already running.
+        activate ();
+
+        // Loop through all selected files.
         foreach (var file in files) {
             if (is_file_opened (file)) {
                 // Present active window with currently opened file.
@@ -107,6 +112,11 @@ public class Akira.Application : Gtk.Application {
     }
 
     protected override void activate () {
+        // Interrupt if we have at least one existing window.
+        if (windows.length () > 0) {
+            return;
+        }
+
         Gtk.Settings.get_default ().set_property ("gtk-icon-theme-name", "elementary");
         Gtk.Settings.get_default ().set_property ("gtk-theme-name", "io.elementary.stylesheet.blueberry");
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -36,10 +36,6 @@ public class Akira.Application : Gtk.Application {
     }
 
     public override void open (File[] files, string hint) {
-        // The application was requested to open some files. Be sure to activate
-        // it in case it wasn't already running.
-        activate ();
-
         // Loop through all selected files.
         foreach (var file in files) {
             if (is_file_opened (file)) {
@@ -57,6 +53,10 @@ public class Akira.Application : Gtk.Application {
                 current_window.event_bus.file_saved (file.get_basename ());
                 continue;
             }
+
+            // The application was requested to open some files. Be sure to
+            // initialize the theme in case it wasn't already running.
+            init_theme ();
 
             // Open a new window.
             var window = new Akira.Window (this);
@@ -112,16 +112,7 @@ public class Akira.Application : Gtk.Application {
     }
 
     protected override void activate () {
-        // Interrupt if we have at least one existing window.
-        if (windows.length () > 0) {
-            return;
-        }
-
-        Gtk.Settings.get_default ().set_property ("gtk-icon-theme-name", "elementary");
-        Gtk.Settings.get_default ().set_property ("gtk-theme-name", "io.elementary.stylesheet.blueberry");
-
-        weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
-        default_theme.add_resource_path ("/com/github/akiraux/akira");
+        init_theme ();
 
         var window = new Akira.Window (this);
         this.add_window (window);
@@ -139,5 +130,19 @@ public class Akira.Application : Gtk.Application {
         if (settings.open_quick) {
             window.action_manager.action_load_first ();
         }
+    }
+
+    private void init_theme () {
+        // Interrupt if we have at least one existing window, meaning the theme
+        // was previously initialized.
+        if (windows.length () > 0) {
+            return;
+        }
+
+        Gtk.Settings.get_default ().set_property ("gtk-icon-theme-name", "elementary");
+        Gtk.Settings.get_default ().set_property ("gtk-theme-name", "io.elementary.stylesheet.blueberry");
+
+        weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
+        default_theme.add_resource_path ("/com/github/akiraux/akira");
     }
 }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
If Akira is opened via a saved `.akira` file, the `activate ()` method doesn't run properly, preventing proper setup and theme loading.
This patch make sure to run that method on the proper occasion, and avoid it if the application is already active.

## Steps to Test
1. Create a file, save it, and close Akira.
2. Double click on the saved file.
3. Confirm the theme and settings are working properly.
4. This can be verified only on a non-elementary system.

- Fixes #551, probably...hopefully.
- Closing #589 in favor of this.
