### PR TITLE
Improve nobs position on resize

### DIFF
--- a/src/Drawables/Drawable.vala
+++ b/src/Drawables/Drawable.vala
@@ -31,7 +31,7 @@ public class Akira.Drawables.Drawable : Goo.CanvasItemSimple, Goo.CanvasItem {
     public double width { get; set; default = 0; }
     public double height { get; set; default = 0; }
 
-    /// Clipping path in global reference frame
+    // Clipping path in global reference frame
     public Geometry.Quad? clipping_path = null;
 
     public bool new_hit_test (

--- a/src/Lib2/Components/CompiledGeometry.vala
+++ b/src/Lib2/Components/CompiledGeometry.vala
@@ -25,10 +25,10 @@ public class Akira.Lib2.Components.CompiledGeometry : Copyable<CompiledGeometry>
         public Size? source_size;
         public Transform? source_transform;
         public Cairo.Matrix _transformation_matrix;
-        // These rectangles are in global coordinates
+        // These rectangles are in global coordinates.
         public Geometry.Quad area;
 
-        // Cahced bounding box that contains the rotated area
+        // Cached bounding box that contains the rotated area.
         public Geometry.Rectangle area_bb;
 
         public CompiledGeometryData () {

--- a/src/Lib2/Managers/ModeManager.vala
+++ b/src/Lib2/Managers/ModeManager.vala
@@ -47,7 +47,7 @@ public class Akira.Lib2.Managers.ModeManager : Object {
 
     public Utils.Nobs.Nob active_mode_nob {
         get {
-            return (active_mode == null) ? Utils.Nobs.Nob.ALL : active_mode.acitve_nob ();
+            return (active_mode == null) ? Utils.Nobs.Nob.ALL : active_mode.active_nob ();
         }
     }
 

--- a/src/Lib2/Managers/NobManager.vala
+++ b/src/Lib2/Managers/NobManager.vala
@@ -142,8 +142,8 @@ public class Akira.Lib2.Managers.NobManager : Object {
     }
 
     /**
-     * Update the position of all nobs of selected items. It will show or hide them based on
-     * the properties of the selection.
+     * Update the position of all nobs of selected items. It will show or hide
+     * them based on the properties of the selection.
      */
     private void update_nob_positions (Lib2.Items.NodeSelection selection) {
         var nob_size = Lib.Selection.Nob.NOB_SIZE / view_canvas.current_scale;
@@ -163,8 +163,7 @@ public class Akira.Lib2.Managers.NobManager : Object {
 
             if (!show_h_centers && Utils.Nobs.is_horizontal_center (nob.handle_id)) {
                 set_visible = false;
-            }
-            else if (!show_v_centers && Utils.Nobs.is_vertical_center (nob.handle_id)) {
+            } else if (!show_v_centers && Utils.Nobs.is_vertical_center (nob.handle_id)) {
                 set_visible = false;
             }
 
@@ -207,11 +206,9 @@ public class Akira.Lib2.Managers.NobManager : Object {
 
                 rotation_line.set ("line-width", LINE_WIDTH / view_canvas.current_scale);
                 rotation_line.set ("visibility", Goo.CanvasItemVisibility.VISIBLE);
-            }
-            else {
+            } else {
                 rotation_line.set ("visibility", Goo.CanvasItemVisibility.HIDDEN);
             }
-
         }
 
         nob.update_global_state (cx, cy, 0, show);

--- a/src/Lib2/Modes/AbstractInteractionMode.vala
+++ b/src/Lib2/Modes/AbstractInteractionMode.vala
@@ -63,7 +63,7 @@ public abstract class Akira.Lib2.Modes.AbstractInteractionMode : Object {
     /*
      * Override to define a sub ModeType associated to mode.
      */
-    public virtual Utils.Nobs.Nob acitve_nob () {
+    public virtual Utils.Nobs.Nob active_nob () {
         return Utils.Nobs.Nob.ALL;
     }
 

--- a/src/Utils/AffineTransform.vala
+++ b/src/Utils/AffineTransform.vala
@@ -149,7 +149,7 @@ public class Akira.Utils.AffineTransform : Object {
      * Calculate adjustments necessary for a nob resize operation. All inputs
      * should have already been transformed to the correct space.
      */
-    public static void calculate_size_adjustments2 (
+    public static Utils.Nobs.Nob calculate_size_adjustments2 (
         Utils.Nobs.Nob nob,
         double item_width,
         double item_height,
@@ -261,6 +261,8 @@ public class Akira.Utils.AffineTransform : Object {
 
         inc_width += perm_w_adj;
         inc_height += perm_h_adj;
+
+        return nob;
     }
     /**
      * Corrects which nob should be used for scaling depending on the delta change of the drag.


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
The currently selected Nobs should always be correct when resizing an item.

## Steps to Test
Resize the item below its original size and confirm that the active Nob is always correct.