### PR TITLE
Move signaling to items manager

### DIFF
--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -99,7 +99,7 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
             return create_context_menu (e, (LayerListItem)row);
         });
 
-        view_canvas.items_manager.item_model.item_added.connect (on_item_added);
+        view_canvas.items_manager.item_added.connect (on_item_added);
         view_canvas.selection_manager.selection_modified_external.connect (on_selection_modified_external);
         view_canvas.hover_manager.hover_changed.connect (on_hover_changed);
         view_canvas.window.event_bus.request_escape.connect (on_escape_request);

--- a/src/Lib/Managers/HistoryManager.vala
+++ b/src/Lib/Managers/HistoryManager.vala
@@ -85,10 +85,7 @@ public class Akira.Lib.Managers.HistoryManager : Object {
         other.add (new Snapshot (last_stack.description, new Lib.Items.Model.clone (im.item_model)));
 
         // replace model
-        im.item_model = last_stack.model;
-        im.item_model.wake (true);
-        view_canvas.set_model_to_render (im.item_model);
-        im.compile_model ();
+        im.replace_model (last_stack.model);
 
         // Regenerate the layers list.
         view_canvas.window.main_window.regenerate_list ();


### PR DESCRIPTION
Model now alerts the itemsmanager directly, which is in charge
of sending signals and keeping connections accross model
replacements.