### PR TITLE
Implement global colors

### DIFF
--- a/data/css/colors.css
+++ b/data/css/colors.css
@@ -11,6 +11,12 @@
 }
 
 .rounded-color-button {
-    border-radius: 12px;
-    border: 1px solid transparent;
+    background-image: /* tint image */
+                      linear-gradient(to right, rgba(192, 192, 192, 0.75), rgba(192, 192, 192, 0.75)),
+                      /* checkered effect */
+                      linear-gradient(to right, black 50%, white 50%),
+                      linear-gradient(to bottom, black 50%, white 50%);
+    background-blend-mode: normal, difference, normal;
+    background-size: 8px 8px;
+    border-radius: 4px;
 }

--- a/data/css/colors.css
+++ b/data/css/colors.css
@@ -9,3 +9,8 @@
 .border-bottom {
     border-bottom: 1px solid shade (@bg_color, 0.8);
 }
+
+.rounded-color-button {
+    border-radius: 12px;
+    border: 1px solid transparent;
+}

--- a/data/css/colors.css
+++ b/data/css/colors.css
@@ -9,14 +9,3 @@
 .border-bottom {
     border-bottom: 1px solid shade (@bg_color, 0.8);
 }
-
-.rounded-color-button {
-    background-image: /* tint image */
-                      linear-gradient(to right, rgba(192, 192, 192, 0.75), rgba(192, 192, 192, 0.75)),
-                      /* checkered effect */
-                      linear-gradient(to right, black 50%, white 50%),
-                      linear-gradient(to bottom, black 50%, white 50%);
-    background-blend-mode: normal, difference, normal;
-    background-size: 8px 8px;
-    border-radius: 4px;
-}

--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -30,6 +30,16 @@
   padding: 8px 5px;
 }
 
+.color-grid flowboxchild {
+    background-color: transparent;
+}
+
+.color-picker label {
+    font-size: 9pt;
+    font-weight: bold;
+    color: @fg_color;
+}
+
 .popover-toggler {
     padding: 3px;
     margin: 3px;

--- a/data/css/option-panel.css
+++ b/data/css/option-panel.css
@@ -28,12 +28,19 @@
                       linear-gradient(to bottom, black 50%, white 50%);
     background-blend-mode: normal, difference, normal;
     background-size: 8px 8px;
-    border-radius: 3px 0 0 3px;
+}
+
+.selected-color-container {
+    border-radius: 4px 0 0 4px;
 }
 
 button.selected-color {
     border-radius: 3px 0 0 3px;
     border: 1px solid;
+}
+
+.saved-color-button {
+    border-radius: 4px;
 }
 
 /* spin button */

--- a/data/schemas/com.github.akiraux.akira.gschema.xml.in
+++ b/data/schemas/com.github.akiraux.akira.gschema.xml.in
@@ -107,6 +107,7 @@
             <summary>Default Border Width.</summary>
             <description>The default width of the border for a newly created shape.</description>
         </key>
+
         <key name="border-color" type="s">
             <default>'#AAAAAA'</default>
             <summary>Default Border Color.</summary>
@@ -177,6 +178,12 @@
             <default>true</default>
             <summary>The alpha setting for exporting PNG images.</summary>
             <description>The alpha setting for exporting PNG images in the export dialog.</description>
+        </key>
+
+        <key name="global-colors" type="as">
+            <default>[]</default>
+            <summary>The list of global colors</summary>
+            <description>Keep track of the colors saved by the user and available in every document file.</description>
         </key>
     </schema>
 </schemalist>

