### PR TITLE
Fix nobs regression

### DIFF
--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -442,13 +442,38 @@ public class Akira.Lib.Managers.NobManager : Object {
 
             var nob_name = nob.handle_id;
 
-            calculate_nob_position ( nob_name, nob_data, ref center_x, ref center_y );
+            calculate_nob_position (nob_name, nob_data, ref center_x, ref center_y);
 
+            // Check if we need to hide the vertically centered nobs.
             if (!print_middle_height_nobs && (nob_name == Nob.RIGHT_CENTER || nob_name == Nob.LEFT_CENTER)) {
                 set_visible = false;
-            } else if (!print_middle_width_nobs && (nob_name == Nob.TOP_CENTER || nob_name == Nob.BOTTOM_CENTER)) {
+            }
+
+            // Check if we need to hide the horizontally centere nobs.
+            if (!print_middle_width_nobs && (nob_name == Nob.TOP_CENTER || nob_name == Nob.BOTTOM_CENTER)) {
                 set_visible = false;
-            } else if (nob.handle_id == Nob.ROTATE) {
+            }
+
+            // If we're hiding all centered nobs, we need to shift the position
+            // of the corner nobs to improve the grabbing area.
+            if (!print_middle_width_nobs && !print_middle_height_nobs) {
+                if (nob_name == Nob.TOP_LEFT) {
+                    center_x -= nob_size / 2;
+                    center_y -= nob_size / 2;
+                } else if (nob_name == Nob.TOP_RIGHT) {
+                    center_x += nob_size / 2;
+                    center_y -= nob_size / 2;
+                } else if (nob_name == Nob.BOTTOM_RIGHT) {
+                    center_x += nob_size / 2;
+                    center_y += nob_size / 2;
+                } else if (nob_name == Nob.BOTTOM_LEFT) {
+                    center_x -= nob_size / 2;
+                    center_y += nob_size / 2;
+                }
+            }
+
+            // Unique calculation for the rotation nob.
+            if (nob.handle_id == Nob.ROTATE) {
                 double line_offset_x = 0;
                 double line_offset_y = - (LINE_HEIGHT / canvas.current_scale);
                 nob_data.bb_matrix.transform_distance (ref line_offset_x, ref line_offset_y);

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -490,26 +490,25 @@ public class Akira.Lib.Managers.NobManager : Object {
                 set_visible = false;
             }
 
+            nob.update_state (nob_data.bb_matrix, center_x, center_y, set_visible);
+            nob.raise (select_effect);
+
             // If we're hiding all centered nobs, we need to shift the position
             // of the corner nobs to improve the grabbing area.
             if (!print_middle_width_nobs && !print_middle_height_nobs) {
+                var half = nob_size / 2;
+
+                // Use Cairo.translate to automatically account for the item's rotation.
                 if (nob_name == Nob.TOP_LEFT) {
-                    center_x -= nob_size / 2;
-                    center_y -= nob_size / 2;
+                    nob.translate (-half, -half);
                 } else if (nob_name == Nob.TOP_RIGHT) {
-                    center_x += nob_size / 2;
-                    center_y -= nob_size / 2;
+                    nob.translate (half, -half);
                 } else if (nob_name == Nob.BOTTOM_RIGHT) {
-                    center_x += nob_size / 2;
-                    center_y += nob_size / 2;
+                    nob.translate (half, half);
                 } else if (nob_name == Nob.BOTTOM_LEFT) {
-                    center_x -= nob_size / 2;
-                    center_y += nob_size / 2;
+                    nob.translate (-half, half);
                 }
             }
-
-            nob.update_state (nob_data.bb_matrix, center_x, center_y, set_visible);
-            nob.raise (select_effect);
         }
     }
 

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -444,34 +444,6 @@ public class Akira.Lib.Managers.NobManager : Object {
 
             calculate_nob_position (nob_name, nob_data, ref center_x, ref center_y);
 
-            // Check if we need to hide the vertically centered nobs.
-            if (!print_middle_height_nobs && (nob_name == Nob.RIGHT_CENTER || nob_name == Nob.LEFT_CENTER)) {
-                set_visible = false;
-            }
-
-            // Check if we need to hide the horizontally centere nobs.
-            if (!print_middle_width_nobs && (nob_name == Nob.TOP_CENTER || nob_name == Nob.BOTTOM_CENTER)) {
-                set_visible = false;
-            }
-
-            // If we're hiding all centered nobs, we need to shift the position
-            // of the corner nobs to improve the grabbing area.
-            if (!print_middle_width_nobs && !print_middle_height_nobs) {
-                if (nob_name == Nob.TOP_LEFT) {
-                    center_x -= nob_size / 2;
-                    center_y -= nob_size / 2;
-                } else if (nob_name == Nob.TOP_RIGHT) {
-                    center_x += nob_size / 2;
-                    center_y -= nob_size / 2;
-                } else if (nob_name == Nob.BOTTOM_RIGHT) {
-                    center_x += nob_size / 2;
-                    center_y += nob_size / 2;
-                } else if (nob_name == Nob.BOTTOM_LEFT) {
-                    center_x -= nob_size / 2;
-                    center_y += nob_size / 2;
-                }
-            }
-
             // Unique calculation for the rotation nob.
             if (nob.handle_id == Nob.ROTATE) {
                 double line_offset_x = 0;
@@ -505,7 +477,35 @@ public class Akira.Lib.Managers.NobManager : Object {
                 // Raise to the rotation_line, so the line is under the rotation nob.
                 nob.update_state (nob_data.bb_matrix, center_x, center_y, set_visible);
                 nob.raise (rotation_line);
-                return;
+                continue;
+            }
+
+            // Check if we need to hide the vertically centered nobs.
+            if (!print_middle_height_nobs && (nob_name == Nob.RIGHT_CENTER || nob_name == Nob.LEFT_CENTER)) {
+                set_visible = false;
+            }
+
+            // Check if we need to hide the horizontally centere nobs.
+            if (!print_middle_width_nobs && (nob_name == Nob.TOP_CENTER || nob_name == Nob.BOTTOM_CENTER)) {
+                set_visible = false;
+            }
+
+            // If we're hiding all centered nobs, we need to shift the position
+            // of the corner nobs to improve the grabbing area.
+            if (!print_middle_width_nobs && !print_middle_height_nobs) {
+                if (nob_name == Nob.TOP_LEFT) {
+                    center_x -= nob_size / 2;
+                    center_y -= nob_size / 2;
+                } else if (nob_name == Nob.TOP_RIGHT) {
+                    center_x += nob_size / 2;
+                    center_y -= nob_size / 2;
+                } else if (nob_name == Nob.BOTTOM_RIGHT) {
+                    center_x += nob_size / 2;
+                    center_y += nob_size / 2;
+                } else if (nob_name == Nob.BOTTOM_LEFT) {
+                    center_x -= nob_size / 2;
+                    center_y += nob_size / 2;
+                }
             }
 
             nob.update_state (nob_data.bb_matrix, center_x, center_y, set_visible);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Add back the feature that allowed corner nobs to move outside the boundaries of the selected item when the size is too small.
I'm fixing this on `master` as I don't want to push against Lib2, in preparation of one final flatpak release before we start going all in `Lib2`.
Not sure if you already have this feature in `Lib2`.

## Steps to Test
Create an item and resize it until all centered nobs are hidden.
You should see the corner nobs "stepping" outside the item's boundaries.

## This PR fixes/implements the following **bugs/features**:
- Do an early `continue` in the `for` loop if we're dealing with the rotation nob and avoid running unnecessary conditions.
- Remove `else` callback for conditions (pure code styling preferences, it shouldn't affect performance).
- Use a simple `Cairo.translate()` to shift the nobs when necessary as it moves them by their local coordinates, automatically accounting for any rotation.

---

- Fixes #607
