### PR TITLE
Use estimated bounding boxes for drawables

### DIFF
--- a/src/Geometry/Quad.vala
+++ b/src/Geometry/Quad.vala
@@ -122,8 +122,8 @@ public struct Akira.Geometry.Quad {
         bl_x = br_x - woffx;
         bl_y = br_y - woffy;
 
-        transform.x0 = center_x - hw; 
-        transform.y0 = center_y - hh; 
+        transform.x0 = center_x - hw;
+        transform.y0 = center_y - hh;
     }
 
     public bool contains (double x, double y) {

--- a/src/Geometry/Quad.vala
+++ b/src/Geometry/Quad.vala
@@ -97,10 +97,13 @@ public struct Akira.Geometry.Quad {
     ) {
         transformation = transform;
 
-        tl_x = - width / 2.0;
-        tl_y = - height / 2.0;
-        br_x = width / 2.0;
-        br_y = height / 2.0;
+        var hw = width / 2.0;
+        var hh = height / 2.0;
+
+        tl_x = - hw;
+        tl_y = - hh;
+        br_x = hw;
+        br_y = hh;
 
         var woffx = width;
         var woffy = 0.0;
@@ -118,6 +121,9 @@ public struct Akira.Geometry.Quad {
         br_y = center_y + br_y;
         bl_x = br_x - woffx;
         bl_y = br_y - woffy;
+
+        transform.x0 = center_x - hw; 
+        transform.y0 = center_y - hh; 
     }
 
     public bool contains (double x, double y) {

--- a/src/Lib/Components/CompiledGeometry.vala
+++ b/src/Lib/Components/CompiledGeometry.vala
@@ -120,6 +120,8 @@ public class Akira.Lib.Components.CompiledGeometry : Copyable<CompiledGeometry> 
         double width = 0;
         double height = 0;
 
+        int border_overestimate = 1;
+
         if (size_from_path) {
             if (components.path == null) {
                 _data.area = Geometry.Quad ();
@@ -131,6 +133,7 @@ public class Akira.Lib.Components.CompiledGeometry : Copyable<CompiledGeometry> 
             width = ext.width;
             height = ext.height;
             _data.source_size = new Lib.Components.Size (ext.width, ext.height, false);
+            border_overestimate = 4;
         } else {
             if (components.size == null) {
                 _data.area = Geometry.Quad ();
@@ -148,7 +151,8 @@ public class Akira.Lib.Components.CompiledGeometry : Copyable<CompiledGeometry> 
         _data.area = Geometry.Quad.from_components (center_x, center_y, width, height, _data._transformation_matrix);
 
         if (border_width > 0) {
-            _data.drawable_area = Geometry.Quad.from_components (center_x, center_y, width + border_width * 2, height + border_width * 2, _data._transformation_matrix);
+            var bw = border_width * 2 * border_overestimate;
+            _data.drawable_area = Geometry.Quad.from_components (center_x, center_y, width + bw, height + bw, _data._transformation_matrix);
         }
         else {
             _data.drawable_area = _data.area;

--- a/src/Lib/Items/ModelInstance.vala
+++ b/src/Lib/Items/ModelInstance.vala
@@ -100,9 +100,9 @@ public class Akira.Lib.Items.ModelInstance {
      */
     public bool compile_components (ModelNode node, ViewLayers.BaseCanvas? canvas) {
         bool something_changed = false;
-        something_changed = compiled_components.maybe_compile_geometry (type, components, node) || something_changed;
         something_changed = compiled_components.maybe_compile_fill (type, components, node) || something_changed;
         something_changed = compiled_components.maybe_compile_border (type, components, node) || something_changed;
+        something_changed = compiled_components.maybe_compile_geometry (type, components, node) || something_changed;
         something_changed = node.instance.type is ModelTypeArtboard
             && compiled_components.maybe_compile_name (type, components, node)
             || something_changed;
@@ -152,11 +152,13 @@ public class Akira.Lib.Items.ModelInstance {
         if (drawable != null) {
             if (canvas != null) {
                 drawable.request_redraw (canvas, false);
-                drawable.request_redraw (canvas, true);
+                drawable.bounds = compiled_geometry.drawable_bb;
+                drawable.request_redraw (canvas, false);
+                drawable_bounding_box = drawable.bounds;
+                return;
             }
-            drawable_bounding_box = drawable.bounds;
-        } else {
-            drawable_bounding_box = bounding_box;
         }
+
+        drawable_bounding_box = bounding_box;
     }
 }


### PR DESCRIPTION

<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
This uses estimated bounding boxes instead of
cairo-calculated bounding boxes for drawables.

This gives SIGNFICANT performance when constructing items
with slight performance hit when drawing. However, the
latter should be insignificant


## Steps to Test
Add 10k items, it should be much faster to create them now.