--- a/src/Layouts/Partials/BorderItem.vala
+++ b/src/Layouts/Partials/BorderItem.vala
@@ -109,7 +109,9 @@ public class Akira.Layouts.Partials.BorderItem : Gtk.Grid {
         color_chooser.margin_end = 5;
 
         var selected_color_container = new Gtk.Grid ();
-        selected_color_container.get_style_context ().add_class ("bg-pattern");
+        var context = selected_color_container.get_style_context ();
+        context.add_class ("selected-color-container");
+        context.add_class ("bg-pattern");
 
         selected_color = new Gtk.Button ();
         selected_color.vexpand = true;

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -113,7 +113,9 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         fill_chooser.margin_end = 5;
 
         var selected_color_container = new Gtk.Grid ();
-        selected_color_container.get_style_context ().add_class ("bg-pattern");
+        var context = selected_color_container.get_style_context ();
+        context.add_class ("selected-color-container");
+        context.add_class ("bg-pattern");
 
         selected_color = new Gtk.Button ();
         selected_color.vexpand = true;

--- a/src/Layouts/Partials/FillItem.vala
+++ b/src/Layouts/Partials/FillItem.vala
@@ -30,14 +30,25 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
     private Gtk.Button delete_button;
     private Gtk.Image hidden_button_icon;
     private Gtk.Button selected_color;
-    public Akira.Partials.InputField opacity_container;
-    public Akira.Partials.ColorField color_container;
+    private Akira.Partials.InputField opacity_container;
+    private Akira.Partials.ColorField color_container;
     private Gtk.Popover color_popover;
     private Gtk.Grid color_picker;
     private Gtk.ColorChooserWidget? color_chooser_widget = null;
     private Akira.Utils.ColorPicker eyedropper;
 
+    private Gtk.FlowBox global_colors_flowbox;
+
     public Akira.Models.FillsItemModel model { get; construct; }
+
+    /*
+     * Type of color containers to add new colors to. We can potentially create
+     * an API to allow adding more containers to the color picker popup.
+     */
+    private enum Container {
+        GLOBAL,
+        DOCUMENT
+    }
 
     private string old_color;
 
@@ -217,7 +228,36 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
 
         color_picker = new Gtk.Grid ();
         color_picker.get_style_context ().add_class ("color-picker");
+        color_picker.row_spacing = 12;
+
+        var global_colors_label = new Gtk.Label (_("Global colors"));
+        global_colors_label.halign = Gtk.Align.START;
+        global_colors_label.margin_start = global_colors_label.margin_end = 6;
+
+        global_colors_flowbox = new Gtk.FlowBox ();
+        global_colors_flowbox.get_style_context ().add_class ("color-grid");
+        global_colors_flowbox.selection_mode = Gtk.SelectionMode.NONE;
+        global_colors_flowbox.homogeneous = false;
+        global_colors_flowbox.column_spacing = global_colors_flowbox.row_spacing = 6;
+        global_colors_flowbox.margin_start = global_colors_flowbox.margin_end = 6;
+        // Large number to allow children to spread out the available space.
+        global_colors_flowbox.max_children_per_line = 100;
+        global_colors_flowbox.set_sort_func (sort_colors_function);
+
+        var add_global_color_btn = new Akira.Partials.AddColorButton ();
+        add_global_color_btn.clicked.connect (() => {
+            on_save_color (Container.GLOBAL);
+        });
+        global_colors_flowbox.add (add_global_color_btn);
+
+        foreach (string color in settings.global_colors) {
+            var btn = create_color_button (color);
+            global_colors_flowbox.add (btn);
+        }
+
         color_picker.attach (color_chooser_widget, 0, 0, 1, 1);
+        color_picker.attach (global_colors_label, 0, 1, 1, 1);
+        color_picker.attach (global_colors_flowbox, 0, 2, 1, 1);
         color_picker.show_all ();
         color_popover.add (color_picker);
 
@@ -229,6 +269,47 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         eyedropper_button.clicked.connect (on_eyedropper_click);
         delete_button.clicked.connect (on_delete_item);
         hidden_button.clicked.connect (toggle_visibility);
+    }
+
+    /*
+     * Add the current color to the parent flowbox.
+     */
+    private void on_save_color (Container parent) {
+        // Store the currently active color.
+        var color = color_chooser_widget.rgba.to_string ();
+
+        // Create the new color button and connect to its signal.
+        var btn = create_color_button (color);
+
+        // Update the colors list and the schema based on the colors container.
+        switch (parent) {
+            case Container.GLOBAL:
+                global_colors_flowbox.add (btn);
+                var array = settings.global_colors;
+                array += color;
+                settings.global_colors = array;
+                break;
+
+            case Container.DOCUMENT:
+                // TODO...
+                break;
+        }
+    }
+
+    private Gtk.FlowBoxChild create_color_button (string color) {
+        var child = new Gtk.FlowBoxChild ();
+        child.valign = child.halign = Gtk.Align.CENTER;
+
+        var btn = new Akira.Partials.RoundedColorButton (color);
+        btn.set_color.connect ((color) => {
+            var rgba_color = Gdk.RGBA ();
+            rgba_color.parse (color);
+            color_chooser_widget.set_rgba (rgba_color);
+        });
+
+        child.add (btn);
+        child.show_all ();
+        return child;
     }
 
     private void on_eyedropper_click () {
@@ -323,5 +404,9 @@ public class Akira.Layouts.Partials.FillItem : Gtk.Grid {
         new_rgba.alpha = (double) alpha / 255;
 
         color_chooser_widget.set_rgba (new_rgba);
+    }
+
+    private int sort_colors_function (Gtk.FlowBoxChild a, Gtk.FlowBoxChild b) {
+        return (a is Akira.Partials.AddColorButton) ? -1 : 1;
     }
 }

