### PR TITLE
Gtk4 bonanza

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ These are mostly guidelines, not rules. Use your best judgment, and feel free to
 
     1. Install required dependencies:
 
-        * `gtk+-3.0>=3.18`
+        * `gtk4>=4.0`
         * `granite>=6.0.0`
         * `glib-2.0`
         * `gee-0.8`
@@ -52,7 +52,7 @@ These are mostly guidelines, not rules. Use your best judgment, and feel free to
     * Debian (Elementary/Ubuntu/Linux Mint)
 
         ```sh
-        sudo apt-get install gtk+-3.0 elementary-sdk glib-2.0 gee-0.8 gobject-2.0 libxml2 libjson-glib-1.0  libarchive-dev libcairo2-dev meson valac
+        sudo apt-get install libgtk-4-dev elementary-sdk glib-2.0 gee-0.8 gobject-2.0 libxml2 libjson-glib-1.0  libarchive-dev libcairo2-dev meson valac
         ```
 
     2. Building:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can install Akira by compiling it from the source
 
 ### Install Dependencies
 
- - `gtk+-3.0>=3.18`
+ - `gtk4>=4.0`
  - `granite>=6.0.0`
  - `glib-2.0`
  - `gee-0.8`

--- a/com.github.akiraux.akira.yml
+++ b/com.github.akiraux.akira.yml
@@ -27,16 +27,16 @@ finish-args:
   - '--device=dri'
 
 modules:
-  - name: granite
-    buildsystem: meson
-    cleanup:
-      - /bin
-      - /share/applications
-    sources:
-      - type: git
-        url: https://github.com/elementary/granite.git
-        tag: 6.0.0
-        commit: e6212b8e55bb35b14b1ebcb199ae2978b518a7f9
+  #- name: granite
+  #  buildsystem: meson
+  #  cleanup:
+  #    - /bin
+  #    - /share/applications
+  #  sources:
+  #    - type: git
+  #      url: https://github.com/elementary/granite.git
+  #      tag: 6.0.0
+  #      commit: e6212b8e55bb35b14b1ebcb199ae2978b518a7f9
 
   - name: elementary-stylesheet
     buildsystem: meson

--- a/com.github.akiraux.akira.yml
+++ b/com.github.akiraux.akira.yml
@@ -1,8 +1,19 @@
 app-id: com.github.akiraux.akira
-runtime: io.elementary.Platform
-runtime-version: '6'
-sdk: io.elementary.Sdk
+#runtime: io.elementary.Platform
+#runtime-version: '6'
+#sdk: io.elementary.Sdk
+runtime: org.gnome.Platform
+runtime-version: '40'
+sdk: org.gnome.Sdk
 command: com.github.akiraux.akira
+cleanup:
+  - '/include'
+  - '/lib/pkgconfig'
+  - '/lib/debug'
+  - '/share/vala'
+  - '/man'
+  - '*.a'
+  - '*.la'
 
 finish-args:
   - '--share=ipc'
@@ -16,6 +27,65 @@ finish-args:
   - '--device=dri'
 
 modules:
+  - name: granite
+    buildsystem: meson
+    cleanup:
+      - /bin
+      - /share/applications
+    sources:
+      - type: git
+        url: https://github.com/elementary/granite.git
+        tag: 6.0.0
+        commit: e6212b8e55bb35b14b1ebcb199ae2978b518a7f9
+
+  - name: elementary-stylesheet
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/elementary/stylesheet.git
+        tag: 6.0.0
+    modules:
+      - name: sassc
+        sources:
+          - type: git
+            url: https://github.com/sass/sassc.git
+            tag: 3.6.2
+          - type: script
+            dest-filename: autogen.sh
+            commands:
+              - autoreconf -si
+        cleanup:
+          - '*'
+        modules:
+          - name: libsass
+            cleanup:
+              - "*"
+            sources:
+              - type: git
+                url: https://github.com/sass/libsass.git
+                tag: 3.6.5
+              - type: script
+                dest-filename: autogen.sh
+                commands:
+                  - autoreconf -si
+
+  - name: elementary-icons
+    buildsystem: meson
+    config-opts:
+      - -Dpalettes=false
+    sources:
+      - type: git
+        url: https://github.com/elementary/icons.git
+        tag: 6.0.0
+    modules:
+      - name: xcursorgen
+        cleanup:
+          - "*"
+        sources:
+          - type: archive
+            url: https://gitlab.freedesktop.org/xorg/app/xcursorgen/-/archive/xcursorgen-1.0.7/xcursorgen-xcursorgen-1.0.7.tar.gz
+            sha256: 7fb30a052b63e3ed02c9e43bd70fe1bf8189f2f3d702ab43b5b0726a2dbafccd
+
   - name: akira
     buildsystem: meson
     sources:

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ add_project_arguments('--vapidir=' + vapi_dir, language: 'vala')
 i18n = import('i18n')
 # Dependencies
 gtk_dependency = dependency('gtk4', version: '>= 4.0')
-granite_dependency = dependency('granite', version: '>= 6.0.0')
+#granite_dependency = dependency('granite', version: '>= 6.0.0')
 gee_dependency = dependency('gee-0.8')
 libxml_dependency = dependency('libxml-2.0')
 cairo_dependency = dependency('cairo', version: '>=1.14')

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@ add_project_arguments('--vapidir=' + vapi_dir, language: 'vala')
 # Include the translations module
 i18n = import('i18n')
 # Dependencies
-gtk_dependency = dependency('gtk+-3.0')
+gtk_dependency = dependency('gtk4', version: '>= 4.0')
 granite_dependency = dependency('granite', version: '>= 6.0.0')
 gee_dependency = dependency('gee-0.8')
 libxml_dependency = dependency('libxml-2.0')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -156,23 +156,25 @@ public class Akira.Application : Gtk.Application {
         gtk_settings.set_property ("gtk-icon-theme-name", "elementary");
         gtk_settings.set_property ("gtk-theme-name", "io.elementary.stylesheet.blueberry");
 
-        // Use the Granite API to listen for global dark style changes.
-        var granite_settings = Granite.Settings.get_default ();
-        if (settings.follow_system_theme) {
-            // Follow the system themeing.
-            gtk_settings.gtk_application_prefer_dark_theme =
-                granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-        } else {
-            // Follow the user's settings.
-            gtk_settings.gtk_application_prefer_dark_theme = settings.dark_theme;
-        }
+        gtk_settings.gtk_application_prefer_dark_theme = settings.dark_theme;
 
-        // Listen for the changes in the theme's preferences.
-        granite_settings.notify["prefers-color-scheme"].connect (() => {
-            if (settings.follow_system_theme) {
-                gtk_settings.gtk_application_prefer_dark_theme =
-                    granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-            }
-        });
+        // Use the Granite API to listen for global dark style changes.
+        // var granite_settings = Granite.Settings.get_default ();
+        // if (settings.follow_system_theme) {
+        //     // Follow the system themeing.
+        //     gtk_settings.gtk_application_prefer_dark_theme =
+        //         granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+        // } else {
+        //     // Follow the user's settings.
+        //     gtk_settings.gtk_application_prefer_dark_theme = settings.dark_theme;
+        // }
+
+        // // Listen for the changes in the theme's preferences.
+        // granite_settings.notify["prefers-color-scheme"].connect (() => {
+        //     if (settings.follow_system_theme) {
+        //         gtk_settings.gtk_application_prefer_dark_theme =
+        //             granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+        //     }
+        // });
     }
 }

--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -182,7 +182,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         recent_files_grid.width_request = 220;
         recent_files_grid.name = "files-menu";
 
-        var open_recent_button = new Gtk.ModelButton ();
+        var open_recent_button = new Gtk.Button ();
         open_recent_button.text = _("Open Recent");
         open_recent_button.menu_name = "files-menu";
         fetch_recent_files.begin ();
@@ -254,7 +254,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         shapes_grid.width_request = 200;
         shapes_grid.name = "shapes-menu";
 
-        var back_button = new Gtk.ModelButton ();
+        var back_button = new Gtk.Button ();
         back_button.text = _("Add Items");
         back_button.inverted = true;
         back_button.menu_name = "main";
@@ -280,7 +280,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         shapes_grid.add (ellipse);
         shapes_grid.show_all ();
 
-        var shapes_button = new Gtk.ModelButton ();
+        var shapes_button = new Gtk.Button ();
         shapes_button.text = _("Shapes");
         shapes_button.menu_name = "shapes-menu";
 
@@ -421,7 +421,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         });
 
         // Add default buttons.
