### PR TITLE
Add viewlayer masking

### DIFF
--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -231,6 +231,9 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
             return;
         }
 
+        var blocker = new Lib.Managers.SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
+        (blocker);
+
         // Add all currently selected rows to the selection. This won't trigger
         // a selection changed loop since the selection_modified_external signal
         // is only triggered from a click on the canvas.

--- a/src/Lib/Items/ModelInstance.vala
+++ b/src/Lib/Items/ModelInstance.vala
@@ -103,7 +103,9 @@ public class Akira.Lib.Items.ModelInstance {
         something_changed = compiled_components.maybe_compile_geometry (type, components, node) || something_changed;
         something_changed = compiled_components.maybe_compile_fill (type, components, node) || something_changed;
         something_changed = compiled_components.maybe_compile_border (type, components, node) || something_changed;
-        something_changed = node.instance.type is ModelTypeArtboard && compiled_components.maybe_compile_name (type, components, node) || something_changed;
+        something_changed = node.instance.type is ModelTypeArtboard
+            && compiled_components.maybe_compile_name (type, components, node)
+            || something_changed;
 
         notify_view_of_changes ();
 

--- a/src/Lib/Items/ModelTypeEllipse.vala
+++ b/src/Lib/Items/ModelTypeEllipse.vala
@@ -83,6 +83,8 @@ public class Akira.Lib.Items.ModelTypeEllipse : ModelType {
                 ellipse.radius_y = instance.components.size.height / 2.0;
                 instance.drawable.transform = instance.compiled_geometry.transformation_matrix;
                 break;
+            default:
+                break;
         }
     }
 }

--- a/src/Lib/Items/ModelTypePath.vala
+++ b/src/Lib/Items/ModelTypePath.vala
@@ -97,6 +97,8 @@ public class Akira.Lib.Items.ModelTypePath : ModelType {
                 drawable.points = instance.components.path.data;
                 drawable.commands = instance.components.path.commands;
                 break;
+            default:
+                break;
         }
     }
 }

--- a/src/Lib/Items/ModelTypeRect.vala
+++ b/src/Lib/Items/ModelTypeRect.vala
@@ -87,6 +87,8 @@ public class Akira.Lib.Items.ModelTypeRect : ModelType {
                 instance.drawable.height = instance.components.size.height;
                 instance.drawable.transform = instance.compiled_geometry.transformation_matrix;
                 break;
+            default:
+                break;
         }
     }
 }

--- a/src/Lib/Managers/CopyManager.vala
+++ b/src/Lib/Managers/CopyManager.vala
@@ -69,7 +69,7 @@ public class Akira.Lib.Managers.CopyManager : Object {
         }
 
         var blocker = new SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
