### PR TITLE
Block UI and selection improvements

### DIFF
--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -391,7 +391,7 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
         // move the first selected layer into the viewport of the layers list.
         if (go_to_layer) {
             it.next ();
-            var first_node =  it.get_value ().node;
+            var first_node = it.get_value ().node;
             if (layers[first_node.id] != null) {
                 select_row_at_index (model.get_index_of (layers[first_node.id]));
             }

--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -143,7 +143,7 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
 
         timer.stop ();
         seconds = timer.elapsed (out microseconds);
-        print ("Created %i items in %s s\n", added, seconds.to_string ());
+        print ("Created %i layers in %s s\n", added, seconds.to_string ());
     }
 
     /*
@@ -168,7 +168,7 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
 
         timer.stop ();
         seconds = timer.elapsed (out microseconds);
-        print ("Deleted %i items in %s s\n", removed, seconds.to_string ());
+        print ("Deleted %i layers in %s s\n", removed, seconds.to_string ());
     }
 
     private void on_item_added (int id) {

--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -105,7 +105,81 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
         view_canvas.window.event_bus.request_escape.connect (on_escape_request);
     }
 
+    /*
+     * Add all existing nodes to the layers list when the UI is revealed.
+     */
+    public void regenerate_list () {
+        ulong microseconds;
+        double seconds;
+        // Create a timer object to track the regeneration of the layers list.
+        Timer timer = new Timer ();
+
+        var added = 0;
+        unowned var im = view_canvas.items_manager;
+
+        foreach (var key in im.item_model.group_nodes.keys) {
+            var node = im.item_model.group_nodes[key];
+            if (node.id == Lib.Items.Model.ORIGIN_ID) {
+                continue;
+            }
+            var item = new LayerItemModel (view_canvas, node);
+            layers[node.id] = item;
+            list_store.add (item);
+            added++;
+        }
+
+        foreach (var key in im.item_model.item_nodes.keys) {
+            var node = im.item_model.item_nodes[key];
+            var item = new LayerItemModel (view_canvas, node);
+            layers[node.id] = item;
+            list_store.add (item);
+            added++;
+        }
+
+        list_store.items_changed (0, 0, added);
+
+        GLib.Timeout.add (1, () => {
+            // Restore the current seleciton state.
+            on_selection_modified_external ();
+            return false;
+        });
+
+
+        timer.stop ();
+        seconds = timer.elapsed (out microseconds);
+        print ("Created %i items in %s s\n", added, seconds.to_string ());
+    }
+
+    /*
+     * Clear the layers list when the UI is hidden.
+     */
+    public void clear_list () {
+        // Interrupt if the layers list is empty.
+        if (layers.size == 0) {
+            return;
+        }
+
+        ulong microseconds;
+        double seconds;
+        // Create a timer object to track the deletion of the layers list.
+        Timer timer = new Timer ();
+
+        // Remove all items.
+        var removed = layers.size;
+        layers.clear ();
+        list_store.remove_all ();
+        list_store.items_changed (0, removed, 0);
+
+        timer.stop ();
+        seconds = timer.elapsed (out microseconds);
+        print ("Deleted %i items in %s s\n", removed, seconds.to_string ());
+    }
+
     private void on_item_added (int id) {
+        if (view_canvas.block_ui) {
+            return;
+        }
+
         var node = view_canvas.items_manager.node_from_id (id);
         // No need to add any layer if we don't have an instance.
         if (node == null) {
@@ -158,6 +232,10 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
      * collapses its children.
      */
     public void add_items (GLib.Array<int> ids) {
+        if (view_canvas.block_ui) {
+            return;
+        }
+
         var added = 0;
         foreach (var uid in ids.data) {
             // Don't create a layer if it already exists. This might happen when
@@ -180,7 +258,13 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
      * newly added items that are currently visible.
      */
     public void show_added_layers (int added) {
+        if (view_canvas.block_ui) {
+            return;
+        }
+
         list_store.items_changed (0, 0, added);
+        // Restore selected items.
+        // on_selection_modified_external ();
     }
 
     /*
@@ -188,6 +272,10 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
      * selected nodes in the view canvas.
      */
     public void remove_items (GLib.Array<int> ids) {
+        if (view_canvas.block_ui) {
+            return;
+        }
+
         var removed = 0;
         foreach (var uid in ids.data) {
             var item = layers[uid];
@@ -309,7 +397,7 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
             }
         }
 
-        if (multi) {
+        if (sm.selection.count () > 1) {
             // Trigger a visual refresh of the visible layers without changing
             // anything in the list store in order to show the newly selected layers.
             list_store.items_changed (0, 0, 0);

--- a/src/Layouts/Sidebars/LayersSidebar.vala
+++ b/src/Layouts/Sidebars/LayersSidebar.vala
@@ -36,6 +36,12 @@ public class Akira.Layouts.Sidebars.LayersSidebar : Gtk.Grid {
         set {
             visible = value;
             no_show_all = !value;
+
+            if (value) {
+                layers_listbox.regenerate_list ();
+            } else {
+                layers_listbox.clear_list ();
+            }
         }
     }
 

--- a/src/Lib/Managers/CopyManager.vala
+++ b/src/Lib/Managers/CopyManager.vala
@@ -89,7 +89,7 @@ public class Akira.Lib.Managers.CopyManager : Object {
 
         // Defer the print of the layer UI after all items have been created.
         view_canvas.window.main_window.show_added_layers ((int) children.length);
-        view_canvas.selection_manager.selection_modified_external ();
+        view_canvas.selection_manager.selection_modified_external (true);
     }
 
     private void on_subtree_cloned (int id) {

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -515,6 +515,9 @@ public class Akira.Lib.Managers.ItemsManager : Object {
     }
 
     public void debug_add_rectangles (uint num_of, bool debug_timer = false) {
+        // Always reset the selection before adding a chunk of items.
+        view_canvas.selection_manager.reset_selection ();
+
         ulong microseconds;
         double seconds;
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -502,14 +502,14 @@ public class Akira.Lib.Managers.ItemsManager : Object {
 
         compile_model ();
 
+        // Defer the print of the layer UI after all items have been created.
+        view_canvas.window.main_window.show_added_layers (num_of++);
+
         if (debug_timer) {
             timer.stop ();
             seconds = timer.elapsed (out microseconds);
             print ("Created %u items in %s s\n", num_of, seconds.to_string ());
         }
-
-        // Defer the print of the layer UI after all items have been created.
-        view_canvas.window.main_window.show_added_layers (num_of++);
 
         return group;
     }
@@ -532,17 +532,17 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             view_canvas.selection_manager.add_to_selection (new_item.id);
         }
 
-        if (debug_timer) {
-            timer.stop ();
-            seconds = timer.elapsed (out microseconds);
-            print ("Created %u items in %s s\n", num_of, seconds.to_string ());
-        }
-
         view_canvas.pause_redraw = false;
         view_canvas.request_redraw (view_canvas.get_bounds ());
 
         // Defer the print of the layer UI after all items have been created.
         view_canvas.window.main_window.show_added_layers ((int) num_of);
+
+        if (debug_timer) {
+            timer.stop ();
+            seconds = timer.elapsed (out microseconds);
+            print ("Created %u items in %s s\n", num_of, seconds.to_string ());
+        }
     }
 
     public void on_item_geometry_changed (int id) {

--- a/src/Lib/Managers/SelectionManager.vala
+++ b/src/Lib/Managers/SelectionManager.vala
@@ -29,7 +29,7 @@ public class Akira.Lib.Managers.SelectionManager : Object {
     // Signal triggered only when an item is added or removed from the selection
     // map exclusively via click event from the ViewCanvas. This is necessary in
     // order to only update the Layers panel without triggering a selection loop.
-    public signal void selection_modified_external ();
+    public signal void selection_modified_external (bool go_to_layer = false);
 
     public unowned ViewCanvas view_canvas { get; construct; }
 

--- a/src/Lib/Modes/ItemInsertMode.vala
+++ b/src/Lib/Modes/ItemInsertMode.vala
@@ -121,7 +121,7 @@ public class Akira.Lib.Modes.ItemInsertMode : AbstractInteractionMode {
 
             // Defer the print of the layer UI after all items have been created.
             view_canvas.window.main_window.show_added_layers (1);
-            view_canvas.selection_manager.selection_modified_external ();
+            view_canvas.selection_manager.selection_modified_external (true);
             return true;
         }
 

--- a/src/Lib/Modes/MultiSelectMode.vala
+++ b/src/Lib/Modes/MultiSelectMode.vala
@@ -117,6 +117,6 @@ public class Akira.Lib.Modes.MultiSelectMode : AbstractInteractionMode {
             view_canvas.selection_manager.add_to_selection (item.instance.id);
         }
 
-        view_canvas.selection_manager.selection_modified_external ();
+        view_canvas.selection_manager.selection_modified_external (true);
     }
 }

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -98,6 +98,8 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
 
         set_model_to_render (items_manager.item_model);
 
+        window.event_bus.toggle_presentation_mode.connect (on_toggle_presentation_mode);
+
         window.event_bus.adjust_zoom.connect (trigger_adjust_zoom);
 
         window.event_bus.set_focus_on_canvas.connect (focus_canvas);
@@ -106,6 +108,11 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
 
         mode_manager.mode_changed.connect (interaction_mode_changed);
         items_manager.items_removed.connect (on_items_removed);
+    }
+
+    public bool block_ui = false;
+    private void on_toggle_presentation_mode () {
+        block_ui = !block_ui;
     }
 
     public signal void canvas_moved (double delta_x, double delta_y);

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -355,7 +355,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
                     }
 
                     selection_manager.add_to_selection (target.id);
-                    selection_manager.selection_modified_external ();
+                    selection_manager.selection_modified_external (true);
                 } else {
                     if (selection_manager.selection.count () > 1) {
                         // Don't trigger sub selection when only one item's selected
@@ -368,7 +368,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
             ) {
                 // Selection area was not clicked, so we reset the selection if we have some.
                 selection_manager.reset_selection ();
-                selection_manager.selection_modified_external ();
+                selection_manager.selection_modified_external (true);
             }
         }
 
@@ -432,14 +432,14 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
             ) {
                 selection_manager.reset_selection ();
                 selection_manager.add_to_selection (target.id);
-                selection_manager.selection_modified_external ();
+                selection_manager.selection_modified_external (true);
             }
 
             // If the click happened on an empty area and we have multiple
             // selected items, deselect them all.
             if (target == null && count > 1) {
                 selection_manager.reset_selection ();
-                selection_manager.selection_modified_external ();
+                selection_manager.selection_modified_external (true);
             }
         }
 

--- a/src/ViewLayers/ViewLayer.vala
+++ b/src/ViewLayers/ViewLayer.vala
@@ -59,7 +59,6 @@ public class Akira.ViewLayers.ViewLayer : Object {
     public bool is_visible { get { return p_is_visible; } }
     public bool is_masked { get { return p_mask_counter > 0; } }
 
-
     public void add_to_canvas (string layer_id, BaseCanvas canvas) {
         p_canvas = canvas;
         p_canvas.add_viewlayer_overlay (layer_id, this);

--- a/src/Widgets/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/Widgets/VirtualizingListBox/VirtualizingListBox.vala
@@ -764,10 +764,10 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
         }
     }
 
-    protected void select_row_at_index (int index, bool multiple) {
+    protected void select_row_at_index (int index) {
         // If multiple rows are being selected, just get the new widget row
         // without scrolling the listbox and ensure its visibility.
-        var row = multiple ? get_widget (index) : ensure_index_visible (index);
+        var row = ensure_index_visible (index);
 
         if (row != null) {
             select_and_activate (row);

--- a/src/Widgets/VirtualizingListBox/VirtualizingListBox.vala
+++ b/src/Widgets/VirtualizingListBox/VirtualizingListBox.vala
@@ -265,7 +265,7 @@ public class VirtualizingListBox : Gtk.Container, Gtk.Scrollable {
         remove_all_widgets ();
         shown_to = shown_from;
         update_bin_window ();
-        ensure_visible_widgets (true);
+        ensure_visible_widgets (removed > 0 || added > 0);
 
         if (vadjustment == null) {
             queue_resize ();


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Some much needed improvements to the layers panel.

## Steps to Test
- Create items with and without the UI by toggling the presentation mode with <kbd>CTRL</kbd>+<kbd>.</kbd>
- Toggle the UI before and after creating various item.
- Confirm the layers are restored correctly.

## This PR fixes/implements the following **bugs/features**:
- Block the creation of layers when the app is in Presentation Mode.
- Fix selection performance issues by setting the selected state to the layers model without requiring the generation/reveal of row widgets.