--- a/src/Partials/AddColorButton.vala
+++ b/src/Partials/AddColorButton.vala
@@ -28,6 +28,6 @@ public class Akira.Partials.AddColorButton : Gtk.Button {
         can_focus = false;
         valign = halign = Gtk.Align.CENTER;
         image = new Gtk.Image.from_icon_name ("list-add-symbolic", Gtk.IconSize.MENU);
-        tooltip_text = _("Add current color to the library");
+        tooltip_text = _("Add the current color to the library");
     }
 }

--- a/src/Partials/AddColorButton.vala
+++ b/src/Partials/AddColorButton.vala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Abdallah "Abdallah-Moh" Mohammad <abdullah_mam1@icloud.com>
+ * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
+ */
+
+/*
+ * Helper class to quickly create a simple style button with a + icon.
+ */
+public class Akira.Partials.AddColorButton : Gtk.Button {
+    public AddColorButton () {
+        get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        width_request = height_request = 24;
+        can_focus = false;
+        valign = halign = Gtk.Align.CENTER;
+        image = new Gtk.Image.from_icon_name ("list-add-symbolic", Gtk.IconSize.MENU);
+        tooltip_text = _("Add current color to the library");
+    }
+}

--- a/src/Partials/RoundedColorButton.vala
+++ b/src/Partials/RoundedColorButton.vala
@@ -22,12 +22,14 @@ public class Akira.Partials.RoundedColorButton : Gtk.Grid {
     public signal void set_color (string color);
 
     public RoundedColorButton (string color) {
-        get_style_context ().add_class ("rounded-color-button");
+        var context = get_style_context ();
+        context.add_class ("saved-color-button");
+        context.add_class ("bg-pattern");
         valign = halign = Gtk.Align.CENTER;
 
         var btn = new Gtk.Button ();
-        var context = btn.get_style_context ();
-        context.add_class ("color-item");
+        var btn_context = btn.get_style_context ();
+        btn_context.add_class ("color-item");
         btn.width_request = btn.height_request = 24;
         btn.valign = btn.halign = Gtk.Align.CENTER;
         btn.can_focus = false;
@@ -41,7 +43,7 @@ public class Akira.Partials.RoundedColorButton : Gtk.Grid {
                 }""".printf (color, color);
 
             provider.load_from_data (css, css.length);
-            context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            btn_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         } catch (Error e) {
             warning ("Style error: %s", e.message);
         }

--- a/src/Partials/RoundedColorButton.vala
+++ b/src/Partials/RoundedColorButton.vala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Abdallah "Abdallah-Moh" Mohammad <abdullah_mam1@icloud.com>
+ * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
+ */
+
+public class Akira.Partials.RoundedColorButton : Gtk.Button {
+    public RoundedColorButton (string color) {
+        var context = get_style_context ();
+        context.add_class ("rounded-color-button");
+        context.add_class ("color-item");
+        width_request = height_request = 24;
+        can_focus = false;
+        tooltip_text = _("Apply this color to the current selection");
+
+        try {
+            var provider = new Gtk.CssProvider ();
+            var css = """.color-item {
+                    background-color: %s;
+                    border-color: shade (%s, 0.75);
+                    border-radius:50%;
+                }""".printf (color, color);
+
+            provider.load_from_data (css, css.length);
+            context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        } catch (Error e) {
+            warning ("Style error: %s", e.message);
+        }
+    }
+}

--- a/src/Partials/RoundedColorButton.vala
+++ b/src/Partials/RoundedColorButton.vala
@@ -18,21 +18,26 @@
  * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
-public class Akira.Partials.RoundedColorButton : Gtk.Button {
+public class Akira.Partials.RoundedColorButton : Gtk.Grid {
+    public signal void set_color (string color);
+
     public RoundedColorButton (string color) {
-        var context = get_style_context ();
-        context.add_class ("rounded-color-button");
+        get_style_context ().add_class ("rounded-color-button");
+        valign = halign = Gtk.Align.CENTER;
+
+        var btn = new Gtk.Button ();
+        var context = btn.get_style_context ();
         context.add_class ("color-item");
-        width_request = height_request = 24;
-        can_focus = false;
-        tooltip_text = _("Apply this color to the current selection");
+        btn.width_request = btn.height_request = 24;
+        btn.valign = btn.halign = Gtk.Align.CENTER;
+        btn.can_focus = false;
+        btn.tooltip_text = color;
 
         try {
             var provider = new Gtk.CssProvider ();
             var css = """.color-item {
                     background-color: %s;
                     border-color: shade (%s, 0.75);
-                    border-radius:50%;
                 }""".printf (color, color);
 
             provider.load_from_data (css, css.length);
@@ -40,5 +45,12 @@ public class Akira.Partials.RoundedColorButton : Gtk.Button {
         } catch (Error e) {
             warning ("Style error: %s", e.message);
         }
+
+        // Emit the set_color signal when the button is clicked.
+        btn.clicked.connect (() => {
+            set_color (color);
+        });
+
+        add (btn);
     }
 }

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -149,6 +149,12 @@ public class Akira.Services.Settings : GLib.Settings {
         set { set_boolean ("export-alpha", value); }
     }
 
+    // Colors library.
+    public string[] global_colors {
+        owned get { return get_strv ("global-colors"); }
+        set { set_strv ("global-colors", value); }
+    }
+
     public Settings () {
         Object (schema_id: Constants.APP_ID);
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,6 +55,7 @@ sources = files(
     'Layouts/Partials/BorderRadiusPanel.vala',
     'Layouts/Partials/AlignItemsPanel.vala',
 
+    'Partials/AddColorButton.vala',
     'Partials/HeaderBarButton.vala',
     'Partials/MenuButton.vala',
     'Partials/ZoomButton.vala',
@@ -64,6 +65,7 @@ sources = files(
     'Partials/ColorField.vala',
     'Partials/LinkedInput.vala',
     'Partials/PanelSeparator.vala',
+    'Partials/RoundedColorButton.vala',
     'Partials/ExportWidget.vala',
 
     'Models/BordersItemModel.vala',


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implement a barebone Global color library users can use to save colors. 

## Steps to Test
Create various colors and save them.
Confirm that the colors are maintained at the next restart.

## Screenshots 
![Screenshot from 2021-05-26 23-35-38](https://user-images.githubusercontent.com/2527103/119777562-34249680-be7b-11eb-9029-5e2e16e5e03f.png)

## Known Issues / Things To Do
This is an initial implementation but the feature is not complete.
Follow up PRs will implement the ability to delete and reorder colors.
