### PR TITLE
Fix paint_hover transform bug

### DIFF
--- a/src/Drawables/Drawable.vala
+++ b/src/Drawables/Drawable.vala
@@ -204,6 +204,8 @@ public class Akira.Drawables.Drawable {
         double scale
     ) {
         cr.save ();
+        Cairo.Matrix global_transform = cr.get_matrix ();
+
         // We apply the item transform before creating the path
         Cairo.Matrix tr = transform;
         cr.transform (tr);
@@ -212,7 +214,7 @@ public class Akira.Drawables.Drawable {
 
         cr.set_line_width (line_width / scale);
         cr.set_source_rgba (color.red, color.green, color.blue, color.alpha);
-        cr.set_matrix (Cairo.Matrix.identity ());
+        cr.set_matrix (global_transform);
         cr.stroke ();
 
         cr.restore ();


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
Hover was drawing huge items because of restoring the wrong matrix.

