### PR TITLE
Deselect on click

### DIFF
--- a/src/Lib/Items/ItemSelection.vala
+++ b/src/Lib/Items/ItemSelection.vala
@@ -142,7 +142,13 @@ public class Akira.Lib.Items.NodeSelection : Object {
         return false;
     }
 
-    public bool is_empty () { return nodes.size == 0; }
+    public bool is_empty () {
+        return nodes.size == 0;
+    }
+
+    public int count () {
+        return nodes.size;
+    }
 
     public Geometry.Quad coordinates () {
         var result = Geometry.Quad ();

--- a/src/Lib/Managers/SelectionManager.vala
+++ b/src/Lib/Managers/SelectionManager.vala
@@ -58,6 +58,10 @@ public class Akira.Lib.Managers.SelectionManager : Object {
         return selection.is_empty ();
     }
 
+    public int count () {
+        return selection.count ();
+    }
+
     public void reset_selection () {
         if (is_empty ()) {
             return;


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Initial tiny PR to start implementing a more standard selection/deselection paradigm for multiselect.
This PR implements the ability to deselect all items if a click happens in an empty area between selected items.

## Steps to Test
- Create multiple items
- Add items to selection by holding <kbd>SHIFT</kbd>
- Click on an item and drag to move the entire selection (no deselection should happen)
- Click on an empty area between selection items and drag to move the entire selection (no deselection should happen)
- Click on an empty area between selection items (the selection should be reset)

## Known Issues / Things To Do
- Clicking on an item that is part of a selection without dragging should deselect all items except the clicked on. Will do in a follow up PR.
- I feel like the code could be better optimized, but I need to get acquainted with the new architecture before I can make these calls.