-        var back_button = new Gtk.ModelButton ();
+        var back_button = new Gtk.Button ();
         back_button.text = _("Main Menu");
         back_button.inverted = true;
         back_button.menu_name = "main";
@@ -466,7 +466,7 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
             string[] split_string = all_files[i].split ("/");
             var file_name = split_string[split_string.length - 1].replace (".akira", "");
 
-            var button = new Gtk.ModelButton ();
+            var button = new Gtk.Button ();
 
             // Add quick accelerators only for the first 3 items.
             string? accels = null;
@@ -574,8 +574,8 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
     //     }
     // }
 
-    private Gtk.ModelButton create_model_button (string text, string? icon, string? accels = null) {
-        var button = new Gtk.ModelButton ();
+    private Gtk.Button create_model_button (string text, string? icon, string? accels = null) {
+        var button = new Gtk.Button ();
         button.get_child ().destroy ();
         var label = new Granite.AccelLabel.from_action_name (text, accels);
 

--- a/src/Layouts/MainCanvas.vala
+++ b/src/Layouts/MainCanvas.vala
@@ -103,7 +103,7 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         window.event_bus.canvas_notification.connect (trigger_notification);
     }
 
-    public bool on_scroll (Gdk.EventScroll event) {
+    public bool on_scroll (Gdk.ScrollEvent event) {
         bool is_shift = (event.state & Gdk.ModifierType.SHIFT_MASK) > 0;
         bool is_ctrl = (event.state & Gdk.ModifierType.CONTROL_MASK) > 0;
 
@@ -159,7 +159,7 @@ public class Akira.Layouts.MainCanvas : Gtk.Grid {
         return true;
     }
 
-    private void zoom_on_cursor (Gdk.EventScroll event, double old_zoom) {
+    private void zoom_on_cursor (Gdk.ScrollEvent event, double old_zoom) {
         // The regular zoom mode shifts the visible viewing area
         // to center itself (it already has one translation applied)
         // so you cannot just move the viewing area by the distance

--- a/src/Layouts/MainViewCanvas.vala
+++ b/src/Layouts/MainViewCanvas.vala
@@ -95,7 +95,7 @@ public class Akira.Layouts.MainViewCanvas : Gtk.Grid {
         add (main_overlay);
     }
 
-    public bool on_scroll (Gdk.EventScroll event) {
+    public bool on_scroll (Gdk.ScrollEvent event) {
         bool is_shift = (event.state & Gdk.ModifierType.SHIFT_MASK) > 0;
         bool is_ctrl = (event.state & Gdk.ModifierType.CONTROL_MASK) > 0;
 

--- a/src/Layouts/Partials/Artboard.OLD.vala
+++ b/src/Layouts/Partials/Artboard.OLD.vala
@@ -418,7 +418,7 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         model.changed (true);
     }
 
-    private bool on_click_event (Gdk.EventButton event) {
+    private bool on_click_event (Gdk.ButtonEvent event) {
         if (model.layer.locked) {
             return true;
         }
@@ -471,7 +471,7 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         return false;
     }
 
-    public bool update_on_escape (Gdk.EventKey key) {
+    public bool update_on_escape (Gdk.KeyEvent key) {
         if (key.keyval == Gdk.Key.Escape) {
             entry.text = label.label;
 
@@ -499,7 +499,7 @@ public class Akira.Layouts.Partials.Artboard : Gtk.ListBoxRow {
         label.label = new_label;
     }
 
-    private bool handle_focus_in (Gdk.EventFocus event) {
+    private bool handle_focus_in (Gdk.FocusEvent event) {
         window.event_bus.disconnect_typing_accel ();
         return false;
     }

--- a/src/Layouts/Partials/Layer.OLD.vala
+++ b/src/Layouts/Partials/Layer.OLD.vala
@@ -499,7 +499,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
      * @param {Gdk.Event} event - The button click event.
      * @return {bool} True to stop propagation, False to let other events run.
      */
-    public bool on_click_event (Gdk.EventButton event) {
+    public bool on_click_event (Gdk.ButtonEvent event) {
         if (model.layer.locked) {
             return true;
         }
@@ -556,7 +556,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         return false;
     }
 
-    public bool update_on_escape (Gdk.EventKey key) {
+    public bool update_on_escape (Gdk.KeyEvent key) {
         if (key.keyval == Gdk.Key.Escape) {
             entry.text = label.label;
 
@@ -697,7 +697,7 @@ public class Akira.Layouts.Partials.Layer : Gtk.ListBoxRow {
         return should_scroll;
     }
 
-    private bool handle_focus_in (Gdk.EventFocus event) {
+    private bool handle_focus_in (Gdk.FocusEvent event) {
         window.event_bus.disconnect_typing_accel ();
         return false;
     }

--- a/src/Layouts/Partials/PagesPanel.vala
+++ b/src/Layouts/Partials/PagesPanel.vala
@@ -31,9 +31,9 @@ public class Akira.Layouts.Partials.PagesPanel : Gtk.ListBox {
     // private const int SCROLL_DISTANCE = 30;
     // private const int SCROLL_DELAY = 50;
 
-    private const Gtk.TargetEntry TARGET_ENTRIES[] = {
-        { "PAGES", Gtk.TargetFlags.SAME_APP, 0 }
-    };
+    // private const Gtk.TargetEntry TARGET_ENTRIES[] = {
+    //     { "PAGES", Gtk.TargetFlags.SAME_APP, 0 }
+    // };
 
     public PagesPanel (Akira.Window window) {
         Object (

--- a/src/Layouts/RightSideBar.OLD.vala
+++ b/src/Layouts/RightSideBar.OLD.vala
@@ -76,9 +76,9 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         layers_scroll.add (layers_grid);
 
         var scrolled_child = layers_scroll.get_child ();
-        if (scrolled_child is Gtk.Container) {
-            ((Gtk.Container) scrolled_child).set_focus_vadjustment (new Gtk.Adjustment (0, 0, 0, 0, 0, 0));
-        }
+        // if (scrolled_child is Gtk.Container) {
+        //     ((Gtk.Container) scrolled_child).set_focus_vadjustment (new Gtk.Adjustment (0, 0, 0, 0, 0, 0));
+        // }
 
         // Motion revealer for Drag and Drop on the top search bar.
         var motion_grid = new Gtk.Grid ();
@@ -213,7 +213,7 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         window.event_bus.change_z_selected (true, true);
     }
 
-    private bool handle_focus_in (Gdk.EventFocus event) {
+    private bool handle_focus_in (Gdk.FocusEvent event) {
         if (!(window is Akira.Window)) {
             return true;
         }
@@ -222,7 +222,7 @@ public class Akira.Layouts.RightSideBar : Gtk.Grid {
         return false;
     }
 
-    private bool handle_focus_out (Gdk.EventFocus event) {
+    private bool handle_focus_out (Gdk.FocusEvent event) {
         if (!(window is Akira.Window)) {
             return true;
         }

--- a/src/Layouts/Sidebars/LayersSidebar.vala
+++ b/src/Layouts/Sidebars/LayersSidebar.vala
@@ -41,11 +41,11 @@ public class Akira.Layouts.Sidebars.LayersSidebar : Gtk.Grid {
 
     // Drag and Drop properties.
     private Gtk.Revealer motion_revealer;
-    private Gtk.TargetList drop_targets;
-    private const Gtk.TargetEntry TARGET_ENTRIES[] = {
-        { "ARTBOARD", Gtk.TargetFlags.SAME_APP, 0 },
-        { "LAYER", Gtk.TargetFlags.SAME_APP, 0 }
-    };
+    // private Gtk.TargetList drop_targets;
+    // private const Gtk.TargetEntry TARGET_ENTRIES[] = {
+    //     { "ARTBOARD", Gtk.TargetFlags.SAME_APP, 0 },
+    //     { "LAYER", Gtk.TargetFlags.SAME_APP, 0 }
+    // };
 
     public Layouts.Sidebars.Partials.LayersPanel layers_panel;
     public Gtk.ScrolledWindow layers_scroll;
@@ -76,13 +76,6 @@ public class Akira.Layouts.Sidebars.LayersSidebar : Gtk.Grid {
         layers_scroll = new Gtk.ScrolledWindow (null, null);
         layers_scroll.expand = true;
         layers_scroll.add (layers_grid);
-
-        var scrolled_child = layers_scroll.get_child ();
-        if (scrolled_child is Gtk.Container) {
-           ((Gtk.Container) scrolled_child).set_focus_vadjustment (
-               new Gtk.Adjustment (0, 0, 0, 0, 0, 0)
-            );
-        }
 
         // Motion revealer for Drag and Drop on the top search bar.
         var motion_grid = new Gtk.Grid ();
@@ -122,12 +115,12 @@ public class Akira.Layouts.Sidebars.LayersSidebar : Gtk.Grid {
         return search_grid;
     }
 
-    private bool handle_focus_in (Gdk.EventFocus event) {
+    private bool handle_focus_in (Gdk.FocusEvent event) {
         view_canvas.window.event_bus.disconnect_typing_accel ();
         return false;
     }
 
-    private bool handle_focus_out (Gdk.EventFocus event) {
+    private bool handle_focus_out (Gdk.FocusEvent event) {
         view_canvas.window.event_bus.connect_typing_accel ();
         return false;
     }

--- a/src/Lib/Managers/ModeManager.vala
+++ b/src/Lib/Managers/ModeManager.vala
@@ -166,7 +166,7 @@ public class Akira.Lib.Managers.ModeManager : Object {
         return active_mode != null ? active_mode.cursor_type () : null;
     }
 
-    public bool key_press_event (Gdk.EventKey event) {
+    public bool key_press_event (Gdk.KeyEvent event) {
         if (pan_mode != null && pan_mode.key_press_event (event)) {
             return false;
         }
@@ -174,7 +174,7 @@ public class Akira.Lib.Managers.ModeManager : Object {
         return (active_mode != null) ? active_mode.key_press_event (event) : false;
     }
 
-    public bool key_release_event (Gdk.EventKey event) {
+    public bool key_release_event (Gdk.KeyEvent event) {
         if (pan_mode != null && pan_mode.key_release_event (event)) {
             return true;
         }
@@ -182,7 +182,7 @@ public class Akira.Lib.Managers.ModeManager : Object {
         return (active_mode != null) ? active_mode.key_release_event (event) : false;
     }
 
-    public bool button_press_event (Gdk.EventButton event) {
+    public bool button_press_event (Gdk.ButtonEvent event) {
         if (pan_mode != null && pan_mode.button_press_event (event)) {
             return true;
         }
@@ -190,7 +190,7 @@ public class Akira.Lib.Managers.ModeManager : Object {
         return (active_mode != null) ? active_mode.button_press_event (event) : false;
     }
 
-    public bool button_release_event (Gdk.EventButton event) {
+    public bool button_release_event (Gdk.ButtonEvent event) {
         if (pan_mode != null && pan_mode.button_release_event (event)) {
             return true;
         }
@@ -198,7 +198,7 @@ public class Akira.Lib.Managers.ModeManager : Object {
         return (active_mode != null) ? active_mode.button_release_event (event) : false;
     }
 
-    public bool motion_notify_event (Gdk.EventMotion event) {
+    public bool motion_notify_event (Gdk.MotionEvent event) {
         if (pan_mode != null && pan_mode.motion_notify_event (event)) {
             return true;
         }

--- a/src/Lib/Managers/ModeManager.vala
+++ b/src/Lib/Managers/ModeManager.vala
@@ -158,13 +158,13 @@ public class Akira.Lib.Managers.ModeManager : Object {
     /*
      * Returns cursor that should be used based on active modes.
      */
-    public Gdk.CursorType? active_cursor_type () {
-        if (pan_mode != null) {
-            return pan_mode.cursor_type ();
-        }
+    // public Gdk.CursorType? active_cursor_type () {
+    //     if (pan_mode != null) {
+    //         return pan_mode.cursor_type ();
+    //     }
 
-        return active_mode != null ? active_mode.cursor_type () : null;
-    }
+    //     return active_mode != null ? active_mode.cursor_type () : null;
+    // }
 
     public bool key_press_event (Gdk.KeyEvent event) {
         if (pan_mode != null && pan_mode.key_press_event (event)) {

--- a/src/Lib/Modes/AbstractInteractionMode.vala
+++ b/src/Lib/Modes/AbstractInteractionMode.vala
@@ -87,35 +87,35 @@ public abstract class Akira.Lib.Modes.AbstractInteractionMode : Object {
     /*
      * Override to define key press event. Return true to absorb.
      */
-    public virtual bool key_press_event (Gdk.EventKey event) {
+    public virtual bool key_press_event (Gdk.KeyEvent event) {
         return false;
     }
 
     /*
      * Override to define key release event. Return true to absorb.
      */
-    public virtual bool key_release_event (Gdk.EventKey event) {
+    public virtual bool key_release_event (Gdk.KeyEvent event) {
         return false;
     }
 
     /*
      * Override to define button press event. Return true to absorb.
      */
-    public virtual bool button_press_event (Gdk.EventButton event) {
+    public virtual bool button_press_event (Gdk.ButtonEvent event) {
         return false;
     }
 
     /*
      * Override to define button release event. Return true to absorb.
      */
-    public virtual bool button_release_event (Gdk.EventButton event) {
+    public virtual bool button_release_event (Gdk.ButtonEvent event) {
         return false;
     }
 
     /*
      * Override to define mouse motion event. Return true to absorb.
      */
-    public virtual bool motion_notify_event (Gdk.EventMotion event) {
+    public virtual bool motion_notify_event (Gdk.MotionEvent event) {
         return false;
     }
 

--- a/src/Lib/Modes/AbstractInteractionMode.vala
+++ b/src/Lib/Modes/AbstractInteractionMode.vala
@@ -80,9 +80,9 @@ public abstract class Akira.Lib.Modes.AbstractInteractionMode : Object {
     /*
      * Override to define cursor associated to mode.
      */
-    public virtual Gdk.CursorType? cursor_type () {
-        return Gdk.CursorType.ARROW;
-    }
+    // public virtual Gdk.CursorType? cursor_type () {
+    //     return Gdk.CursorType.ARROW;
+    // }
 
     /*
      * Override to define key press event. Return true to absorb.

--- a/src/Lib/Modes/ItemInsertMode.vala
+++ b/src/Lib/Modes/ItemInsertMode.vala
@@ -52,13 +52,13 @@ public class Akira.Lib.Modes.ItemInsertMode : AbstractInteractionMode {
         }
     }
 
-    public override Gdk.CursorType? cursor_type () {
-        if (transform_mode != null) {
-            return transform_mode.cursor_type ();
-        }
+    // public override Gdk.CursorType? cursor_type () {
+    //     if (transform_mode != null) {
+    //         return transform_mode.cursor_type ();
+    //     }
 
-        return Gdk.CursorType.CROSSHAIR;
-    }
+    //     return Gdk.CursorType.CROSSHAIR;
+    // }
 
     public override bool key_press_event (Gdk.KeyEvent event) {
         if (transform_mode != null) {

--- a/src/Lib/Modes/ItemInsertMode.vala
+++ b/src/Lib/Modes/ItemInsertMode.vala
@@ -60,21 +60,21 @@ public class Akira.Lib.Modes.ItemInsertMode : AbstractInteractionMode {
         return Gdk.CursorType.CROSSHAIR;
     }
 
-    public override bool key_press_event (Gdk.EventKey event) {
+    public override bool key_press_event (Gdk.KeyEvent event) {
         if (transform_mode != null) {
             return transform_mode.key_press_event (event);
         }
         return false;
     }
 
-    public override bool key_release_event (Gdk.EventKey event) {
+    public override bool key_release_event (Gdk.KeyEvent event) {
         if (transform_mode != null) {
             return transform_mode.key_press_event (event);
         }
         return false;
      }
 
-    public override bool button_press_event (Gdk.EventButton event) {
+    public override bool button_press_event (Gdk.ButtonEvent event) {
         if (transform_mode != null) {
             return transform_mode.button_press_event (event);
         }
@@ -105,7 +105,7 @@ public class Akira.Lib.Modes.ItemInsertMode : AbstractInteractionMode {
         return false;
     }
 
-    public override bool button_release_event (Gdk.EventButton event) {
+    public override bool button_release_event (Gdk.ButtonEvent event) {
         if (transform_mode != null) {
             transform_mode.button_release_event (event);
             request_deregistration (mode_type ());
@@ -114,7 +114,7 @@ public class Akira.Lib.Modes.ItemInsertMode : AbstractInteractionMode {
         return true;
     }
 
-    public override bool motion_notify_event (Gdk.EventMotion event) {
+    public override bool motion_notify_event (Gdk.MotionEvent event) {
         if (transform_mode != null) {
             return transform_mode.motion_notify_event (event);
         }

--- a/src/Lib/Modes/PanMode.vala
+++ b/src/Lib/Modes/PanMode.vala
@@ -39,9 +39,9 @@ public class Akira.Lib.Modes.PanMode : AbstractInteractionMode {
     public override AbstractInteractionMode.ModeType mode_type () { return AbstractInteractionMode.ModeType.PAN; }
 
 
-    public override Gdk.CursorType? cursor_type () {
-        return panning ? Gdk.CursorType.HAND2 : Gdk.CursorType.HAND1;
-    }
+    // public override Gdk.CursorType? cursor_type () {
+    //     return panning ? Gdk.CursorType.HAND2 : Gdk.CursorType.HAND1;
+    // }
 
     public override bool key_press_event (Gdk.KeyEvent event) {
         uint uppercase_keyval = Gdk.keyval_to_upper (event.keyval);

--- a/src/Lib/Modes/PanMode.vala
+++ b/src/Lib/Modes/PanMode.vala
@@ -43,7 +43,7 @@ public class Akira.Lib.Modes.PanMode : AbstractInteractionMode {
         return panning ? Gdk.CursorType.HAND2 : Gdk.CursorType.HAND1;
     }
 
-    public override bool key_press_event (Gdk.EventKey event) {
+    public override bool key_press_event (Gdk.KeyEvent event) {
         uint uppercase_keyval = Gdk.keyval_to_upper (event.keyval);
         if (uppercase_keyval == Gdk.Key.space) {
             space_held = true;
@@ -51,7 +51,7 @@ public class Akira.Lib.Modes.PanMode : AbstractInteractionMode {
         return true;
     }
 
-    public override bool key_release_event (Gdk.EventKey event) {
+    public override bool key_release_event (Gdk.KeyEvent event) {
         uint uppercase_keyval = Gdk.keyval_to_upper (event.keyval);
         if (uppercase_keyval == Gdk.Key.space) {
             space_held = false;
@@ -63,7 +63,7 @@ public class Akira.Lib.Modes.PanMode : AbstractInteractionMode {
         return true;
     }
 
-    public override bool button_press_event (Gdk.EventButton event) {
+    public override bool button_press_event (Gdk.ButtonEvent event) {
         if (!panning && (space_held || event.button == Gdk.BUTTON_MIDDLE)) {
             origin_x = event.x;
             origin_y = event.y;
@@ -74,7 +74,7 @@ public class Akira.Lib.Modes.PanMode : AbstractInteractionMode {
         return true;
     }
 
-    public override bool button_release_event (Gdk.EventButton event) {
+    public override bool button_release_event (Gdk.ButtonEvent event) {
         toggle_panning (false);
 
         if (!space_held) {
@@ -84,7 +84,7 @@ public class Akira.Lib.Modes.PanMode : AbstractInteractionMode {
         return true;
     }
 
-    public override bool motion_notify_event (Gdk.EventMotion event) {
+    public override bool motion_notify_event (Gdk.MotionEvent event) {
         if (panning) {
             canvas.canvas_moved (event.x, event.y);
         }

--- a/src/Lib/Modes/TransformMode.vala
+++ b/src/Lib/Modes/TransformMode.vala
@@ -123,9 +123,9 @@ public class Akira.Lib.Modes.TransformMode : AbstractInteractionMode {
         return effective_nob;
     }
 
-    public override Gdk.CursorType? cursor_type () {
-        return Utils.Nobs.cursor_from_nob (nob);
-    }
+    // public override Gdk.CursorType? cursor_type () {
+    //     return Utils.Nobs.cursor_from_nob (nob);
+    // }
 
     public override bool key_press_event (Gdk.KeyEvent event) {
         return true;

--- a/src/Lib/Modes/TransformMode.vala
+++ b/src/Lib/Modes/TransformMode.vala
@@ -127,26 +127,26 @@ public class Akira.Lib.Modes.TransformMode : AbstractInteractionMode {
         return Utils.Nobs.cursor_from_nob (nob);
     }
 
-    public override bool key_press_event (Gdk.EventKey event) {
+    public override bool key_press_event (Gdk.KeyEvent event) {
         return true;
     }
 
-    public override bool key_release_event (Gdk.EventKey event) {
+    public override bool key_release_event (Gdk.KeyEvent event) {
         return false;
     }
 
-    public override bool button_press_event (Gdk.EventButton event) {
+    public override bool button_press_event (Gdk.ButtonEvent event) {
         initial_drag_state.press_x = event.x;
         initial_drag_state.press_y = event.y;
         return true;
     }
 
-    public override bool button_release_event (Gdk.EventButton event) {
+    public override bool button_release_event (Gdk.ButtonEvent event) {
         request_deregistration (mode_type ());
         return true;
     }
 
-    public override bool motion_notify_event (Gdk.EventMotion event) {
+    public override bool motion_notify_event (Gdk.MotionEvent event) {
         switch (nob) {
             case Utils.Nobs.Nob.NONE:
                 move_from_event (

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -186,7 +186,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
         grab_focus ();
     }
 
-    public override bool key_press_event (Gdk.EventKey event) {
+    public override bool key_press_event (Gdk.KeyEvent event) {
         uint uppercase_keyval = Gdk.keyval_to_upper (event.keyval);
 
         switch (uppercase_keyval) {
@@ -245,7 +245,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
         return false;
     }
 
-    public override bool key_release_event (Gdk.EventKey event) {
+    public override bool key_release_event (Gdk.KeyEvent event) {
         uint uppercase_keyval = Gdk.keyval_to_upper (event.keyval);
 
         switch (uppercase_keyval) {
@@ -272,7 +272,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
         return false;
     }
 
-    public override bool button_press_event (Gdk.EventButton event) {
+    public override bool button_press_event (Gdk.ButtonEvent event) {
         base.button_press_event (event);
 
         hover_manager.remove_hover_effect ();
@@ -302,7 +302,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
      * Check if a selection exists, and transform it appropriately, return true if
      * the event should be abosrbed.
      */
-    private bool handle_selection_press_event (Gdk.EventButton event) {
+    private bool handle_selection_press_event (Gdk.ButtonEvent event) {
         var nob_clicked = nob_manager.hit_test (event.x, event.y);
 
         if (nob_clicked == Utils.Nobs.Nob.NONE) {
@@ -336,7 +336,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
         return false;
     }
 
-    public override bool button_release_event (Gdk.EventButton event) {
+    public override bool button_release_event (Gdk.ButtonEvent event) {
         event.x = event.x / current_scale;
         event.y = event.y / current_scale;
 
@@ -346,7 +346,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
         return false;
     }
 
-    public override bool motion_notify_event (Gdk.EventMotion event) {
+    public override bool motion_notify_event (Gdk.MotionEvent event) {
         event.x = event.x / current_scale;
         event.y = event.y / current_scale;
 

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -49,7 +49,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
     public bool holding = false;
 
     private Utils.Nobs.Nob hovered_nob = Utils.Nobs.Nob.NONE;
-    private Gdk.CursorType current_cursor = Gdk.CursorType.ARROW;
+    // private Gdk.CursorType current_cursor = Gdk.CursorType.ARROW;
 
     private ViewLayers.ViewLayerGrid grid_layout;
 
@@ -128,18 +128,18 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
     }
 
     public void set_cursor_by_interaction_mode () {
-        hover_manager.remove_hover_effect ();
-        Gdk.CursorType? new_cursor = mode_manager.active_cursor_type ();
+        // hover_manager.remove_hover_effect ();
+        // Gdk.CursorType? new_cursor = mode_manager.active_cursor_type ();
 
-        if (new_cursor == null) {
-            var hover_cursor = Utils.Nobs.cursor_from_nob (hovered_nob);
-            new_cursor = (hover_cursor == null) ? Gdk.CursorType.ARROW : hover_cursor;
-        }
+        // if (new_cursor == null) {
+        //     var hover_cursor = Utils.Nobs.cursor_from_nob (hovered_nob);
+        //     new_cursor = (hover_cursor == null) ? Gdk.CursorType.ARROW : hover_cursor;
+        // }
 
-        if (current_cursor != new_cursor) {
-            // debug (@"Changing cursor. $new_cursor");
-            set_cursor (new_cursor);
-        }
+        // if (current_cursor != new_cursor) {
+        //     // debug (@"Changing cursor. $new_cursor");
+        //     set_cursor (new_cursor);
+        // }
     }
 
     private void trigger_adjust_zoom (double new_scale, bool absolute, Geometry.Point? reference) {
@@ -374,11 +374,11 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
         return false;
     }
 
-    private void set_cursor (Gdk.CursorType? cursor_type) {
-        current_cursor = (cursor_type == null ? Gdk.CursorType.ARROW : cursor_type);
-        var cursor = new Gdk.Cursor.for_display (Gdk.Display.get_default (), current_cursor);
-        get_window ().set_cursor (cursor);
-    }
+    // private void set_cursor (Gdk.CursorType? cursor_type) {
+    //     current_cursor = (cursor_type == null ? Gdk.CursorType.ARROW : cursor_type);
+    //     var cursor = new Gdk.Cursor.for_display (Gdk.Display.get_default (), current_cursor);
+    //     get_window ().set_cursor (cursor);
+    // }
 
     // #TODO temporary
     public override bool draw (Cairo.Context ctx) {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -36,7 +36,7 @@ public class Akira.Services.EventBus : Object {
     public signal void coordinate_change (double x, double y);
     public signal void insert_item (string type);
     public signal void item_inserted ();
-    public signal void move_item_from_canvas (Gdk.EventKey event);
+    public signal void move_item_from_canvas (Gdk.KeyEvent event);
     public signal void request_escape ();
     public signal void set_focus_on_canvas ();
     public signal void update_nob_size ();

--- a/src/Utils/ColorPicker.vala
+++ b/src/Utils/ColorPicker.vala
@@ -24,8 +24,8 @@ public class Akira.Utils.ColorPicker : Gtk.Window {
     public signal void picked (Gdk.RGBA color);
     public signal void cancelled ();
     public signal void moved (Gdk.RGBA color);
-    public signal void key_pressed (Gdk.EventKey e);
-    public signal void key_released (Gdk.EventKey e);
+    public signal void key_pressed (Gdk.KeyEvent e);
+    public signal void key_released (Gdk.KeyEvent e);
 
     const string DARK_BORDER_COLOR_STRING = "#333333";
     private Gdk.RGBA dark_border_color = Gdk.RGBA ();
@@ -83,7 +83,7 @@ public class Akira.Utils.ColorPicker : Gtk.Window {
     }
 
 
-    public override bool button_release_event (Gdk.EventButton e) {
+    public override bool button_release_event (Gdk.ButtonEvent e) {
         // button_1 is left mouse button
         if (e.button == 1) {
             Gdk.RGBA color = get_color_at ((int) e.x_root, (int) e.y_root);
@@ -102,7 +102,7 @@ public class Akira.Utils.ColorPicker : Gtk.Window {
     }
 
 
-    public override bool motion_notify_event (Gdk.EventMotion e) {
+    public override bool motion_notify_event (Gdk.MotionEvent e) {
         Gdk.RGBA color = get_color_at ((int) e.x_root, (int) e.y_root);
 
         moved (color);
@@ -113,7 +113,7 @@ public class Akira.Utils.ColorPicker : Gtk.Window {
     }
 
 
-    public override bool scroll_event (Gdk.EventScroll e) {
+    public override bool scroll_event (Gdk.ScrollEvent e) {
         switch (e.direction) {
             case Gdk.ScrollDirection.UP:
                 if (zoomlevel < max_zoomlevel) {
@@ -246,7 +246,7 @@ public class Akira.Utils.ColorPicker : Gtk.Window {
     }
 
 
-    public override bool key_press_event (Gdk.EventKey e) {
+    public override bool key_press_event (Gdk.KeyEvent e) {
         var manager = Gdk.Display.get_default ().get_default_seat ();
         int px, py;
         get_window ().get_device_position (manager.get_pointer (), out px, out py, null);
@@ -278,7 +278,7 @@ public class Akira.Utils.ColorPicker : Gtk.Window {
         return true;
     }
 
-    public override bool key_release_event (Gdk.EventKey e) {
+    public override bool key_release_event (Gdk.KeyEvent e) {
         key_released (e);
 
         return true;

--- a/src/Utils/ColorPicker.vala
+++ b/src/Utils/ColorPicker.vala
@@ -135,106 +135,105 @@ public class Akira.Utils.ColorPicker : Gtk.Window {
     }
 
     public void set_magnifier_cursor () {
-        var manager = Gdk.Display.get_default ().get_default_seat ();
+        // var manager = Gdk.Display.get_default ().get_default_seat ();
 
-        // get cursor position
-         int px, py;
-         get_window ().get_device_position (manager.get_pointer (), out px, out py, null);
+        // // get cursor position
+        //  int px, py;
+        //  get_window ().get_device_position (manager.get_pointer (), out px, out py, null);
 
-         var radius = snapsize * zoomlevel / 2;
+        //  var radius = snapsize * zoomlevel / 2;
 
-         // get a small area (snap) meant to be zoomed
-         var snapped_pixbuf = snap (px - snapsize / 2, py - snapsize / 2, snapsize, snapsize);
+        //  // get a small area (snap) meant to be zoomed
+        //  var snapped_pixbuf = snap (px - snapsize / 2, py - snapsize / 2, snapsize, snapsize);
 
-         // Zoom that screenshot up, and grab a snapsize-sized piece from the middle
-         var scaled_pb = snapped_pixbuf.scale_simple (
-            snapsize * zoomlevel + shadow_width * 2 ,
-            snapsize * zoomlevel + shadow_width * 2 ,
-            Gdk.InterpType.NEAREST
-        );
-
-
-         // Create the base surface for our cursor
-         var base_surface = new Cairo.ImageSurface (
-            Cairo.Format.ARGB32,
-            snapsize * zoomlevel + shadow_width * 2 ,
-            snapsize * zoomlevel + shadow_width * 2
-        );
-
-         var base_context = new Cairo.Context (base_surface);
+        //  // Zoom that screenshot up, and grab a snapsize-sized piece from the middle
+        //  var scaled_pb = snapped_pixbuf.scale_simple (
+        //     snapsize * zoomlevel + shadow_width * 2 ,
+        //     snapsize * zoomlevel + shadow_width * 2 ,
+        //     Gdk.InterpType.NEAREST
+        // );
 
 
-         // Create the circular path on our base surface
-         base_context.arc (radius + shadow_width, radius + shadow_width, radius, 0, 2 * Math.PI);
+        //  // Create the base surface for our cursor
+        //  var base_surface = new Cairo.ImageSurface (
+        //     Cairo.Format.ARGB32,
+        //     snapsize * zoomlevel + shadow_width * 2 ,
+        //     snapsize * zoomlevel + shadow_width * 2
+        // );
 
-         // Paste in the screenshot
-         Gdk.cairo_set_source_pixbuf (base_context, scaled_pb, 0, 0);
-
-         // Clip to that circular path, keeping the path around for later, and paint the pasted screenshot
-         base_context.save ();
-         base_context.clip_preserve ();
-         base_context.paint ();
-         base_context.restore ();
+        //  var base_context = new Cairo.Context (base_surface);
 
 
-         // Draw a shadow as outside magnifier border
-         double shadow_alpha = 0.6;
-         base_context.set_line_width (1);
+        //  // Create the circular path on our base surface
+        //  base_context.arc (radius + shadow_width, radius + shadow_width, radius, 0, 2 * Math.PI);
 
-         for (int i = 0; i <= shadow_width; i++) {
-             base_context.arc (
-                radius + shadow_width, radius + shadow_width,
-                radius + shadow_width - i, 0, 2 * Math.PI
-            );
-             Gdk.RGBA shadow_color = Gdk.RGBA ();
-             shadow_color.parse (DARK_BORDER_COLOR_STRING);
-             shadow_color.alpha = shadow_alpha / ((shadow_width - i + 1) * (shadow_width - i + 1));
-             Gdk.cairo_set_source_rgba (base_context, shadow_color);
-             base_context.stroke ();
-         }
+        //  // Paste in the screenshot
+        //  Gdk.cairo_set_source_pixbuf (base_context, scaled_pb, 0, 0);
+
+        //  // Clip to that circular path, keeping the path around for later, and paint the pasted screenshot
+        //  base_context.save ();
+        //  base_context.clip_preserve ();
+        //  base_context.paint ();
+        //  base_context.restore ();
 
 
-        // Draw an outside bright magnifier border
-        Gdk.cairo_set_source_rgba (base_context, bright_border_color);
-        base_context.arc (radius + shadow_width, radius + shadow_width, radius - 1, 0, 2 * Math.PI);
-        base_context.stroke ();
+        //  // Draw a shadow as outside magnifier border
+        //  double shadow_alpha = 0.6;
+        //  base_context.set_line_width (1);
+
+        //  for (int i = 0; i <= shadow_width; i++) {
+        //      base_context.arc (
+        //         radius + shadow_width, radius + shadow_width,
+        //         radius + shadow_width - i, 0, 2 * Math.PI
+        //     );
+        //      Gdk.RGBA shadow_color = Gdk.RGBA ();
+        //      shadow_color.parse (DARK_BORDER_COLOR_STRING);
+        //      shadow_color.alpha = shadow_alpha / ((shadow_width - i + 1) * (shadow_width - i + 1));
+        //      Gdk.cairo_set_source_rgba (base_context, shadow_color);
+        //      base_context.stroke ();
+        //  }
 
 
-        // Draw inside square
-        base_context.set_line_width (1);
-
-        Gdk.cairo_set_source_rgba (base_context, dark_border_color);
-        base_context.move_to (radius + shadow_width - zoomlevel, radius + shadow_width - zoomlevel);
-        base_context.line_to (radius + shadow_width + zoomlevel, radius + shadow_width - zoomlevel);
-        base_context.line_to (radius + shadow_width + zoomlevel, radius + shadow_width + zoomlevel);
-        base_context.line_to (radius + shadow_width - zoomlevel, radius + shadow_width + zoomlevel);
-        base_context.close_path ();
-        base_context.stroke ();
-
-        Gdk.cairo_set_source_rgba (base_context, bright_border_color);
-        base_context.move_to (radius + shadow_width - zoomlevel + 1, radius + shadow_width - zoomlevel + 1);
-        base_context.line_to (radius + shadow_width + zoomlevel - 1, radius + shadow_width - zoomlevel + 1);
-        base_context.line_to (radius + shadow_width + zoomlevel - 1, radius + shadow_width + zoomlevel - 1);
-        base_context.line_to (radius + shadow_width - zoomlevel + 1, radius + shadow_width + zoomlevel - 1);
-        base_context.close_path ();
-        base_context.stroke ();
+        // // Draw an outside bright magnifier border
+        // Gdk.cairo_set_source_rgba (base_context, bright_border_color);
+        // base_context.arc (radius + shadow_width, radius + shadow_width, radius - 1, 0, 2 * Math.PI);
+        // base_context.stroke ();
 
 
-        magnifier = new Gdk.Cursor.from_surface (
-            get_screen ().get_display (),
-            base_surface,
-            base_surface.get_width () / 2,
-            base_surface.get_height () / 2);
+        // // Draw inside square
+        // base_context.set_line_width (1);
 
-        // Set the cursor
-        manager.grab (
-            get_window (),
-            Gdk.SeatCapabilities.ALL,
-            true,
-            magnifier,
-            new Gdk.Event (Gdk.EventType.BUTTON_PRESS | Gdk.EventType.MOTION_NOTIFY | Gdk.EventType.SCROLL),
-            null);
+        // Gdk.cairo_set_source_rgba (base_context, dark_border_color);
+        // base_context.move_to (radius + shadow_width - zoomlevel, radius + shadow_width - zoomlevel);
+        // base_context.line_to (radius + shadow_width + zoomlevel, radius + shadow_width - zoomlevel);
+        // base_context.line_to (radius + shadow_width + zoomlevel, radius + shadow_width + zoomlevel);
+        // base_context.line_to (radius + shadow_width - zoomlevel, radius + shadow_width + zoomlevel);
+        // base_context.close_path ();
+        // base_context.stroke ();
 
+        // Gdk.cairo_set_source_rgba (base_context, bright_border_color);
+        // base_context.move_to (radius + shadow_width - zoomlevel + 1, radius + shadow_width - zoomlevel + 1);
+        // base_context.line_to (radius + shadow_width + zoomlevel - 1, radius + shadow_width - zoomlevel + 1);
+        // base_context.line_to (radius + shadow_width + zoomlevel - 1, radius + shadow_width + zoomlevel - 1);
+        // base_context.line_to (radius + shadow_width - zoomlevel + 1, radius + shadow_width + zoomlevel - 1);
+        // base_context.close_path ();
+        // base_context.stroke ();
+
+
+        // magnifier = new Gdk.Cursor.from_surface (
+        //     get_screen ().get_display (),
+        //     base_surface,
+        //     base_surface.get_width () / 2,
+        //     base_surface.get_height () / 2);
+
+        // // Set the cursor
+        // manager.grab (
+        //     get_window (),
+        //     Gdk.SeatCapabilities.ALL,
+        //     true,
+        //     magnifier,
+        //     new Gdk.Event (Gdk.EventType.BUTTON_PRESS | Gdk.EventType.MOTION_NOTIFY | Gdk.EventType.SCROLL),
+        //     null);
     }
 
 
@@ -312,20 +311,20 @@ public class Akira.Utils.ColorPicker : Gtk.Window {
     public override void show_all () {
         base.show_all ();
 
-        var manager = Gdk.Display.get_default ().get_default_seat ();
-        var window = get_window ();
+        // var manager = Gdk.Display.get_default ().get_default_seat ();
+        // var window = get_window ();
 
-        var status = manager.grab (
-            window,
-            Gdk.SeatCapabilities.ALL,
-            false,
-            new Gdk.Cursor.for_display (window.get_display (), Gdk.CursorType.CROSSHAIR),
-            new Gdk.Event (Gdk.EventType.BUTTON_PRESS | Gdk.EventType.BUTTON_RELEASE | Gdk.EventType.MOTION_NOTIFY),
-            null);
+        // var status = manager.grab (
+        //     window,
+        //     Gdk.SeatCapabilities.ALL,
+        //     false,
+        //     new Gdk.Cursor.for_display (window.get_display (), Gdk.CursorType.CROSSHAIR),
+        //     new Gdk.Event (Gdk.EventType.BUTTON_PRESS | Gdk.EventType.BUTTON_RELEASE | Gdk.EventType.MOTION_NOTIFY),
+        //     null);
 
-        if (status != Gdk.GrabStatus.SUCCESS) {
-            manager.ungrab ();
-        }
+        // if (status != Gdk.GrabStatus.SUCCESS) {
+        //     manager.ungrab ();
+        // }
 
         // show magnifier
         set_magnifier_cursor ();

--- a/src/Utils/Dialogs.vala
+++ b/src/Utils/Dialogs.vala
@@ -28,27 +28,27 @@ public class Akira.Utils.Dialogs : Object {
         );
     }
 
-    public Granite.MessageDialog message_dialog (
-        string title,
-        string description,
-        string icon,
-        string primary_button,
-        string? secondary_button = null
-    ) {
-        var dialog = new Granite.MessageDialog.with_image_from_icon_name (
-            title, description, icon, Gtk.ButtonsType.CANCEL);
-        dialog.transient_for = window;
+    // public Granite.MessageDialog message_dialog (
+    //     string title,
+    //     string description,
+    //     string icon,
+    //     string primary_button,
+    //     string? secondary_button = null
+    // ) {
+    //     var dialog = new Granite.MessageDialog.with_image_from_icon_name (
+    //         title, description, icon, Gtk.ButtonsType.CANCEL);
+    //     dialog.transient_for = window;
 
-        if (secondary_button != null) {
-            var button2 = new Gtk.Button.with_label (secondary_button);
-            button2.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-            dialog.add_action_widget (button2, 2);
-        }
+    //     if (secondary_button != null) {
+    //         var button2 = new Gtk.Button.with_label (secondary_button);
+    //         button2.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+    //         dialog.add_action_widget (button2, 2);
+    //     }
 
-        var button = new Gtk.Button.with_label (primary_button);
-        button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
-        dialog.add_action_widget (button, Gtk.ResponseType.ACCEPT);
+    //     var button = new Gtk.Button.with_label (primary_button);
+    //     button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+    //     dialog.add_action_widget (button, Gtk.ResponseType.ACCEPT);
 
-        return dialog;
-    }
+    //     return dialog;
+    // }
 }

--- a/src/Utils/Nobs.vala
+++ b/src/Utils/Nobs.vala
@@ -172,43 +172,43 @@ public class Akira.Utils.Nobs : Object {
     /*
      * Return a cursor type based of the type of nob.
      */
-    public static Gdk.CursorType? cursor_from_nob (Nob nob_id) {
-        Gdk.CursorType? result = null;
-        switch (nob_id) {
-            case Nob.NONE:
-                result = null;
-                break;
-            case Nob.TOP_LEFT:
-                result = Gdk.CursorType.TOP_LEFT_CORNER;
-                break;
-            case Nob.TOP_CENTER:
-                result = Gdk.CursorType.TOP_SIDE;
-                break;
-            case Nob.TOP_RIGHT:
-                result = Gdk.CursorType.TOP_RIGHT_CORNER;
-                break;
-            case Nob.RIGHT_CENTER:
-                result = Gdk.CursorType.RIGHT_SIDE;
-                break;
-            case Nob.BOTTOM_RIGHT:
-                result = Gdk.CursorType.BOTTOM_RIGHT_CORNER;
-                break;
-            case Nob.BOTTOM_CENTER:
-                result = Gdk.CursorType.BOTTOM_SIDE;
-                break;
-            case Nob.BOTTOM_LEFT:
-                result = Gdk.CursorType.BOTTOM_LEFT_CORNER;
-                break;
-            case Nob.LEFT_CENTER:
-                result = Gdk.CursorType.LEFT_SIDE;
-                break;
-            case Nob.ROTATE:
-                result = Gdk.CursorType.EXCHANGE;
-                break;
-        }
+    // public static Gdk.CursorType? cursor_from_nob (Nob nob_id) {
+    //     Gdk.CursorType? result = null;
+    //     switch (nob_id) {
+    //         case Nob.NONE:
+    //             result = null;
+    //             break;
+    //         case Nob.TOP_LEFT:
+    //             result = Gdk.CursorType.TOP_LEFT_CORNER;
+    //             break;
+    //         case Nob.TOP_CENTER:
+    //             result = Gdk.CursorType.TOP_SIDE;
+    //             break;
+    //         case Nob.TOP_RIGHT:
+    //             result = Gdk.CursorType.TOP_RIGHT_CORNER;
+    //             break;
+    //         case Nob.RIGHT_CENTER:
+    //             result = Gdk.CursorType.RIGHT_SIDE;
+    //             break;
+    //         case Nob.BOTTOM_RIGHT:
+    //             result = Gdk.CursorType.BOTTOM_RIGHT_CORNER;
+    //             break;
+    //         case Nob.BOTTOM_CENTER:
+    //             result = Gdk.CursorType.BOTTOM_SIDE;
+    //             break;
+    //         case Nob.BOTTOM_LEFT:
+    //             result = Gdk.CursorType.BOTTOM_LEFT_CORNER;
+    //             break;
+    //         case Nob.LEFT_CENTER:
+    //             result = Gdk.CursorType.LEFT_SIDE;
+    //             break;
+    //         case Nob.ROTATE:
+    //             result = Gdk.CursorType.EXCHANGE;
+    //             break;
+    //     }
 
-        return result;
-    }
+    //     return result;
+    // }
 
     public static Nob opposite_nob (Nob nob_id) {
         switch (nob_id) {

--- a/src/ViewLayers/BaseCanvas.vala
+++ b/src/ViewLayers/BaseCanvas.vala
@@ -46,7 +46,7 @@ public class Akira.ViewLayers.BaseCanvas : Gtk.Widget , Gtk.Scrollable {
     public bool pause_redraw = false;
 
     // The main window that gets scrolled around
-    private Gdk.Window canvas_window;
+    private X.Window canvas_window;
 
     private unowned Lib.Items.Model? model_to_render = null;
 

--- a/src/ViewLayers/BaseCanvas.vala
+++ b/src/ViewLayers/BaseCanvas.vala
@@ -235,7 +235,7 @@ public class Akira.ViewLayers.BaseCanvas : Gtk.Widget , Gtk.Scrollable {
         reconfigure (true);
     }
 
-    public override bool scroll_event (Gdk.EventScroll event) {
+    public override bool scroll_event (Gdk.ScrollEvent event) {
         Gtk.Adjustment adj;
         if (event.direction == Gdk.ScrollDirection.UP || event.direction == Gdk.ScrollDirection.DOWN) {
             adj = vadjustment;

--- a/src/Widgets/ColorField.vala
+++ b/src/Widgets/ColorField.vala
@@ -80,17 +80,17 @@ public class Akira.Widgets.ColorField : Gtk.Entry {
         }
     }
 
-    private bool handle_focus_in (Gdk.EventFocus event) {
+    private bool handle_focus_in (Gdk.FocusEvent event) {
         window.event_bus.disconnect_typing_accel ();
         return false;
     }
 
-    private bool handle_focus_out (Gdk.EventFocus event) {
+    private bool handle_focus_out (Gdk.FocusEvent event) {
         window.event_bus.connect_typing_accel ();
         return false;
     }
 
-    private bool handle_key_press (Gdk.EventKey event) {
+    private bool handle_key_press (Gdk.KeyEvent event) {
         // Enter or Escape
         if (event.keyval == Gdk.Key.Return || event.keyval == Gdk.Key.Escape) {
             window.event_bus.set_focus_on_canvas ();

--- a/src/Widgets/ColorRow.vala
+++ b/src/Widgets/ColorRow.vala
@@ -277,7 +277,7 @@ public class Akira.Widgets.ColorRow : Gtk.Grid {
                     border-color: shade (%s, 0.75);
                 }""".printf (new_color, new_color);
 
-            provider.load_from_data (css, css.length);
+            provider.load_from_data (css.data);
 
             context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         } catch (Error e) {

--- a/src/Widgets/InputField.vala
+++ b/src/Widgets/InputField.vala
@@ -19,7 +19,7 @@
  * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
-public class Akira.Widgets.InputField : Gtk.EventBox {
+public class Akira.Widgets.InputField : Gtk.Widget {
     public Gtk.SpinButton entry { get; construct set; }
 
     public int chars { get; construct set; }

--- a/src/Widgets/InputField.vala
+++ b/src/Widgets/InputField.vala
@@ -107,7 +107,7 @@ public class Akira.Widgets.InputField : Gtk.EventBox {
         entry.set_range (min_value, max_value);
     }
 
-    private bool handle_key_press (Gdk.EventKey event) {
+    private bool handle_key_press (Gdk.KeyEvent event) {
         // Arrow UP
         if (event.keyval == Gdk.Key.Up && (event.state & Gdk.ModifierType.SHIFT_MASK) > 0) {
             entry.spin (Gtk.SpinType.STEP_FORWARD, 10);
@@ -130,7 +130,7 @@ public class Akira.Widgets.InputField : Gtk.EventBox {
         return false;
     }
 
-    private bool handle_scroll_event (Gdk.EventScroll event) {
+    private bool handle_scroll_event (Gdk.ScrollEvent event) {
         // If the input field is not focused, don't change the value.
         if (!entry.has_focus) {
             return true;
@@ -138,7 +138,7 @@ public class Akira.Widgets.InputField : Gtk.EventBox {
         return false;
     }
 
-    private bool handle_focus_in (Gdk.EventFocus event) {
+    private bool handle_focus_in (Gdk.FocusEvent event) {
         Akira.Window window = get_toplevel () as Akira.Window;
         if (!(window is Akira.Window)) {
             return true;
@@ -148,7 +148,7 @@ public class Akira.Widgets.InputField : Gtk.EventBox {
         return false;
     }
 
-    private bool handle_focus_out (Gdk.EventFocus event) {
+    private bool handle_focus_out (Gdk.FocusEvent event) {
         Akira.Window window = get_toplevel () as Akira.Window;
         if (!(window is Akira.Window)) {
             return true;

--- a/src/Widgets/LinkedInput.vala
+++ b/src/Widgets/LinkedInput.vala
@@ -65,10 +65,8 @@ public class Akira.Widgets.LinkedInput : Gtk.Grid {
     construct {
         valign = Gtk.Align.CENTER;
         hexpand = true;
-        get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
-
-        var event_box = new Gtk.EventBox ();
-        event_box.event.connect (handle_event);
+        // TODO GTK4: Add missing styling.
+        // get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
 
         var entry_label = new Gtk.Label (label);
         entry_label.get_style_context ().add_class ("entry-label");
@@ -76,6 +74,8 @@ public class Akira.Widgets.LinkedInput : Gtk.Grid {
         entry_label.width_request = 20;
         entry_label.hexpand = false;
         entry_label.tooltip_text = tooltip;
+        // TODO GTK4: We need an EventController for the label.
+        // entry_label.connect (handle_event);
 
         switch (unit) {
             case "#":
@@ -100,13 +100,11 @@ public class Akira.Widgets.LinkedInput : Gtk.Grid {
             "value", input_field.entry, "value",
             BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
 
-        event_box.add (entry_label);
-
         if (reversed) {
             attach (input_field, 0, 0);
-            attach (event_box, 1, 0);
+            attach (entry_label, 1, 0);
         } else {
-            attach (event_box, 0, 0);
+            attach (entry_label, 0, 0);
             attach (input_field, 1, 0);
         }
     }

--- a/src/Widgets/LinkedInput.vala
+++ b/src/Widgets/LinkedInput.vala
@@ -117,11 +117,11 @@ public class Akira.Widgets.LinkedInput : Gtk.Grid {
         }
 
         if (event.type == Gdk.EventType.ENTER_NOTIFY) {
-            set_cursor_from_name ("ew-resize");
+            // set_cursor_from_name ("ew-resize");
         }
 
         if (event.type == Gdk.EventType.LEAVE_NOTIFY) {
-            set_cursor (Gdk.CursorType.ARROW);
+            // set_cursor (Gdk.CursorType.ARROW);
         }
 
         if (event.type == Gdk.EventType.BUTTON_PRESS) {
@@ -150,13 +150,13 @@ public class Akira.Widgets.LinkedInput : Gtk.Grid {
         return false;
     }
 
-    private void set_cursor (Gdk.CursorType cursor_type) {
-        var cursor = new Gdk.Cursor.for_display (Gdk.Display.get_default (), cursor_type);
-        get_window ().set_cursor (cursor);
-    }
+    // private void set_cursor (Gdk.CursorType cursor_type) {
+    //     var cursor = new Gdk.Cursor.for_display (Gdk.Display.get_default (), cursor_type);
+    //     get_window ().set_cursor (cursor);
+    // }
 
-    private void set_cursor_from_name (string name) {
-        var cursor = new Gdk.Cursor.from_name (Gdk.Display.get_default (), name);
-        get_window ().set_cursor (cursor);
-    }
+    // private void set_cursor_from_name (string name) {
+    //     var cursor = new Gdk.Cursor.from_name (Gdk.Display.get_default (), name);
+    //     get_window ().set_cursor (cursor);
+    // }
 }

--- a/src/Widgets/RoundedColorButton.vala
+++ b/src/Widgets/RoundedColorButton.vala
@@ -44,7 +44,7 @@ public class Akira.Widgets.RoundedColorButton : Gtk.Grid {
                     border-color: shade (%s, 0.75);
                 }""".printf (color, color);
 
-            provider.load_from_data (css, css.length);
+            provider.load_from_data (css.data);
             btn_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         } catch (Error e) {
             warning ("Style error: %s", e.message);
@@ -55,6 +55,6 @@ public class Akira.Widgets.RoundedColorButton : Gtk.Grid {
             set_color (color);
         });
 
-        add (btn);
+        attach (btn, 0, 0);
     }
 }

--- a/src/Widgets/ZoomButton.vala
+++ b/src/Widgets/ZoomButton.vala
@@ -129,7 +129,7 @@ public class Akira.Widgets.ZoomButton : Gtk.Grid {
      * input field for manual inputing if the user pressed the CTRL key
      * while clicking on the button.
      */
-    public bool zoom_reset (Gdk.EventButton event) {
+    public bool zoom_reset (Gdk.ButtonEvent event) {
         // If the CTRL key was pressed, show the popover with the input field.
         if ((event.state & Gdk.ModifierType.CONTROL_MASK) > 0) {
             zoom_popover.popup ();
@@ -156,7 +156,7 @@ public class Akira.Widgets.ZoomButton : Gtk.Grid {
     /*
      * Key press events on the input field.
      */
-    private bool handle_key_press (Gdk.EventKey event) {
+    private bool handle_key_press (Gdk.KeyEvent event) {
         // Arrow UP pressed, increase value by 1.
         if (event.keyval == Gdk.Key.Up) {
             window.event_bus.adjust_zoom (0.1, true, null);
@@ -210,7 +210,7 @@ public class Akira.Widgets.ZoomButton : Gtk.Grid {
     /*
      * When the input field gains focus.
      */
-    private bool handle_focus_in (Gdk.EventFocus event) {
+    private bool handle_focus_in (Gdk.FocusEvent event) {
         window.event_bus.disconnect_typing_accel ();
         return false;
     }
@@ -218,7 +218,7 @@ public class Akira.Widgets.ZoomButton : Gtk.Grid {
     /*
      * When the input field loses focus.
      */
-    private bool handle_focus_out (Gdk.EventFocus event) {
+    private bool handle_focus_out (Gdk.FocusEvent event) {
         window.event_bus.connect_typing_accel ();
         return false;
     }

--- a/src/Widgets/ZoomButton.vala
+++ b/src/Widgets/ZoomButton.vala
@@ -33,8 +33,9 @@ public class Akira.Widgets.ZoomButton : Gtk.Grid {
         this.window = window;
 
         // Grid specific attributes.
-        get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
-        get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        // TODO GTK4: Add missing styling.
+        // get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
+        // get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         valign = Gtk.Align.CENTER;
         column_homogeneous = false;
         width_request = 140;

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -32,7 +32,7 @@ public class Akira.Window : Gtk.ApplicationWindow {
     public Akira.Utils.Dialogs dialogs;
 
     public SimpleActionGroup actions { get; construct; }
-    public Gtk.AccelGroup accel_group { get; construct; }
+    // public Gtk.AccelGroup accel_group { get; construct; }
 
     public bool edited { get; set; default = false; }
 
@@ -45,8 +45,8 @@ public class Akira.Window : Gtk.ApplicationWindow {
     }
 
     construct {
-        accel_group = new Gtk.AccelGroup ();
-        add_accel_group (accel_group);
+        // accel_group = new Gtk.AccelGroup ();
+        // add_accel_group (accel_group);
 
         event_bus = new Akira.Services.EventBus ();
         action_manager = new Akira.Services.ActionManager (app, this);

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -108,37 +108,37 @@ public class Akira.Window : Gtk.ApplicationWindow {
             on_destroy ();
         }
 
-        if (edited) {
-            var dialog = dialogs.message_dialog (
-                _("Are you sure you want to quit?"),
-                _("All unsaved data will be lost and impossible to recover."),
-                "system-shutdown",
-                _("Quit without saving!"),
-                _("Save file")
-            );
+        // if (edited) {
+        //     var dialog = dialogs.message_dialog (
+        //         _("Are you sure you want to quit?"),
+        //         _("All unsaved data will be lost and impossible to recover."),
+        //         "system-shutdown",
+        //         _("Quit without saving!"),
+        //         _("Save file")
+        //     );
 
-            dialog.show_all ();
+        //     dialog.show_all ();
 
-            dialog.response.connect ((id) => {
-                switch (id) {
-                    case Gtk.ResponseType.ACCEPT:
-                        dialog.destroy ();
-                        close_current_file ();
-                        app.get_active_window ().destroy ();
-                        on_destroy ();
-                        break;
-                    case 2:
-                        dialog.destroy ();
-                        file_manager.save_file ();
-                        break;
-                    default:
-                        dialog.destroy ();
-                        break;
-                }
-            });
+        //     dialog.response.connect ((id) => {
+        //         switch (id) {
+        //             case Gtk.ResponseType.ACCEPT:
+        //                 dialog.destroy ();
+        //                 close_current_file ();
+        //                 app.get_active_window ().destroy ();
+        //                 on_destroy ();
+        //                 break;
+        //             case 2:
+        //                 dialog.destroy ();
+        //                 file_manager.save_file ();
+        //                 break;
+        //             default:
+        //                 dialog.destroy ();
+        //                 break;
+        //         }
+        //     });
 
-            dialog.run ();
-        }
+        //     dialog.run ();
+        // }
 
         return true;
     }

--- a/src/meson.build
+++ b/src/meson.build
@@ -143,7 +143,7 @@ sources = files(
 
 deps = [
     gtk_dependency,
-    granite_dependency,
+    #granite_dependency,
     gee_dependency,
     libxml_dependency,
     cairo_dependency,


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Upgrading the dependencies to start using GTK4.
This will break the whole UI and more as the API changes are substantial.

If you don't have GTK4 installed in your system, you can't use `meson` to build but you'll have to rely on flatpak:
`flatpak-builder build com.github.akiraux.akira.yml --user --force-clean`.

## Known Issues / Things To Do
- [ ] Figure out a proper replacement/rework of the `BaseCanvas` that was using `GdkWindow`, now deprecated in favor of `GdkSurface`.
- [ ] Upgrade all deprecated API where possible, comment out the most complicated.
- [ ] Make a successful build

## This PR fixes/implements the following **bugs/features**:
- Require `gtk4`
- Temporarily remove `LibGranite` as it depends on `gtk3`
- Update the flatpak to build against GNOME SDK 40
- Build the elementary style and icon
