### PR TITLE
Add quad hittest

### DIFF
--- a/src/Geometry/Quad.vala
+++ b/src/Geometry/Quad.vala
@@ -120,6 +120,17 @@ public struct Akira.Geometry.Quad {
         bl_y = br_y - woffy;
     }
 
+    public bool contains (double x, double y) {
+        if (!bounding_box.contains (x, y)) {
+            return false;
+        }
+
+        return Utils.GeometryMath.points_on_same_side_of_line (tl_x, tl_y, tr_x, tr_y, br_x, br_y, x, y)
+            && Utils.GeometryMath.points_on_same_side_of_line (tr_x, tr_y, br_x, br_y, bl_x, bl_y, x, y)
+            && Utils.GeometryMath.points_on_same_side_of_line (br_x, br_y, bl_x, bl_y, tl_x, tl_y, x, y)
+            && Utils.GeometryMath.points_on_same_side_of_line (bl_x, bl_y, tl_x, tl_y, tr_x, tr_y, x, y);
+    }
+
     public void translate (double dx, double dy) {
         tl_x += dx;
         tr_x += dx;

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -356,7 +356,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
                     }
                 }
             } else if (
-                !selection_manager.selection.bounding_box ().contains (event.x, event.y) &&
+                !selection_manager.selection.coordinates ().contains (event.x, event.y) &&
                 !selection_manager.selection.is_empty ()
             ) {
                 // Selection area was not clicked, so we reset the selection if we have some.

--- a/src/Utils/GeometryMath.vala
+++ b/src/Utils/GeometryMath.vala
@@ -82,6 +82,25 @@ public class Akira.Utils.GeometryMath : Object {
         y = rot_center_y + dy;
     }
 
+    public static bool points_on_same_side_of_line (
+        double l1_x,
+        double l1_y,
+        double l2_x,
+        double l2_y,
+        double p1_x,
+        double p1_y,
+        double p2_x,
+        double p2_y
+    ) {
+        double delta_x = l2_x - l1_x;
+        double delta_y = l2_y - l1_y;
+
+        double one = delta_x * (p1_y - l1_y) - delta_y * (p1_x - l1_x);
+        double two = delta_x * (p2_y - l2_y) - delta_y * (p2_x - l2_x);
+
+        return (one >= 0 && two >= 0) || (one <= 0 && two <= 0);
+    }
+
     public static bool is_normal_rotation (double rot_in_degrees) {
          return GLib.Math.fmod (rot_in_degrees, 90) == 0;
     }
@@ -268,4 +287,6 @@ public class Akira.Utils.GeometryMath : Object {
 
         return area;
     }
+
+
 }


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
Rotated shapes were having their extents hit tested to deselect. Added hit testing to the quad and applied it for that particular case so that when clicking outside of a rotated shape, deselection is done properly