-        (void) blocker;
+        (blocker);
 
         view_canvas.selection_manager.reset_selection ();
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -247,7 +247,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     public void flip_items (GLib.Array<int> ids, bool vertical) {
         /*
         var blocker = new Lib.Managers.SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
-        (void) blocker;
+        (blocker);
 
         foreach (var target_id in ids.data) {
             var target = item_model.instance_from_id (target_id);
@@ -432,7 +432,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         Timer timer = new Timer ();
 
         var blocker = new Lib.Managers.SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
-        (void) blocker;
+        (blocker);
 
         var group = Lib.Items.ModelTypeArtboard.default_artboard (
             new Lib.Components.Coordinates (500, 500),
@@ -487,7 +487,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         Timer timer = new Timer ();
 
         var blocker = new SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
-        (void) blocker;
+        (blocker);
         view_canvas.pause_redraw = true;
 
         for (var i = 0; i < num_of; ++i) {

--- a/src/Lib/Modes/TransformMode.vala
+++ b/src/Lib/Modes/TransformMode.vala
@@ -330,7 +330,6 @@ public class Akira.Lib.Modes.TransformMode : AbstractInteractionMode {
         double event_x,
         double event_y
     ) {
-        // TODO WIP
         var blocker = new Lib.Managers.SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
         (blocker);
 

--- a/src/Lib/Modes/TransformMode.vala
+++ b/src/Lib/Modes/TransformMode.vala
@@ -53,6 +53,8 @@ public class Akira.Lib.Modes.TransformMode : AbstractInteractionMode {
         }
     }
 
+    // Simply defines whether the drag threshold was met to start transforming the object
+
     public class TransformExtraContext : Object {
         public Lib.Managers.SnapManager.SnapGuideData snap_guide_data;
     }
@@ -148,6 +150,7 @@ public class Akira.Lib.Modes.TransformMode : AbstractInteractionMode {
     }
 
     public override bool motion_notify_event (Gdk.EventMotion event) {
+
         switch (nob) {
             case Utils.Nobs.Nob.NONE:
                 move_from_event (
@@ -196,7 +199,7 @@ public class Akira.Lib.Modes.TransformMode : AbstractInteractionMode {
         ref Lib.Managers.SnapManager.SnapGuideData guide_data
     ) {
         var blocker = new Lib.Managers.SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
-        (void) blocker;
+        (blocker);
 
         var delta_x = event_x - initial_drag_state.press_x;
         var delta_y = event_y - initial_drag_state.press_y;
@@ -329,7 +332,7 @@ public class Akira.Lib.Modes.TransformMode : AbstractInteractionMode {
     ) {
         // TODO WIP
         var blocker = new Lib.Managers.SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
-        (void) blocker;
+        (blocker);
 
         double rot_center_x = initial_drag_state.area.center_x;
         double rot_center_y = initial_drag_state.area.center_y;
@@ -431,7 +434,7 @@ public class Akira.Lib.Modes.TransformMode : AbstractInteractionMode {
         double event_y
     ) {
         var blocker = new Lib.Managers.SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
-        (void) blocker;
+        (blocker);
 
         double original_center_x = initial_drag_state.area.center_x;
         double original_center_y = initial_drag_state.area.center_y;

--- a/src/Utils/ItemAlignment.vala
+++ b/src/Utils/ItemAlignment.vala
@@ -64,7 +64,7 @@ public class Akira.Utils.ItemAlignment : Object {
         }
 
         var blocker = new Lib.Managers.SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
-        (void) blocker;
+        (blocker);
 
         unowned var items_manager = view_canvas.items_manager;
         unowned var model = items_manager.item_model;

--- a/src/Utils/Nobs.vala
+++ b/src/Utils/Nobs.vala
@@ -205,6 +205,8 @@ public class Akira.Utils.Nobs : Object {
             case Nob.ROTATE:
                 result = Gdk.CursorType.EXCHANGE;
                 break;
+            default:
+                break;
         }
 
         return result;
@@ -396,6 +398,8 @@ public class Akira.Utils.Nobs : Object {
 
                 x = (rect.tl_x + rect.tr_x) / 2.0 + dx * ROTATION_LINE_HEIGHT / scale;
                 y = (rect.tl_y + rect.tr_y) / 2.0 + dy * ROTATION_LINE_HEIGHT / scale;
+                break;
+            default:
                 break;
         }
     }

--- a/src/ViewLayers/BaseCanvas.vala
+++ b/src/ViewLayers/BaseCanvas.vala
@@ -146,9 +146,17 @@ public class Akira.ViewLayers.BaseCanvas : Gtk.Widget , Gtk.Scrollable {
             overlays = new Gee.TreeMap<string, ViewLayers.ViewLayer> ();
         }
         overlays[id] = layer;
-        if (layer.is_visible) {
+        if (layer.is_visible && !layer.is_masked) {
             layer.update ();
         }
+    }
+
+    public ViewLayer.Mask? mask_viewlayer_overlay (string id) {
+        if (overlays == null) {
+            return null;
+        }
+
+        return overlays.has_key (id) ? new ViewLayer.Mask (overlays[id]) : null;
     }
 
     public bool get_border (out Gtk.Border border) {

--- a/src/ViewLayers/ViewLayer.vala
+++ b/src/ViewLayers/ViewLayer.vala
@@ -20,6 +20,24 @@
  */
 
 public class Akira.ViewLayers.ViewLayer : Object {
+    public class Mask {
+        private ViewLayer view_layer;
+
+        // Scoped mask implementation to hide masks temporarily during a scope (RAII)
+        public Mask (ViewLayer layer) {
+            view_layer = layer;
+            if (view_layer != null) {
+                view_layer.add_mask ();
+            }
+        }
+
+        ~Mask () {
+            if (view_layer != null) {
+                view_layer.remove_mask ();
+            }
+        }
+    }
+
     // Higher numbers are higher on the stack
     public const string VSNAPS_LAYER_ID = "99_vsnaps_layer";
     public const string HSNAPS_LAYER_ID = "99_hsnaps_layer";
@@ -33,9 +51,12 @@ public class Akira.ViewLayers.ViewLayer : Object {
 
     private bool p_is_visible { get; set; default = false; }
     private BaseCanvas? p_canvas { get; set; default = null; }
+    private int p_mask_counter { get; set; default = 0; }
 
     public BaseCanvas? canvas { get { return p_canvas; } }
     public bool is_visible { get { return p_is_visible; } }
+    public bool is_masked { get { return p_mask_counter > 0; } }
+
 
     public void add_to_canvas (string layer_id, BaseCanvas canvas) {
         p_canvas = canvas;
@@ -50,6 +71,21 @@ public class Akira.ViewLayers.ViewLayer : Object {
         p_is_visible = visible;
 
         update ();
+    }
+
+    public void add_mask () {
+        p_mask_counter++;
+        if (is_visible && is_masked) {
+            update ();
+        }
+    }
+
+    public void remove_mask () {
+        p_mask_counter = int.min(p_mask_counter - 1, 0);
+
+        if (is_visible && !is_masked) {
+            update ();
+        }
     }
 
     public virtual void draw_layer (Cairo.Context context, Geometry.Rectangle target_bounds, double scale) {}

--- a/src/ViewLayers/ViewLayer.vala
+++ b/src/ViewLayers/ViewLayer.vala
@@ -81,7 +81,7 @@ public class Akira.ViewLayers.ViewLayer : Object {
     }
 
     public void remove_mask () {
-        p_mask_counter = int.min(p_mask_counter - 1, 0);
+        p_mask_counter = int.min (p_mask_counter - 1, 0);
 
         if (is_visible && !is_masked) {
             update ();


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Add ability to mask ViewLayers. This will work via a RAII class that on construction masks and on destruction unmasks a specific viewlayer. If the viewlayer is masked, it doesn't show even if it is technically set visible. This allows a user to easily scope when a viewlayer should be disabled temporarily.

This PR also includes some warning removals on newer versions of vala (0.54).

Finally this includes a significant improvment to selecting multiple things in the layer listbox by blocking unnecessarily selection change signals.

## Steps to Test
Create 10k objects with "j". Select all by clicking first item in the list, and scrolling down and selection the last. It should now be significantly faster than before, and will generally scale linearly rather than squared :P

