### PR TITLE
Prevent ctrl_is_pressed from remaining true

### DIFF
--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -275,6 +275,11 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_preferences () {
+        // Since the settings dialog was opened with the `CTRL+.` shortcut, we
+        // need to reset the boolean variable in the canvas to avoid affecting
+        // items resize and rotation.
+        window.main_window.main_view_canvas.canvas.ctrl_is_pressed = false;
+
         var settings_dialog = new Akira.Dialogs.SettingsDialog (window);
         settings_dialog.show_all ();
         settings_dialog.present ();


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
When opening the Settings dialog with the <kbd>CTRL</kbd>+<kbd>.</kbd> shortcut, the `canvas.ctrl_is_pressed` is set to true, and since the `key_release_event` is not triggered as the focus is not on the canvas anymore but on the dialog, the variable remains `TRUE`.
This causes a locked rotation of the item and all other things connected to that variable. 

## Steps to Test
Open the settings dialog with the shortcut, then close it and ensure the rotation is not locked.
