### PR TITLE
Sub selection to anchor point update

### DIFF
--- a/src/Drawables/Drawable.vala
+++ b/src/Drawables/Drawable.vala
@@ -36,9 +36,6 @@ public class Akira.Drawables.Drawable {
         OUTSIDE
     }
 
-    // Constant styling.
-    private const int TARGET_SCALE = 10;
-
     // Style
     public double line_width { get; set; default = 0; }
     public Gdk.RGBA fill_rgba { get; set; default = Gdk.RGBA (); }
@@ -248,11 +245,9 @@ public class Akira.Drawables.Drawable {
         Cairo.Matrix tr = transform;
         context.transform (tr);
 
-        var t_scale = TARGET_SCALE / scale;
         // context.save ();
         context.new_path ();
-        context.scale (t_scale, t_scale);
-        context.arc (0.0, 0.0, 1.0, 0.0, 2.0 * GLib.Math.PI);
+        context.arc (0.0, 0.0, 5 / scale, 0.0, 2.0 * GLib.Math.PI);
         // context.restore ();
 
         context.set_line_width (line_width / scale);

--- a/src/Drawables/Drawable.vala
+++ b/src/Drawables/Drawable.vala
@@ -36,6 +36,9 @@ public class Akira.Drawables.Drawable {
         OUTSIDE
     }
 
+    // Constant styling.
+    private const int TARGET_SCALE = 10;
+
     // Style
     public double line_width { get; set; default = 0; }
     public Gdk.RGBA fill_rgba { get; set; default = Gdk.RGBA (); }
@@ -216,6 +219,41 @@ public class Akira.Drawables.Drawable {
         context.transform (tr);
 
         simple_create_path (context);
+
+        context.set_line_width (line_width / scale);
+        context.set_source_rgba (color.red, color.green, color.blue, color.alpha);
+        context.set_matrix (global_transform);
+        context.stroke ();
+
+        context.restore ();
+
+        // Very important to initialize new path
+        context.new_path ();
+    }
+
+    /*
+     * Create a target like element on top of the drawable to represent the
+     * current subselection anchor point that will be used as alignment pivot.
+     */
+    public virtual void paint_anchor (
+        Cairo.Context context,
+        Gdk.RGBA color,
+        double line_width,
+        double scale
+    ) {
+        context.save ();
+        Cairo.Matrix global_transform = context.get_matrix ();
+
+        // We apply the item transform before creating the path
+        Cairo.Matrix tr = transform;
+        context.transform (tr);
+
+        var t_scale = TARGET_SCALE / scale;
+        // context.save ();
+        context.new_path ();
+        context.scale (t_scale, t_scale);
+        context.arc (0.0, 0.0, 1.0, 0.0, 2.0 * GLib.Math.PI);
+        // context.restore ();
 
         context.set_line_width (line_width / scale);
         context.set_source_rgba (color.red, color.green, color.blue, color.alpha);

--- a/src/Drawables/Drawable.vala
+++ b/src/Drawables/Drawable.vala
@@ -245,16 +245,32 @@ public class Akira.Drawables.Drawable {
         Cairo.Matrix tr = transform;
         context.transform (tr);
 
-        // context.save ();
-        context.new_path ();
-        context.arc (0.0, 0.0, 5 / scale, 0.0, 2.0 * GLib.Math.PI);
-        // context.restore ();
-
+        // Set the visual properties.
         context.set_line_width (line_width / scale);
         context.set_source_rgba (color.red, color.green, color.blue, color.alpha);
-        context.set_matrix (global_transform);
+
+        // Create the circle.
+        context.new_path ();
+        context.arc (0.0, 0.0, 5 / scale, 0.0, 2.0 * GLib.Math.PI);
+        // Draw the circle and preserve the visual properties.
+        context.stroke_preserve ();
+
+        var lenght = 10 / scale;
+        // Create the horizontal stroke.
+        context.new_path ();
+        context.move_to (-lenght, 0);
+        context.line_to (lenght, 0);
+        context.stroke_preserve ();
+
+        // Create the vertical stroke.
+        context.new_path ();
+        context.move_to (0, -lenght);
+        context.line_to (0, lenght);
         context.stroke ();
 
+        // Apply the matrix transform of the drawable item so the new path is
+        // properly positioned.
+        context.set_matrix (global_transform);
         context.restore ();
 
         // Very important to initialize new path

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -561,13 +561,13 @@ public class Akira.Lib.Managers.ItemsManager : Object {
             return;
         }
 
-        unowned int? sub_selection_node_id = view_canvas.nob_manager.sub_selection_node_id;
+        unowned int? anchor_point_node_id = view_canvas.nob_manager.anchor_point_node_id;
 
         var type = Utils.ItemAlignment.AlignmentType.AUTO;
         Lib.Items.ModelNode? anchor = null;
 
-        if (sub_selection_node_id != null) {
-            anchor = node_from_id (sub_selection_node_id);
+        if (anchor_point_node_id != null) {
+            anchor = node_from_id (anchor_point_node_id);
             type = Utils.ItemAlignment.AlignmentType.ANCHOR;
         }
 

--- a/src/Lib/Managers/NobManager.vala
+++ b/src/Lib/Managers/NobManager.vala
@@ -31,7 +31,7 @@ public class Akira.Lib.Managers.NobManager : Object {
 
     private Utils.Nobs.NobSet nobs;
     private ViewLayers.ViewLayerNobs nob_layer = null;
-    public int? sub_selection_node_id;
+    public int? anchor_point_node_id;
 
     // Tracks if an artboard is part of the current selection.
     private int last_id = -1;
@@ -58,8 +58,8 @@ public class Akira.Lib.Managers.NobManager : Object {
         unowned var sm = view_canvas.selection_manager;
         if (sm.is_empty ()) {
             remove_select_effect ();
-            remove_sub_selection_effect ();
-            sub_selection_node_id = null;
+            remove_anchor_point_effect ();
+            anchor_point_node_id = null;
             return;
         }
 
@@ -142,31 +142,31 @@ public class Akira.Lib.Managers.NobManager : Object {
         nob_layer.update_nob_data (nobs);
     }
 
-    public void toggle_sub_selection (int id) {
-        remove_sub_selection_effect ();
+    public void toggle_anchor_point (int id) {
+        remove_anchor_point_effect ();
 
-        if (sub_selection_node_id == id) {
-            sub_selection_node_id = null;
+        if (anchor_point_node_id == id) {
+            anchor_point_node_id = null;
             return;
         }
 
-        sub_selection_node_id = id;
+        anchor_point_node_id = id;
 
-        maybe_create_sub_selection_effect ();
+        maybe_create_anchor_point_effect ();
     }
 
-    private void remove_sub_selection_effect () {
-        nob_layer.add_sub_selection (null);
+    private void remove_anchor_point_effect () {
+        nob_layer.add_anchor_point (null);
     }
 
-    private void maybe_create_sub_selection_effect () {
-        var node = view_canvas.items_manager.node_from_id (sub_selection_node_id);
+    private void maybe_create_anchor_point_effect () {
+        var node = view_canvas.items_manager.node_from_id (anchor_point_node_id);
         if (node == null) {
             assert (node != null);
             return;
         }
 
-        nob_layer.add_sub_selection (node.instance.drawable);
+        nob_layer.add_anchor_point (node.instance.drawable);
     }
 
 }

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -414,7 +414,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
             ) {
                 if (ctrl_is_pressed) {
                     // If CTRL is pressed, toggle alignment anchor.
-                    nob_manager.toggle_sub_selection (target.id);
+                    nob_manager.toggle_anchor_point (target.id);
                 } else {
                     // Deselect them all and select the clicked item.
                     selection_manager.reset_selection ();

--- a/src/ViewLayers/ViewLayerNobs.vala
+++ b/src/ViewLayers/ViewLayerNobs.vala
@@ -29,9 +29,9 @@ public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
     private Utils.Nobs.NobSet? nobs = null;
     private Utils.Nobs.NobSet? old_nobs = null;
 
-    private Drawables.Drawable? sub_selection_drawable = null;
-    private Drawables.Drawable? old_sub_selection_drawable = null;
-    private Geometry.Rectangle sub_selection_last_bb_drawn = Geometry.Rectangle.empty ();
+    private Drawables.Drawable? anchor_point_drawable = null;
+    private Drawables.Drawable? old_anchor_point_drawable = null;
+    private Geometry.Rectangle anchor_point_last_bb_drawn = Geometry.Rectangle.empty ();
 
     public void update_nob_data (Utils.Nobs.NobSet? new_nobs) {
         if (nobs != null) {
@@ -42,8 +42,8 @@ public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
         update ();
     }
 
-    public void add_sub_selection (Drawables.Drawable? new_sub_selection_drawable) {
-        if (new_sub_selection_drawable == sub_selection_drawable) {
+    public void add_anchor_point (Drawables.Drawable? new_anchor_point_drawable) {
+        if (new_anchor_point_drawable == anchor_point_drawable) {
             return;
         }
 
@@ -52,14 +52,14 @@ public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
             color.parse (settings.snaps_color);
         }
 
-        old_sub_selection_drawable = sub_selection_drawable;
-        sub_selection_drawable = new_sub_selection_drawable;
+        old_anchor_point_drawable = anchor_point_drawable;
+        anchor_point_drawable = new_anchor_point_drawable;
 
         update ();
 
         // Nullify the color if the sub selection is removed so we can always
         // get the updated settings color if the user changes it.
-        if (new_sub_selection_drawable == null) {
+        if (new_anchor_point_drawable == null) {
             color = null;
         }
     }
@@ -86,9 +86,9 @@ public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
         draw_rect (context, nobs, canvas.scale);
         draw_nobs (context, nobs, canvas.scale);
 
-        if (sub_selection_drawable != null) {
-            sub_selection_drawable.paint_anchor (context, color, UI_ANCHOR_LINE_WIDTH, scale);
-            sub_selection_last_bb_drawn = sub_selection_drawable.bounds;
+        if (anchor_point_drawable != null) {
+            anchor_point_drawable.paint_anchor (context, color, UI_ANCHOR_LINE_WIDTH, scale);
+            anchor_point_last_bb_drawn = anchor_point_drawable.bounds;
         }
 
         context.new_path ();
@@ -168,23 +168,23 @@ public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
         }
         update_nobs (old_nobs);
         update_nobs (nobs);
-        update_sub_selection ();
+        update_anchor_point ();
 
         old_nobs = null;
     }
 
-    private void update_sub_selection () {
+    private void update_anchor_point () {
         if (canvas == null) {
             return;
         }
 
-        if (old_sub_selection_drawable != null) {
-            canvas.request_redraw (sub_selection_last_bb_drawn);
-            old_sub_selection_drawable = null;
+        if (old_anchor_point_drawable != null) {
+            canvas.request_redraw (anchor_point_last_bb_drawn);
+            old_anchor_point_drawable = null;
         }
 
-        if (sub_selection_drawable != null) {
-            canvas.request_redraw (sub_selection_drawable.bounds);
+        if (anchor_point_drawable != null) {
+            canvas.request_redraw (anchor_point_drawable.bounds);
         }
     }
 

--- a/src/ViewLayers/ViewLayerNobs.vala
+++ b/src/ViewLayers/ViewLayerNobs.vala
@@ -23,7 +23,7 @@
 public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
     public const double UI_NOB_SIZE = 5;
     public const double UI_LINE_WIDTH = 1.01;
-    public const double UI_SUB_SELECTION_LINE_WIDTH = 4.0;
+    public const double UI_ANCHOR_LINE_WIDTH = 2.0;
 
     private Utils.Nobs.NobSet? nobs = null;
     private Utils.Nobs.NobSet? old_nobs = null;
@@ -77,7 +77,7 @@ public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
 
         if (sub_selection_drawable != null) {
             var color = Gdk.RGBA () { red = 0.25, green = 0.79, blue = 0.98, alpha = 1.0 };
-            sub_selection_drawable.paint_hover (context, color, UI_SUB_SELECTION_LINE_WIDTH, target_bounds, scale);
+            sub_selection_drawable.paint_anchor (context, color, UI_ANCHOR_LINE_WIDTH, scale);
             sub_selection_last_bb_drawn = sub_selection_drawable.bounds;
         }
 

--- a/src/ViewLayers/ViewLayerNobs.vala
+++ b/src/ViewLayers/ViewLayerNobs.vala
@@ -23,15 +23,15 @@
 public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
     public const double UI_NOB_SIZE = 5;
     public const double UI_LINE_WIDTH = 1.01;
-    public const double UI_ANCHOR_LINE_WIDTH = 2.0;
+    public const double UI_ANCHOR_LINE_WIDTH = 1.01;
 
+    private Gdk.RGBA? color = null;
     private Utils.Nobs.NobSet? nobs = null;
     private Utils.Nobs.NobSet? old_nobs = null;
 
     private Drawables.Drawable? sub_selection_drawable = null;
     private Drawables.Drawable? old_sub_selection_drawable = null;
     private Geometry.Rectangle sub_selection_last_bb_drawn = Geometry.Rectangle.empty ();
-    // private bool redraw_only_sub_selection = false;
 
     public void update_nob_data (Utils.Nobs.NobSet? new_nobs) {
         if (nobs != null) {
@@ -47,10 +47,21 @@ public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
             return;
         }
 
+        if (color == null) {
+            color = Gdk.RGBA ();
+            color.parse (settings.snaps_color);
+        }
+
         old_sub_selection_drawable = sub_selection_drawable;
         sub_selection_drawable = new_sub_selection_drawable;
 
         update ();
+
+        // Nullify the color if the sub selection is removed so we can always
+        // get the updated settings color if the user changes it.
+        if (new_sub_selection_drawable == null) {
+            color = null;
+        }
     }
 
     public override void draw_layer (Cairo.Context context, Geometry.Rectangle target_bounds, double scale) {
@@ -76,7 +87,6 @@ public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
         draw_nobs (context, nobs, canvas.scale);
 
         if (sub_selection_drawable != null) {
-            var color = Gdk.RGBA () { red = 0.25, green = 0.79, blue = 0.98, alpha = 1.0 };
             sub_selection_drawable.paint_anchor (context, color, UI_ANCHOR_LINE_WIDTH, scale);
             sub_selection_last_bb_drawn = sub_selection_drawable.bounds;
         }
@@ -97,10 +107,6 @@ public class Akira.ViewLayers.ViewLayerNobs : ViewLayer {
             context.new_path ();
             context.set_source_rgba (1, 1, 1, 1);
             context.set_line_width (line_width);
-
-            //apply nob transform here
-
-            // Then translate it
             context.translate (nob.center_x, nob.center_y);
 
             if (nob.handle_id == Utils.Nobs.Nob.ROTATE) {


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Update the "subselection" effect to draw a target above the item.

## Screenshots 
![image](https://user-images.githubusercontent.com/2527103/149682136-7025e0c5-44b5-48e8-8ef1-d41e1c346464.png)

## This PR fixes/implements the following **bugs/features**:
- Rename all instances of `sub_selection` to `anchor_point`.
- Draw a target-like path to represent the active anchor point.
- Use the snaps color to draw the anchor point.
