### PR TITLE
Fix rotation issue

### DIFF
--- a/src/Lib2/Modes/TransformMode.vala
+++ b/src/Lib2/Modes/TransformMode.vala
@@ -541,11 +541,13 @@ public class Akira.Lib2.Modes.TransformMode : AbstractInteractionMode {
                     rotation_center_x + new_center_delta_x,
                     rotation_center_y + new_center_delta_y
                 );
+
+                tmp_rotation += item_rotation;
             }
         }
 
         if (item.components.transform != null) {
-            tmp_rotation = GLib.Math.fmod (item_rotation + tmp_rotation + GLib.Math.PI * 2, GLib.Math.PI * 2);
+            tmp_rotation = GLib.Math.fmod (tmp_rotation + GLib.Math.PI * 2, GLib.Math.PI * 2);
             item.components.transform = item.components.transform.with_main_rotation (tmp_rotation);
         }
 

--- a/src/Utils/GeometryMath.vala
+++ b/src/Utils/GeometryMath.vala
@@ -125,6 +125,13 @@ public class Akira.Utils.GeometryMath : Object {
     }
 
     /*
+     * Returns the rotation component of a matrix.
+     */
+    public static double matrix_rotation_component (Cairo.Matrix mat) {
+        return GLib.Math.atan2 (mat.yx, mat.xx);
+    }
+
+    /*
      * Decomposes a matrix to three operations (scale, shear and rotation)
      *
      * To recompose run two multiplications:


### PR DESCRIPTION

<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
Single objects were having their rotation compounded twice due to multiselect code. This code fixes the issue by forking the logic where the original rotation was being factored back into the total rotation for multiselections.

## Steps to Test
Rotate a single object twice.