### PR TITLE
Fix Artboard and multiselection hitbox detection

### DIFF
--- a/src/Drawables/Drawable.vala
+++ b/src/Drawables/Drawable.vala
@@ -25,6 +25,11 @@
  * 2. Add a clipping quad to make clipping more efficient.
  */
 public class Akira.Drawables.Drawable {
+    public enum HitTestType {
+        SELECT,
+        GROUP_REGION
+    }
+
     public enum BorderType {
         CENTER,
         INSIDE,
@@ -35,201 +40,203 @@ public class Akira.Drawables.Drawable {
     public double line_width { get; set; default = 0; }
     public Gdk.RGBA fill_rgba { get; set; default = Gdk.RGBA (); }
     public Gdk.RGBA stroke_rgba { get; set; default = Gdk.RGBA (); }
+    public BorderType border_type { get; set; default = BorderType.CENTER; }
+    public double radius_tr { get; set; default = 0; }
+    public double radius_tl { get; set; default = 0; }
+    public double radius_br { get; set; default = 0; }
+    public double radius_bl { get; set; default = 0; }
 
     public int parent_id { get; set; default = -1; }
     public double center_x { get; set; default = 0; }
     public double center_y { get; set; default = 0; }
     public double width { get; set; default = 0; }
     public double height { get; set; default = 0; }
-    public BorderType border_type { get; set; default = BorderType.CENTER; }
-
     public Cairo.Matrix transform { get; set; default = Cairo.Matrix.identity (); }
+
     public Geometry.Rectangle bounds { get; set; default = Geometry.Rectangle (); }
 
     // Clipping path in global reference frame
     public Geometry.Quad? clipping_path = null;
 
-    public bool new_hit_test (
+    // Convenience getters
+    public bool has_radius { get { return (radius_tr + radius_tl + radius_br + radius_bl) > 0; } }
+
+    public bool is_drawn = false;
+
+    /*
+     * Return true if the position x,y in local coordinates is inside of the selectable
+     * area of a drawable.
+     */
+    public virtual bool hit_test (
         double x,
         double y,
-        Cairo.Context cr,
-        bool is_pointer_event,
-        bool parent_visible
+        Cairo.Context context,
+        double scale,
+        HitTestType hit_test_type
     ) {
+        if (hit_test_type == GROUP_REGION) {
+            return false;
+        }
+
         double user_x = x, user_y = y;
         bool add_item = false;
 
         // Ignore if out of bounds
-        if (bounds.left > x || bounds.right < x || bounds.top > y || bounds.bottom < y) {
-          return false;
+        if (bounds.does_not_contain (x, y)) {
+            return false;
         }
 
-        Cairo.Matrix global_transform = cr.get_matrix ();
-        cr.save ();
+        Cairo.Matrix global_transform = context.get_matrix ();
+        context.save ();
 
         Cairo.Matrix tr = transform;
-        cr.transform (tr);
+        context.transform (tr);
 
         // Account for clipping path first, since they should be in the global reference
         if (clipping_path != null) {
-            cr.move_to (clipping_path.tl_x, clipping_path.tl_y);
-            cr.line_to (clipping_path.tr_x, clipping_path.tr_y);
-            cr.line_to (clipping_path.br_x, clipping_path.br_y);
-            cr.line_to (clipping_path.bl_x, clipping_path.bl_y);
-            cr.close_path ();
+            context.move_to (clipping_path.tl_x, clipping_path.tl_y);
+            context.line_to (clipping_path.tr_x, clipping_path.tr_y);
+            context.line_to (clipping_path.br_x, clipping_path.br_y);
+            context.line_to (clipping_path.bl_x, clipping_path.bl_y);
+            context.close_path ();
 
-            cr.set_fill_rule (Cairo.FillRule.WINDING);
-            if (!cr.in_fill (user_x, user_y)) {
-                cr.restore ();
-                cr.new_path ();
+            context.set_fill_rule (Cairo.FillRule.WINDING);
+            if (!context.in_fill (user_x, user_y)) {
+                context.restore ();
+                context.new_path ();
                 return false;
             }
         }
 
-        cr.device_to_user (ref user_x, ref user_y);
+        context.device_to_user (ref user_x, ref user_y);
 
         /* Remove any current translation, to avoid the 16-bit cairo limit. */
-        var tmp = cr.get_matrix ();
+        var tmp = context.get_matrix ();
         tmp.x0 = 0.0;
         tmp.y0 = 0.0;
-        cr.set_matrix (tmp);
+        context.set_matrix (tmp);
 
-        simple_create_path (cr);
+        simple_create_path (context);
 
         /* Check the filled path, if required. */
-        if (set_fill_options (cr)) {
-            if (cr.in_fill (user_x, user_y)) {
+        if (set_fill_options (context)) {
+            if (context.in_fill (user_x, user_y)) {
                 add_item = true;
             }
         }
 
         /* Check the stroke, if required. */
-        if (set_stroke_options (cr)) {
-            cr.set_matrix (global_transform);
+        if (set_stroke_options (context)) {
+            context.set_matrix (global_transform);
             user_x = x - tr.x0;
             user_y = y - tr.y0;
 
-            if (cr.in_stroke (user_x, user_y)) {
+            if (context.in_stroke (user_x, user_y)) {
                 add_item = true;
             }
         }
 
-        cr.restore ();
-        cr.new_path ();
+        context.restore ();
+        context.new_path ();
 
         return add_item;
     }
 
-
-    public unowned GLib.List<Drawable> get_items_at (
-        double x,
-        double y,
-        Cairo.Context cr,
-        bool is_pointer_event,
-        bool parent_visible,
-        GLib.List<Drawable> found_items
-    ) {
-        if (new_hit_test (x, y, cr, is_pointer_event, parent_visible)) {
-            found_items.prepend (this);
-        }
-
-        return found_items;
-    }
-
-    public bool set_fill_options (Cairo.Context context) {
-        context.set_source_rgba (fill_rgba.red, fill_rgba.green, fill_rgba.blue, fill_rgba.alpha);
-        context.set_antialias (Cairo.Antialias.GRAY);
-        return true;
-    }
-
-    public bool set_stroke_options (Cairo.Context context) {
-        context.set_source_rgba (stroke_rgba.red, stroke_rgba.green, stroke_rgba.blue, stroke_rgba.alpha);
-        context.set_line_width (line_width);
-        context.set_antialias (Cairo.Antialias.GRAY);
-        return line_width > 0;
-    }
-
+    /*
+     * Create the path for an drawable, used in other methods.
+     */
     public virtual void simple_create_path (Cairo.Context context) {}
 
-    public void paint (Cairo.Context cr, Geometry.Rectangle target_bounds, double scale) {
+    /*
+     * Main paint method.
+     */
+    public virtual void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale) {
         // Simple bounds check
         if (bounds.left > target_bounds.right || bounds.right < target_bounds.left
             || bounds.top > target_bounds.bottom || bounds.bottom < target_bounds.top) {
           return;
         }
 
-        cr.save ();
-        Cairo.Matrix global_transform = cr.get_matrix ();
+        context.save ();
+        Cairo.Matrix global_transform = context.get_matrix ();
 
         // The clipping path is in global coordinates, so we can ignore the transformation.
         if (clipping_path != null) {
-            cr.move_to (clipping_path.tl_x, clipping_path.tl_y);
-            cr.line_to (clipping_path.tr_x, clipping_path.tr_y);
-            cr.line_to (clipping_path.br_x, clipping_path.br_y);
-            cr.line_to (clipping_path.bl_x, clipping_path.bl_y);
-            cr.close_path ();
-            cr.set_fill_rule (Cairo.FillRule.WINDING);
-            cr.clip ();
+            context.move_to (clipping_path.tl_x, clipping_path.tl_y);
+            context.line_to (clipping_path.tr_x, clipping_path.tr_y);
+            context.line_to (clipping_path.br_x, clipping_path.br_y);
+            context.line_to (clipping_path.bl_x, clipping_path.bl_y);
+            context.close_path ();
+            context.set_fill_rule (Cairo.FillRule.WINDING);
+            context.clip ();
         }
 
         // We apply the item transform before creating the path
         Cairo.Matrix tr = transform;
-        cr.transform (tr);
+        context.transform (tr);
 
-        simple_create_path (cr);
+        simple_create_path (context);
 
-        if (set_fill_options (cr)) {
-            cr.fill_preserve ();
+        if (set_fill_options (context)) {
+            context.fill_preserve ();
         }
 
         // We restore the global transformation to draw strokes with uniform width. Changing
         // the matrix does not affect the path already generated.
-        cr.set_matrix (global_transform);
+        context.set_matrix (global_transform);
 
-        if (set_stroke_options (cr)) {
-            cr.stroke ();
+        if (set_stroke_options (context)) {
+            context.stroke ();
         }
 
-        cr.restore ();
+        context.restore ();
 
         // Very important to initialize new path
-        cr.new_path ();
+        context.new_path ();
+
+        is_drawn = true;
     }
 
-    public void paint_hover (
-        Cairo.Context cr,
+    /*
+     * Hover paint method for the drawable.
+     */
+    public virtual void paint_hover (
+        Cairo.Context context,
         Gdk.RGBA color,
         double line_width,
         Geometry.Rectangle target_bounds,
         double scale
     ) {
-        cr.save ();
-        Cairo.Matrix global_transform = cr.get_matrix ();
+        context.save ();
+        Cairo.Matrix global_transform = context.get_matrix ();
 
         // We apply the item transform before creating the path
         Cairo.Matrix tr = transform;
-        cr.transform (tr);
+        context.transform (tr);
 
-        simple_create_path (cr);
+        simple_create_path (context);
 
-        cr.set_line_width (line_width / scale);
-        cr.set_source_rgba (color.red, color.green, color.blue, color.alpha);
-        cr.set_matrix (global_transform);
-        cr.stroke ();
+        context.set_line_width (line_width / scale);
+        context.set_source_rgba (color.red, color.green, color.blue, color.alpha);
+        context.set_matrix (global_transform);
+        context.stroke ();
 
-        cr.restore ();
+        context.restore ();
 
         // Very important to initialize new path
-        cr.new_path ();
+        context.new_path ();
     }
 
-    public Geometry.Rectangle generate_bounding_box () {
+    /*
+     * Generates the bounding box for the drawable.
+    */
+    public virtual Geometry.Rectangle generate_bounding_box () {
         double x1 = 0;
         double x2 = 0;
         double y1 = 0;
         double y2 = 0;
 
-        Cairo.ImageSurface surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, 1, 1);
+        Cairo.ImageSurface surface = new Cairo.ImageSurface (Cairo.Format.A1, 1, 1);
         Cairo.Context context = new Cairo.Context (surface);
 
         context.set_antialias (Cairo.Antialias.GRAY);
@@ -306,4 +313,30 @@ public class Akira.Drawables.Drawable {
             y2 + translate_y
         );
     }
+
+    public virtual void request_redraw (ViewLayers.BaseCanvas canvas, bool recalculate_bounds) {
+        if (recalculate_bounds) {
+            bounds = generate_bounding_box ();
+        }
+        else if (!is_drawn) {
+            // This request is to clear the old draw, but since it was never drawn, we can ignore.
+            return;
+        }
+
+        canvas.request_redraw (bounds);
+    }
+
+    public bool set_fill_options (Cairo.Context context) {
+        context.set_source_rgba (fill_rgba.red, fill_rgba.green, fill_rgba.blue, fill_rgba.alpha);
+        context.set_antialias (Cairo.Antialias.GRAY);
+        return true;
+    }
+
+    public bool set_stroke_options (Cairo.Context context) {
+        context.set_source_rgba (stroke_rgba.red, stroke_rgba.green, stroke_rgba.blue, stroke_rgba.alpha);
+        context.set_line_width (line_width);
+        context.set_antialias (Cairo.Antialias.GRAY);
+        return line_width > 0;
+    }
+
 }

--- a/src/Drawables/DrawableArtboard.vala
+++ b/src/Drawables/DrawableArtboard.vala
@@ -23,8 +23,9 @@
  * Drawable for artboards.
  */
 public class Akira.Drawables.DrawableArtboard : Drawable {
-    public double radius_x { get; set; default = 0; }
-    public double radius_y { get; set; default = 0; }
+    private const double LABEL_HEIGHT = 20;
+    private const double LABEL_MARGIN = 5;
+    private string label = "Artboard";
 
     public DrawableArtboard (double tl_x, double tl_y, double width, double height) {
        this.center_x = tl_x + width / 2.0;
@@ -33,71 +34,144 @@ public class Akira.Drawables.DrawableArtboard : Drawable {
        this.height = height;
     }
 
-    public override void simple_create_path (Cairo.Context cr) {
-        var x = center_x - width / 2.0;
-        var y = center_y - height / 2.0;
+    public override bool hit_test (
+        double x,
+        double y,
+        Cairo.Context context,
+        double scale,
+        Drawable.HitTestType hit_test_type
+    ) {
+        if (hit_test_type == GROUP_REGION) {
+            return base.hit_test (x, y, context, scale, Drawable.HitTestType.SELECT);
+        }
 
-        if (radius_x > 0 || radius_y > 0) {
-            /* The radii can't be more than half the size of the rect. */
-            double rx = double.min (radius_x, width / 2);
-            double ry = double.min (radius_y, height / 2);
+        var lheight = LABEL_HEIGHT / scale;
+        var lbot = bounds.top;
+        var ltop = lbot - lheight;
 
-            /* Draw the top-right arc. */
-            cr.save ();
-            cr.translate (x + width - rx, y + ry);
-            cr.scale (rx, ry);
-            cr.arc (0.0, 0.0, 1.0, 1.5 * GLib.Math.PI, 2.0 * GLib.Math.PI);
-            cr.restore ();
+        var m = label_margin (scale);
+        var w = bounds.width - m * 2;
+        if (w <= 0) {
+            return false;
+        }
 
-            /* Draw the line down the right side. */
-            cr.line_to (x + width, y + height - ry);
-
-            /* Draw the bottom-right arc. */
-            cr.save ();
-            cr.translate (x + width - rx, y + height - ry);
-            cr.scale (rx, ry);
-            cr.arc (0.0, 0.0, 1.0, 0.0, 0.5 * GLib.Math.PI);
-            cr.restore ();
-
-            /* Draw the line left across the bottom. */
-            cr.line_to (x + rx, y + height);
-
-            /* Draw the bottom-left arc. */
-            cr.save ();
-            cr.translate (x + rx, y + height - y);
-            cr.scale (rx, ry);
-            cr.arc (0.0, 0.0, 1.0, 0.5 * GLib.Math.PI, GLib.Math.PI);
-            cr.restore ();
-
-            /* Draw the line up the left side. */
-            cr.line_to (x, y + ry);
-
-            /* Draw the top-left arc. */
-            cr.save ();
-            cr.translate (x + rx, y + ry);
-            cr.scale (rx, ry);
-            cr.arc (0.0, 0.0, 1.0, GLib.Math.PI, 1.5 * GLib.Math.PI);
-            cr.restore ();
-
-            /* Close the path across the top. */
-            cr.close_path ();
-       } else {
-            cr.rectangle (x, y, width, height);
-       }
+        double extent_width = 0;
+        create_pango_layout (context, label, w, scale, &extent_width);
+        extent_width /= scale;
+        return !(x < bounds.left || x > bounds.left + extent_width + m * 2 || y < ltop || y > lbot);
     }
 
-    //public override void simple_update (Cairo.Context cr) {
-    //    /* We can quickly compute the bounds as being just the rectangle's size
-    //       plus half the line width around each edge.
-    //       For now we keep it as the full width to avoid weird clipping issues*/
-    //    var half_line_width = get_line_width (); // / 2;
+    public override void simple_create_path (Cairo.Context context) {
+        Drawables.DrawableRect.rect_path (context, this);
+    }
 
-    //    var x = center_x - width / 2.0;
-    //    var y = center_y - height / 2.0;
+    public override void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale) {
+        base.paint (context, target_bounds, scale);
 
-    //    bounds.x1 = x - half_line_width;
-    //    bounds.y1 = y - half_line_width;
-    //    bounds.x2 = x + width + half_line_width;
-    //    bounds.y2 = y + height + half_line_width;
-    //}
+        draw_text (context, scale);
+    }
+
+    private void draw_text (Cairo.Context context, double scale) {
+        var m = label_margin (scale);
+        var w = bounds.width - m * 2;
+        if (w <= 0) {
+            return;
+        }
+
+        context.save ();
+
+        if (settings.dark_theme) {
+            context.set_source_rgba (1, 1, 1, 0.75);
+        } else {
+            context.set_source_rgba (0, 0, 0, 0.75);
+        }
+
+        var layout = create_pango_layout (context, label, w, scale, null);
+        context.move_to (bounds.left + m, bounds.top - LABEL_HEIGHT / scale);
+        context.scale (1 / scale, 1 / scale);
+        Pango.cairo_show_layout (context, layout);
+
+        context.restore ();
+        context.new_path ();
+    }
+
+    private static Pango.Layout create_pango_layout (
+        Cairo.Context context,
+        string text,
+        double layout_width,
+        double scale,
+        double* extent_width
+    ) {
+        var p_layout = Pango.cairo_create_layout (context);
+        var p_context = p_layout.get_context ();
+
+        if (layout_width > 0) {
+            p_layout.set_width ( (int)(layout_width * Pango.SCALE));
+        }
+
+        p_layout.set_text (text, -1);
+
+        // Load font description
+        var desc = new Pango.FontDescription ();
+        desc.set_family ("Open Sans");
+        desc.set_size ((int) (10 * Pango.SCALE));
+        p_layout.set_font_description (desc);
+
+        // Load hint metrics
+
+        var font_options = new Cairo.FontOptions ();
+        font_options.set_hint_metrics (Cairo.HintMetrics.DEFAULT);
+        Pango.cairo_context_set_font_options (p_context, font_options);
+
+        p_layout.set_alignment (Pango.Alignment.LEFT);
+        p_layout.set_ellipsize (Pango.EllipsizeMode.END);
+        p_layout.set_wrap (Pango.WrapMode.WORD);
+
+        if (extent_width != null) {
+            Pango.Rectangle ink_rect;
+            Pango.Rectangle logical_rect;
+            p_layout.get_extents (out ink_rect, out logical_rect);
+
+            var logical_width = (double) logical_rect.width / Pango.SCALE;
+            *extent_width = logical_width;
+        }
+
+        return p_layout;
+    }
+
+    /*
+     * Hover paint method for the drawable.
+     */
+    public override void paint_hover (
+        Cairo.Context context,
+        Gdk.RGBA color,
+        double line_width,
+        Geometry.Rectangle target_bounds,
+        double scale
+    ) {
+        base.paint_hover (context, color, line_width, target_bounds, scale);
+    }
+
+    public override Geometry.Rectangle generate_bounding_box () {
+        var r = base.generate_bounding_box ();
+        return r;
+    }
+
+    public override void request_redraw (ViewLayers.BaseCanvas canvas, bool recalculate_bounds) {
+        if (recalculate_bounds) {
+            bounds = generate_bounding_box ();
+        }
+        else if (!is_drawn) {
+            // This request is to clear the old draw, but since it was never drawn, we can ignore.
+            return;
+        }
+
+        var tb = bounds;
+        tb.top -= LABEL_HEIGHT / canvas.scale;
+        canvas.request_redraw (tb);
+    }
+
+    protected double label_margin (double scale) {
+        return LABEL_MARGIN / scale;
+    }
 }

--- a/src/Drawables/DrawableRect.vala
+++ b/src/Drawables/DrawableRect.vala
@@ -25,13 +25,6 @@
  * Drawable for rects.
  */
 public class Akira.Drawables.DrawableRect : Drawable {
-    public double radius_tr { get; set; default = 0; }
-    public double radius_tl { get; set; default = 0; }
-    public double radius_br { get; set; default = 0; }
-    public double radius_bl { get; set; default = 0; }
-
-    public bool has_radius { get { return (radius_tr + radius_tl + radius_br + radius_bl) > 0; } }
-
     public DrawableRect (double tl_x, double tl_y, double width, double height) {
        this.center_x = tl_x + width / 2.0;
        this.center_y = tl_y + height / 2.0;
@@ -39,76 +32,34 @@ public class Akira.Drawables.DrawableRect : Drawable {
        this.height = height;
     }
 
-    public override void simple_create_path (Cairo.Context cr) {
-        if (has_radius) {
+    public override void simple_create_path (Cairo.Context context) {
+        rect_path (context, this);
+    }
+
+    public static void rect_path (Cairo.Context context, Drawable drawable) {
+        if (drawable.has_radius) {
             //path_impl1 (cr);
-            path_impl2 (cr);
+            rounded_rect_path (context, drawable);
             return;
         }
 
-        var x = center_x - width / 2.0;
-        var y = center_y - height / 2.0;
-        cr.rectangle (x, y, width, height);
+        var w = drawable.width;
+        var h = drawable.height;
+        var x = drawable.center_x - w / 2.0;
+        var y = drawable.center_y - h / 2.0;
+        context.rectangle (x, y, w, h);
     }
 
-    public void path_impl1 (Cairo.Context cr) {
-        var x = center_x - width / 2.0;
-        var y = center_y - height / 2.0;
-        /* The radii can't be more than half the size of the rect. */
-        double rx = double.min (radius_tr, width / 2);
-        double ry = double.min (radius_bl, height / 2);
-
-        /* Draw the top-right arc. */
-        cr.save ();
-        cr.translate (x + width - rx, y + ry);
-        cr.scale (rx, ry);
-        cr.arc (0.0, 0.0, 1.0, 1.5 * GLib.Math.PI, 2.0 * GLib.Math.PI);
-        cr.restore ();
-
-        /* Draw the line down the right side. */
-        cr.line_to (x + width, y + height - ry);
-
-        /* Draw the bottom-right arc. */
-        cr.save ();
-        cr.translate (x + width - rx, y + height - ry);
-        cr.scale (rx, ry);
-        cr.arc (0.0, 0.0, 1.0, 0.0, 0.5 * GLib.Math.PI);
-        cr.restore ();
-
-        /* Draw the line left across the bottom. */
-        cr.line_to (x + rx, y + height);
-
-        /* Draw the bottom-left arc. */
-        cr.save ();
-        cr.translate (x + rx, y + height - y);
-        cr.scale (rx, ry);
-        cr.arc (0.0, 0.0, 1.0, 0.5 * GLib.Math.PI, GLib.Math.PI);
-        cr.restore ();
-
-        /* Draw the line up the left side. */
-        cr.line_to (x, y + ry);
-
-        /* Draw the top-left arc. */
-        cr.save ();
-        cr.translate (x + rx, y + ry);
-        cr.scale (rx, ry);
-        cr.arc (0.0, 0.0, 1.0, GLib.Math.PI, 1.5 * GLib.Math.PI);
-        cr.restore ();
-
-        /* Close the path across the top. */
-        cr.close_path ();
-    }
-
-    public void path_impl2 (Cairo.Context cr) {
-        var w = width;
-        var h = height;
+    public static void rounded_rect_path (Cairo.Context context, Drawable drawable) {
+        var w = drawable.width;
+        var h = drawable.height;
 
         // aspect_ratio yet unused
         var aspect_ratio = 1.0;
-        double rtl = radius_tl / aspect_ratio;
-        double rtr = radius_tr / aspect_ratio;
-        double rbl = radius_bl / aspect_ratio;
-        double rbr = radius_br / aspect_ratio;
+        double rtl = drawable.radius_tl / aspect_ratio;
+        double rtr = drawable.radius_tr / aspect_ratio;
+        double rbl = drawable.radius_bl / aspect_ratio;
+        double rbr = drawable.radius_br / aspect_ratio;
 
         double r_top = rtl + rtr;
         double r_bot = rbl + rbr;
@@ -136,38 +87,39 @@ public class Akira.Drawables.DrawableRect : Drawable {
         }
 
 
-        var x = center_x - w / 2.0;
-        var y = center_y - h / 2.0;
+        var x = drawable.center_x - w / 2.0;
+        var y = drawable.center_y - h / 2.0;
         var degrees = GLib.Math.PI / 180.0;
 
         // Add top-right
         if (rtr > 0) {
-            cr.arc (x + w - rtr, y + rtr, rtr, -90 * degrees, 0);
+            context.arc (x + w - rtr, y + rtr, rtr, -90 * degrees, 0);
         } else {
-            cr.move_to (x + w, y);
+            context.move_to (x + w, y);
         }
 
         if (rbr > 0) {
             // Add bottom-right
-            cr.arc (x + w - rbr, y + h - rbr, rbr, 0, 90 * degrees);
+            context.arc (x + w - rbr, y + h - rbr, rbr, 0, 90 * degrees);
         } else {
-            cr.line_to (x + w, y + h);
+            context.line_to (x + w, y + h);
         }
 
         if (rbl > 0) {
             // Add bottom-left
-            cr.arc (x + rbl, y + h - rbl, rbl, 90 * degrees, 180 * degrees);
+            context.arc (x + rbl, y + h - rbl, rbl, 90 * degrees, 180 * degrees);
         } else {
-            cr.line_to (x, y + h);
+            context.line_to (x, y + h);
         }
 
         if (rtl > 0) {
             // Add top-left
-            cr.arc (x + rtl, y + rtl, rtl, 180 * degrees, 270 * degrees);
+            context.arc (x + rtl, y + rtl, rtl, 180 * degrees, 270 * degrees);
         } else {
-            cr.line_to (x, y);
+            context.line_to (x, y);
         }
-        cr.close_path ();
+
+        context.close_path ();
     }
 
     //public override void simple_update (Cairo.Context cr) {

--- a/src/Geometry/Rectangle.vala
+++ b/src/Geometry/Rectangle.vala
@@ -59,6 +59,14 @@ public struct Akira.Geometry.Rectangle {
         }
     }
 
+    public bool contains (double x, double y) {
+        return (left < x < right) && (top < y < bottom);
+    }
+
+    public bool does_not_contain (double x, double y) {
+        return x < left || x > right || y < top || y > bottom;
+    }
+
     public void translate (double dx, double dy) {
         left += dx;
         right += dx;

--- a/src/Lib2/Items/ModelInstance.vala
+++ b/src/Lib2/Items/ModelInstance.vala
@@ -106,7 +106,7 @@ public class Akira.Lib2.Items.ModelInstance {
 
     public void remove_from_canvas (ViewLayers.BaseCanvas? canvas) {
         if (canvas != null) {
-            canvas.request_redraw (drawable.bounds);
+            drawable.request_redraw (canvas, false);
         }
         drawable = null;
     }
@@ -114,16 +114,11 @@ public class Akira.Lib2.Items.ModelInstance {
     private void update_drawable_bounds (ViewLayers.BaseCanvas? canvas) {
         bounding_box = compiled_geometry.area_bb;
         if (drawable != null) {
-            if (canvas != null && drawable.bounds.width != 0) {
-                canvas.request_redraw (drawable.bounds);
-            }
-
-            drawable.bounds = drawable.generate_bounding_box ();
-            drawable_bounding_box = drawable.bounds;
-
             if (canvas != null) {
-                canvas.request_redraw (drawable.bounds);
+                drawable.request_redraw (canvas, false);
+                drawable.request_redraw (canvas, true);
             }
+            drawable_bounding_box = drawable.bounds;
         } else {
             drawable_bounding_box = bounding_box;
         }

--- a/src/Lib2/Items/ModelNode.vala
+++ b/src/Lib2/Items/ModelNode.vala
@@ -60,20 +60,29 @@ public class Akira.Lib2.Items.ModelNode {
         return false;
     }
 
-    public void items_in_canvas (double x, double y, Cairo.Context cr, ref Gee.ArrayList<unowned ModelNode> nodes) {
-        if (instance.drawable_bounding_box.left > x || instance.drawable_bounding_box.right < x
-            || instance.drawable_bounding_box.top > y || instance.drawable_bounding_box.bottom < y) {
-            return;
-        }
-
+    public void items_in_canvas (
+        double x,
+        double y,
+        Cairo.Context cr,
+        double scale,
+        Drawables.Drawable.HitTestType hit_test_type,
+        ref Gee.ArrayList<unowned ModelNode> nodes
+    ) {
         unowned var dr = instance.drawable;
-        if (dr != null && dr.new_hit_test (x, y, cr, true, true)) {
-          nodes.add (this);
+        if (dr == null) {
+            if (!instance.bounding_box.contains (x, y)) {
+                return;
+            }
+        }
+        else {
+            if (dr.hit_test (x, y, cr, scale, hit_test_type)) {
+                nodes.add (this);
+            }
         }
 
         if (children != null) {
             foreach (unowned var child in children.data) {
-                child.items_in_canvas (x, y, cr, ref nodes);
+                child.items_in_canvas (x, y, cr, scale, hit_test_type, ref nodes);
             }
         }
     }

--- a/src/Lib2/Managers/HoverManager.vala
+++ b/src/Lib2/Managers/HoverManager.vala
@@ -36,7 +36,11 @@ public class Akira.Lib2.Managers.HoverManager : Object {
     }
 
     public void on_mouse_over (double event_x, double event_y) {
-        var target = view_canvas.items_manager.hit_test (event_x, event_y, false);
+        var target = view_canvas.items_manager.node_at_canvas_position (
+            event_x,
+            event_y,
+            Drawables.Drawable.HitTestType.SELECT
+        );
 
         // Remove the hover effect is no item is hovered
         // TODO: artboard
@@ -55,18 +59,18 @@ public class Akira.Lib2.Managers.HoverManager : Object {
         current_hovered_id = -1;
     }
 
-    private void maybe_create_hover_effect (Lib2.Items.ModelInstance instance) {
-        if (view_canvas.selection_manager.item_selected (instance.id)) {
+    private void maybe_create_hover_effect (Lib2.Items.ModelNode node) {
+        if (view_canvas.selection_manager.item_selected (node.id)) {
             return;
         }
 
-        if (current_hovered_id == instance.id) {
+        if (current_hovered_id == node.id) {
             return;
         }
         else {
             remove_hover_effect ();
         }
 
-        hover_layer.add_drawable (instance.drawable);
+        hover_layer.add_drawable (node.instance.drawable);
     }
 }

--- a/src/Lib2/Managers/ItemsManager.vala
+++ b/src/Lib2/Managers/ItemsManager.vala
@@ -295,39 +295,12 @@ public class Akira.Lib2.Managers.ItemsManager : Object {
         return item_model.children_in_group (group_id);
     }
 
-    public Lib2.Items.ModelInstance? hit_test (double x, double y, bool ignore_groups = true) {
-        Lib2.Items.ModelNode node = node_at_canvas_position (x, y);
-
-        if (node == null) {
-            return null;
-        }
-
-        if (ignore_groups) {
-            return node.instance;
-        }
-
-        unowned var parent = node.parent;
-
-        if (parent == null || parent.id == Lib2.Items.Model.ORIGIN_ID) {
-            return node.instance;
-        }
-
-        if (parent.instance.type is Lib2.Items.ModelTypeArtboard) {
-            return node.instance;
-        }
-
-        var root = Lib2.Items.Model.root (node);
-        if (root == null) {
-            // this is not stable behavior -- it should never happen
-            assert (false);
-            return node.instance;
-        }
-
-        return root.instance;
-    }
-
-    public Lib2.Items.ModelNode? node_at_canvas_position (double x, double y) {
-        var found_items = nodes_at_canvas_position (x, y);
+    public Lib2.Items.ModelNode? node_at_canvas_position (
+        double x,
+        double y,
+        Drawables.Drawable.HitTestType hit_test_type
+    ) {
+        var found_items = nodes_at_canvas_position (x, y, hit_test_type);
         if (found_items.size == 0) {
             return null;
         }
@@ -339,7 +312,7 @@ public class Akira.Lib2.Managers.ItemsManager : Object {
      * Returns the top-most group at position. Origin if no other group found.
      */
     public Lib2.Items.ModelNode first_group_at (double x, double y) {
-        var found_items = nodes_at_canvas_position (x, y);
+        var found_items = nodes_at_canvas_position (x, y, Drawables.Drawable.HitTestType.GROUP_REGION);
 
         var it = found_items.bidir_list_iterator ();
         for (var has_next = it.last (); has_next; has_next = it.previous ()) {
@@ -352,7 +325,11 @@ public class Akira.Lib2.Managers.ItemsManager : Object {
         return item_model.node_from_id (Lib2.Items.Model.ORIGIN_ID);
     }
 
-    public Gee.ArrayList<unowned Lib2.Items.ModelNode> nodes_at_canvas_position (double x, double y) {
+    public Gee.ArrayList<unowned Lib2.Items.ModelNode> nodes_at_canvas_position (
+        double x,
+        double y,
+        Drawables.Drawable.HitTestType hit_test_type
+    ) {
         Cairo.ImageSurface surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, 1, 1);
         Cairo.Context context = new Cairo.Context (surface);
         context.set_antialias (Cairo.Antialias.GRAY);
@@ -366,7 +343,7 @@ public class Akira.Lib2.Managers.ItemsManager : Object {
         }
 
         foreach (unowned var root in origin.children.data) {
-            root.items_in_canvas (x, y, context, ref found_items);
+            root.items_in_canvas (x, y, context, view_canvas.scale, hit_test_type, ref found_items);
         }
         return found_items;
     }

--- a/src/Lib2/Modes/ItemInsertMode.vala
+++ b/src/Lib2/Modes/ItemInsertMode.vala
@@ -80,11 +80,15 @@ public class Akira.Lib2.Modes.ItemInsertMode : AbstractInteractionMode {
         }
 
         if (event.button == Gdk.BUTTON_PRIMARY) {
-            var instance = construct_item (item_insert_type, event.x, event.y);
+            bool is_artboard;
+            var instance = construct_item (item_insert_type, event.x, event.y, out is_artboard);
 
-            var group = view_canvas.items_manager.first_group_at (event.x, event.y);
+            var group_id = Lib2.Items.Model.ORIGIN_ID;
+            if (!is_artboard) {
+                group_id = view_canvas.items_manager.first_group_at (event.x, event.y).id;
+            }
 
-            view_canvas.items_manager.add_item_to_group (group.id, instance, false);
+            view_canvas.items_manager.add_item_to_group (group_id, instance, false);
 
             view_canvas.selection_manager.reset_selection ();
             view_canvas.selection_manager.add_to_selection (instance.id);
@@ -126,11 +130,12 @@ public class Akira.Lib2.Modes.ItemInsertMode : AbstractInteractionMode {
         return null;
     }
 
-    private static Lib2.Items.ModelInstance construct_item (string from_type, double x, double y) {
+    private static Lib2.Items.ModelInstance construct_item (string from_type, double x, double y, out bool is_artboard) {
         double center_x = 0.0;
         double center_y = 0.0;
         double width = 1.0;
         double height = 1.0;
+        is_artboard = false;
 
         // We use floor to align to the pixel that is clicked.
         Utils.AffineTransform.geometry_from_top_left (
@@ -184,6 +189,7 @@ public class Akira.Lib2.Modes.ItemInsertMode : AbstractInteractionMode {
                 break;
 
             case "artboard":
+                is_artboard = true;
                 new_item = Lib2.Items.ModelTypeArtboard.default_artboard (
                     coordinates,
                     size

--- a/src/Lib2/ViewCanvas.vala
+++ b/src/Lib2/ViewCanvas.vala
@@ -291,42 +291,35 @@ public class Akira.Lib2.ViewCanvas : ViewLayers.BaseCanvas {
             }
         }
 
-        handle_selection_press_event (event);
-
-        var target_nob = nob_manager.hit_test (event.x, event.y);
-
-        if (target_nob != Utils.Nobs.Nob.NONE) {
-            // TODO - hook up transform
-
+        if (handle_selection_press_event (event)) {
             return true;
         }
-
-        var target = items_manager.hit_test (event.x, event.y);
-        if (target != null) {
-            if (!selection_manager.item_selected (target.id)) {
-                selection_manager.add_to_selection (target.id);
-                return true;
-            }
-        }
-        else {
-            selection_manager.reset_selection ();
-        }
-
 
         return false;
     }
 
+    /*
+     * Check if a selection exists, and transform it appropriately, return true if
+     * the event should be abosrbed.
+     */
     private bool handle_selection_press_event (Gdk.EventButton event) {
         var nob_clicked = nob_manager.hit_test (event.x, event.y);
 
         if (nob_clicked == Utils.Nobs.Nob.NONE) {
-            var target = items_manager.hit_test (event.x, event.y, false);
+            // If no nob is selected, we test for an item.
+            var target = items_manager.node_at_canvas_position (
+                event.x,
+                event.y,
+                Drawables.Drawable.HitTestType.SELECT
+            );
+
             if (target != null) {
                 if (!selection_manager.item_selected (target.id)) {
                     selection_manager.add_to_selection (target.id);
                 }
             }
-            else {
+            else if (!selection_manager.selection.bounding_box ().contains (event.x, event.y)) {
+                // Selection area was not clicked, so we reset the selection
                 selection_manager.reset_selection ();
             }
         }


### PR DESCRIPTION

<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
Fix Artboard and multiselection hitbox detection
* Artboards now have different effective for selection or for item creation.
* Selection hitbox is now used for translation, which enhances artboard.
* Artboard now draws label. This can probably be improved by scaling the
  final pixmap rather than the font size...which results in nasty
  hinting.
* In general, virtual methods were added to drawables to allow for
  static items (items that change size with different scales.
  Although they should probably be used sparringly.


## Steps to Test
Use artboards!

