### PR TITLE
Multi selection performance

### DIFF
--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -301,9 +301,11 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
             return;
         }
 
+        bool multi = false;
         foreach (var node in sm.selection.nodes.values) {
             if (layers[node.node.id] != null) {
-                select_row_at_index (model.get_index_of (layers[node.node.id]));
+                select_row_at_index (model.get_index_of (layers[node.node.id]), multi);
+                multi = true;
             }
         }
     }

--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -320,13 +320,13 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
      * Show the hover effect on a canvas item if available.
      */
     private void on_row_hovered (GLib.Object? item) {
-        view_canvas.hover_manager.remove_hover_effect ();
-
-        if (item != null) {
-            view_canvas.hover_manager.maybe_create_hover_effect_by_id (
-                ((LayerItemModel) item).id
-            );
+        unowned var hm = view_canvas.hover_manager;
+        if (item == null) {
+            hm.remove_hover_effect ();
+            return;
         }
+
+        hm.maybe_create_hover_effect_by_id (((LayerItemModel) item).id);
     }
 
     /*

--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -308,6 +308,12 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
                 multi = true;
             }
         }
+
+        if (multi) {
+            // Trigger a visual refresh of the visible layers without changing
+            // anything in the list store in order to show the newly selected layers.
+            list_store.items_changed (0, 0, 0);
+        }
     }
 
     /*

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -470,7 +470,7 @@ public class Akira.Lib.Managers.ItemsManager : Object {
         (blocker);
 
         var group = Lib.Items.ModelTypeArtboard.default_artboard (
-            new Lib.Components.Coordinates (500, 500),
+            new Lib.Components.Coordinates (520, 520),
             new Lib.Components.Size (1000, 1000, false)
         );
         //var group = Lib.Items.ModelTypeGroup.default_group ();

--- a/src/Widgets/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/Widgets/VirtualizingListBox/VirtualizingListBox.vala
@@ -645,7 +645,7 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
 
     private void on_multipress_pressed (int n_press, double x, double y) {
         active_row = null;
-        var row = get_row_at_y ((int)y);
+        var row = get_row_at_y ((int) y);
         if (row != null && row.sensitive && row.selectable) {
             active_row = row;
             row.set_state_flags (Gtk.StateFlags.ACTIVE, false);
@@ -764,8 +764,10 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
         }
     }
 
-    protected void select_row_at_index (int index) {
-        var row = ensure_index_visible (index);
+    protected void select_row_at_index (int index, bool multiple) {
+        // If multiple rows are being selected, just get the new widget row
+        // without scrolling the listbox and ensure its visibility.
+        var row = multiple ? get_widget (index) : ensure_index_visible (index);
 
         if (row != null) {
             select_and_activate (row);

--- a/src/Widgets/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/Widgets/VirtualizingListBox/VirtualizingListBox.vala
@@ -915,13 +915,20 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
     }
 
     private void on_mouse_move (double x, double y) {
+        var row = get_row_at_y ((int) y);
+
+        // No need to trigger any update if we're still hovering over the same
+        // row widget.
+        if (row != null && row == hovered_row) {
+            return;
+        }
+
         if (hovered_row != null) {
             hovered_row.unset_state_flags (Gtk.StateFlags.PRELIGHT);
             hovered_row = null;
             row_hovered (null);
         }
 
-        var row = get_row_at_y ((int) y);
         if (row != null) {
             row.set_state_flags (Gtk.StateFlags.PRELIGHT, false);
             row_hovered (row.model_item);


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
- Improve the multi selection performance by preventing scroll+selection of the entire listbox if not necessary.
- Improve the hover effect performance on layers by preventing triggering the update of the hover effect in the canvas if we're hovering over the same layer.