### PR TITLE
Fix terminal warnings and crosshair cursor after Image File is dragged into the canvas

### DIFF
--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -117,7 +117,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
 
         Gtk.drag_finish (drag_context, true, false, time);
-        mode_manager.deregister_mode (Modes.InteractionMode.ModeType.ITEM_INSERT);
+        mode_manager.deregister_active_mode ();
 
         update_canvas ();
     }

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -98,6 +98,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
     ) {
         // Loop through the list of the dragged files.
         int index = 0;
+        window.event_bus.insert_item ("image");
         foreach (string link in data.get_uris ()) {
             var file_link = link.replace ("file://", "").replace ("file:/", "");
             file_link = Uri.unescape_string (file_link);
@@ -108,7 +109,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
             // Create the image manager.
             var manager = new Lib.Managers.ImageManager (image, index);
             // Let the app know that we're adding image items.
-            window.event_bus.insert_item ("image");
+
             // Create the item.
             var item = window.items_manager.insert_item (x, y, manager);
             // Force the resize of the item to its original size.

--- a/src/Lib/Canvas.vala
+++ b/src/Lib/Canvas.vala
@@ -117,6 +117,7 @@ public class Akira.Lib.Canvas : Goo.Canvas {
         }
 
         Gtk.drag_finish (drag_context, true, false, time);
+        mode_manager.deregister_mode (Modes.InteractionMode.ModeType.ITEM_INSERT);
 
         update_canvas ();
     }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
After the modes manager has been implemented some code stayed outdated
This will deregister the insert mode after the canvas image has been created

## Steps to Test
Drag an Image File into the canvas

## Screenshots
![image](https://user-images.githubusercontent.com/77546233/119257484-ac623200-bbc5-11eb-96db-3f1b126041f0.png)


## Known Issues / Things To Do
No known issues

## This PR fixes/implements the following **bugs/features**:
Fix terminal warnings and crosshair cursor after Image File is dragged into the canvas

- Fixes Fix terminal warnings after Image File is dragged into the canvas
- Crosshair cursor after Image File is dragged into the canvas
