### PR TITLE
Add multi selection by click and drag

### DIFF
--- a/src/Geometry/Rectangle.vala
+++ b/src/Geometry/Rectangle.vala
@@ -63,6 +63,10 @@ public struct Akira.Geometry.Rectangle {
         return (left < x < right) && (top < y < bottom);
     }
 
+    public bool contains_bound (Geometry.Rectangle bound) {
+        return (left <= bound.left) && (top <= bound.top) && (right >= bound.right) && (bottom >= bound.bottom);
+    }
+
     public bool does_not_contain (double x, double y) {
         return x < left || x > right || y < top || y > bottom;
     }

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -316,7 +316,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         return found_items.last ();
     }
 
-    public Gee.ArrayList<unowned Lib.Items.ModelNode>  nodes_in_bounded_region (
+    public Gee.ArrayList<unowned Lib.Items.ModelNode> nodes_in_bounded_region (
         Geometry.Rectangle bound
     ) {
         var found_items = new Gee.ArrayList<unowned Lib.Items.ModelNode> ();

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -330,7 +330,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         foreach (unowned var node in origin.children.data) {
             var node_type = node.instance.type.name_id;
 
-            if (node_type == "artboard") {
+            if (node_type == "artboard" && node.children != null) {
                 foreach (unowned var child_node in node.children.data) {
                     if (bound.contains_bound (child_node.instance.drawable.bounds)) {
                         found_items.add (child_node);

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -316,6 +316,26 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         return found_items.last ();
     }
 
+    public Gee.ArrayList<unowned Lib.Items.ModelNode>  nodes_in_bounded_region (
+        Geometry.Rectangle bound
+    ) {
+        var found_items = new Gee.ArrayList<unowned Lib.Items.ModelNode> ();
+
+        var origin = item_model.node_from_id (Lib.Items.Model.ORIGIN_ID);
+
+        if (origin.children == null) {
+            return found_items;
+        }
+
+        foreach (unowned var root in origin.children.data) {
+            if (bound.contains_bound (root.instance.drawable.bounds)) {
+                found_items.add (root);
+            }
+        }
+
+        return found_items;
+    }
+
     /*
      * Returns the top-most group at position. Origin if no other group found.
      */

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -329,7 +329,6 @@ public class Akira.Lib.Managers.ItemsManager : Object {
 
         foreach (unowned var node in origin.children.data) {
             var node_type = node.instance.type.name_id;
-            debug (@"Node: $(node.instance.components.name.name) type: $(node.instance.type.name_id)");
 
             if (node_type == "artboard") {
                 foreach (unowned var child_node in node.children.data) {

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -327,9 +327,21 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             return found_items;
         }
 
-        foreach (unowned var root in origin.children.data) {
-            if (bound.contains_bound (root.instance.drawable.bounds)) {
-                found_items.add (root);
+        foreach (unowned var node in origin.children.data) {
+            var node_type = node.instance.type.name_id;
+            debug (@"Node: $(node.instance.components.name.name) type: $(node.instance.type.name_id)");
+
+            if (node_type == "artboard") {
+                foreach (unowned var child_node in node.children.data) {
+                    if (bound.contains_bound (child_node.instance.drawable.bounds)) {
+                        found_items.add (child_node);
+                    }
+                }
+                continue;
+            }
+
+            if (bound.contains_bound (node.instance.drawable.bounds)) {
+                found_items.add (node);
             }
         }
 

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -133,6 +133,7 @@ public class Akira.Lib.Managers.NobManager : Object {
     }
 
     private void update_nob_layer () {
+        nob_layer.set_visible (true);
         nob_layer.update_nob_data (nobs);
     }
 

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -64,6 +64,9 @@ public class Akira.Lib.Managers.NobManager : Object {
         last_id = new_id;
         update_nob_positions (sm.selection);
         update_nob_layer ();
+
+        // Set the nob layer visible after is has been set non-visible by remove_select_effect
+        nob_layer.set_visible (true);
     }
 
     /*
@@ -133,7 +136,6 @@ public class Akira.Lib.Managers.NobManager : Object {
     }
 
     private void update_nob_layer () {
-        nob_layer.set_visible (true);
         nob_layer.update_nob_data (nobs);
     }
 

--- a/src/Lib/Modes/AbstractInteractionMode.vala
+++ b/src/Lib/Modes/AbstractInteractionMode.vala
@@ -51,7 +51,8 @@ public abstract class Akira.Lib.Modes.AbstractInteractionMode : Object {
         ITEM_INSERT,
         EXPORT,
         PAN,
-        PATH_EDIT
+        PATH_EDIT,
+        MULTI_SELECT
     }
 
     public signal void request_deregistration (ModeType type);

--- a/src/Lib/Modes/MultiSelectMode.vala
+++ b/src/Lib/Modes/MultiSelectMode.vala
@@ -109,7 +109,6 @@ public class Akira.Lib.Modes.MultiSelectMode : AbstractInteractionMode {
         var found_items = view_canvas.items_manager.nodes_in_bounded_region (bounds);
 
         foreach (unowned var item in found_items) {
-            debug (@"Item in selection: $(item.instance.components.name.name) type: $(item.instance.type.name_id)");
             view_canvas.selection_manager.add_to_selection (item.instance.id);
         }
 

--- a/src/Lib/Modes/MultiSelectMode.vala
+++ b/src/Lib/Modes/MultiSelectMode.vala
@@ -106,6 +106,11 @@ public class Akira.Lib.Modes.MultiSelectMode : AbstractInteractionMode {
     private void select_items_inside_region () {
         var bounds = multi_select_layer.get_region_bounds ();
 
+        // Block selection manager while selecting potentially many items
+        var blocker = new Lib.Managers.SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
+        // Get rid of unused var warning
+        (blocker);
+
         var found_items = view_canvas.items_manager.nodes_in_bounded_region (bounds);
 
         foreach (unowned var item in found_items) {

--- a/src/Lib/Modes/MultiSelectMode.vala
+++ b/src/Lib/Modes/MultiSelectMode.vala
@@ -109,7 +109,7 @@ public class Akira.Lib.Modes.MultiSelectMode : AbstractInteractionMode {
         var found_items = view_canvas.items_manager.nodes_in_bounded_region (bounds);
 
         foreach (unowned var item in found_items) {
-            debug (@"Item in selection: $(item.instance.components.name.name)");
+            debug (@"Item in selection: $(item.instance.components.name.name) type: $(item.instance.type.name_id)");
             view_canvas.selection_manager.add_to_selection (item.instance.id);
         }
 

--- a/src/Lib/Modes/MultiSelectMode.vala
+++ b/src/Lib/Modes/MultiSelectMode.vala
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+ */
+
+public class Akira.Lib.Modes.MultiSelectMode : AbstractInteractionMode {
+    public unowned Lib.ViewCanvas view_canvas { get; construct; }
+
+    public class DragItemData : Object {
+        public Lib.Components.CompiledGeometry item_geometry;
+    }
+
+    public class InitialDragState : Object {
+        public double press_x;
+        public double press_y;
+
+        // initial_selection_data
+        public Geometry.Quad area;
+
+        public Gee.HashMap<int, DragItemData> item_data_map;
+
+        construct {
+            item_data_map = new Gee.HashMap<int, DragItemData> ();
+        }
+    }
+
+    private InitialDragState initial_drag_state;
+    private ViewLayers.ViewLayerMultiSelect multi_select_layer;
+
+    public MultiSelectMode (Akira.Lib.ViewCanvas canvas) {
+        Object (view_canvas: canvas);
+
+        initial_drag_state = new InitialDragState ();
+    }
+
+    construct {
+        multi_select_layer = new ViewLayers.ViewLayerMultiSelect ();
+    }
+
+    public override void mode_begin () {
+        multi_select_layer.add_to_canvas (ViewLayers.ViewLayer.MULTI_SELECT_LAYER_ID, view_canvas);
+    }
+
+    public override void mode_end () {
+
+    }
+
+    public override AbstractInteractionMode.ModeType mode_type () {
+        return AbstractInteractionMode.ModeType.MULTI_SELECT;
+    }
+
+    public override bool key_press_event (Gdk.EventKey event) {
+        return true;
+    }
+
+    public override bool key_release_event (Gdk.EventKey event) {
+        return false;
+    }
+
+    public override bool button_press_event (Gdk.EventButton event) {
+        initial_drag_state.press_x = event.x;
+        initial_drag_state.press_y = event.y;
+
+        multi_select_layer.create_region (event);
+
+        return true;
+    }
+
+    public override bool button_release_event (Gdk.EventButton event) {
+        select_items_inside_region ();
+        multi_select_layer.remove_region ();
+
+        request_deregistration (mode_type ());
+        return true;
+    }
+
+    public override bool motion_notify_event (Gdk.EventMotion event) {
+        var width = event.x - initial_drag_state.press_x;
+        var height = event.y - initial_drag_state.press_y;
+
+        multi_select_layer.update_region (width, height);
+
+        return true;
+    }
+
+    public override Object? extra_context () {
+        return null;
+    }
+
+    private void select_items_inside_region () {
+        var bounds = multi_select_layer.get_region_bounds ();
+
+        var found_items = view_canvas.items_manager.nodes_in_bounded_region (bounds);
+
+        foreach (unowned var item in found_items) {
+            debug (@"Item in selection: $(item.instance.components.name.name)");
+            view_canvas.selection_manager.add_to_selection (item.instance.id);
+        }
+
+        view_canvas.selection_manager.selection_modified_external ();
+    }
+}

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -309,6 +309,11 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
             return true;
         }
 
+        var new_mode = new Lib.Modes.MultiSelectMode (this);
+        mode_manager.register_mode (new_mode);
+
+        mode_manager.button_press_event (event);
+
         return false;
     }
 

--- a/src/ViewLayers/ViewLayer.vala
+++ b/src/ViewLayers/ViewLayer.vala
@@ -43,6 +43,7 @@ public class Akira.ViewLayers.ViewLayer : Object {
     public const string HSNAPS_LAYER_ID = "99_hsnaps_layer";
     public const string GRID_LAYER_ID = "88_grid_layer";
     public const string HOVER_LAYER_ID = "77_hover_layer";
+    public const string MULTI_SELECT_LAYER_ID = "76_multiselect_layer";
     // at a time, only one of nobs and path layer will be shown.
     // so they have equal priority
     public const string NOBS_LAYER_ID = "66_nobs_layer";

--- a/src/ViewLayers/ViewLayerMultiSelect.vala
+++ b/src/ViewLayers/ViewLayerMultiSelect.vala
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Giacomo "giacomoalbe" Alberini <giacomoalbe@gmail.com>
+ */
+
+public class Akira.ViewLayers.ViewLayerMultiSelect : ViewLayer {
+    public Gdk.RGBA color { get; default = Gdk.RGBA () { red = 0.25, green = 0.79, blue = 0.98, alpha = 0.5 }; }
+
+    private Drawables.Drawable? drawable = null;
+    private Drawables.Drawable? old_drawable = null;
+    private Geometry.Rectangle last_drawn_bb = Geometry.Rectangle.empty ();
+
+    private double initial_press_x;
+    private double initial_press_y;
+
+    public ViewLayerMultiSelect () {}
+
+    public void create_region (Gdk.EventButton event) {
+        initial_press_x = event.x;
+        initial_press_y = event.y;
+
+        drawable = new Drawables.DrawableRect (event.x, event.y, 0, 0);
+    }
+
+    public void update_region (double width, double height) {
+        var center_x = initial_press_x + width / 2;
+        var center_y = initial_press_y + height / 2;
+
+        drawable.center_x = center_x;
+        drawable.center_y = center_y;
+        drawable.width = width;
+        drawable.height = height;
+
+        old_drawable = drawable;
+
+        drawable.bounds = Geometry.Rectangle.with_coordinates (
+            initial_press_x,
+            initial_press_y,
+            initial_press_x + width,
+            initial_press_y + height
+        );
+
+        update ();
+    }
+
+    public void remove_region () {
+        update ();
+        drawable = null;
+    }
+
+    public Geometry.Rectangle? get_region_bounds () {
+        return drawable.bounds;
+    }
+
+    public override void draw_layer (Cairo.Context context, Geometry.Rectangle target_bounds, double scale) {
+        if (canvas == null || drawable == null) {
+            return;
+        }
+
+        drawable.fill_rgba = color;
+        drawable.paint (context, target_bounds, scale);
+
+        last_drawn_bb = drawable.bounds;
+    }
+
+    public override void update () {
+        if (canvas == null) {
+            return;
+        }
+
+        if (old_drawable != null) {
+            canvas.request_redraw (last_drawn_bb);
+        }
+
+        if (drawable != null) {
+            canvas.request_redraw (drawable.bounds);
+        }
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -80,6 +80,7 @@ sources = files(
     'ViewLayers/ViewLayerHover.vala',
     'ViewLayers/ViewLayerGrid.vala',
     'ViewLayers/ViewLayerPath.vala',
+    'ViewLayers/ViewLayerMultiSelect.vala',
 
     #'Models/ColorModel.vala',
     #'Models/ExportModel.vala',
@@ -144,6 +145,7 @@ sources = files(
     'Lib/Modes/ExportMode.vala',
     'Lib/Modes/PanMode.vala',
     'Lib/Modes/PathEditMode.vala',
+    'Lib/Modes/MultiSelectMode.vala',
 
     'Lib/ViewCanvas.vala',
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
<!--- Please write a description here -->
This PR handles click and drag multi selection, both inside artboard and outside (on freeitems).

It does create a new mode and a new ViewLayer. 

Inside test is performed on item's bound. This needs to be completely included inside the selection bound. 
Partial bound inclusion yields no selection. 

## Steps to Test
<!--- In case your change requires testing, this should show that your code is solid! --> 

* Create some freeitems or some items inside an artboard
* Click on an empty area on the canvas
* Drag to include the items you'd like to select

## Screenshots 
<!--- Share a screenshot with us if it was a visual change, -->
<!--- preferably with before/after shots -->

https://user-images.githubusercontent.com/11556031/147583828-0ba2b44c-157e-41ab-9d2d-1c9757f2d090.mp4

## Known Issues / Things To Do
<!--- If your PR is in progress or you know something is wrong with the code -->
<!--- write it here so we can help/discuss it -->
<!--- This is also a good place for a checklist with things left to fix in the PR -->

* I don't know if ViewLayers and Mode are coded in the right way, please enlight me :)
