### PR TITLE
Regenerate layers list when restacking items

### DIFF
--- a/src/Layouts/HeaderBar.vala
+++ b/src/Layouts/HeaderBar.vala
@@ -401,7 +401,6 @@ public class Akira.Layouts.HeaderBar : Gtk.HeaderBar {
         window.event_bus.file_edited.connect (on_file_edited);
         window.event_bus.file_saved.connect (on_file_saved);
         window.event_bus.selection_modified.connect (on_selection_modified);
-        // window.event_bus.z_selected_changed.connect (update_button_sensitivity);
         window.event_bus.update_recent_files_list.connect (fetch_recent_files);
     }
 

--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -108,7 +108,7 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
     /*
      * Add all existing nodes to the layers list when the UI is revealed.
      */
-    public void regenerate_list () {
+    public void regenerate_list (bool go_to_layer) {
         unowned var im = view_canvas.items_manager;
 
         // Bail out if we don't have anything to add.
@@ -144,7 +144,7 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
         list_store.items_changed (0, 0, added);
 
         // Restore the selected items.
-        on_selection_modified_external ();
+        on_selection_modified_external (go_to_layer);
 
         timer.stop ();
         seconds = timer.elapsed (out microseconds);

--- a/src/Layouts/MainWindow.vala
+++ b/src/Layouts/MainWindow.vala
@@ -88,8 +88,8 @@ public class Akira.Layouts.MainWindow : Gtk.Grid {
     /*
      * Regenerate the entire layers list. This is used during history navigation.
      */
-    public void regenerate_list () {
+    public void regenerate_list (bool go_to_layer = false) {
         layers_sidebar.layers_listbox.clear_list ();
-        layers_sidebar.layers_listbox.regenerate_list ();
+        layers_sidebar.layers_listbox.regenerate_list (go_to_layer);
     }
 }

--- a/src/Layouts/Sidebars/LayersSidebar.vala
+++ b/src/Layouts/Sidebars/LayersSidebar.vala
@@ -38,7 +38,7 @@ public class Akira.Layouts.Sidebars.LayersSidebar : Gtk.Grid {
             no_show_all = !value;
 
             if (value) {
-                layers_listbox.regenerate_list ();
+                layers_listbox.regenerate_list (true);
             } else {
                 layers_listbox.clear_list ();
             }

--- a/src/Lib/Managers/CopyManager.vala
+++ b/src/Lib/Managers/CopyManager.vala
@@ -89,9 +89,8 @@ public class Akira.Lib.Managers.CopyManager : Object {
         view_canvas.items_manager.compile_model ();
         assert (res == 0);
 
-        // Defer the print of the layer UI after all items have been created.
-        view_canvas.window.main_window.show_added_layers ((int) children.length);
-        view_canvas.selection_manager.selection_modified_external (true);
+        // Regenerate the layers list.
+        view_canvas.window.main_window.regenerate_list (true);
     }
 
     private void on_subtree_cloned (int id) {

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -527,8 +527,8 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
         view_canvas.pause_redraw = false;
         view_canvas.request_redraw (view_canvas.get_bounds ());
 
-        // Defer the print of the layer UI after all items have been created.
-        view_canvas.window.main_window.show_added_layers (num_of++);
+        // Regenerate the layers list.
+        view_canvas.window.main_window.regenerate_list ();
 
         if (debug_timer) {
             timer.stop ();
@@ -563,8 +563,8 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
         view_canvas.pause_redraw = false;
         view_canvas.request_redraw (view_canvas.get_bounds ());
 
-        // Defer the print of the layer UI after all items have been created.
-        view_canvas.window.main_window.show_added_layers ((int) num_of);
+        // Regenerate the layers list.
+        view_canvas.window.main_window.regenerate_list ();
 
         if (debug_timer) {
             timer.stop ();

--- a/src/Lib/Managers/SelectionManager.vala
+++ b/src/Lib/Managers/SelectionManager.vala
@@ -148,6 +148,8 @@ public class Akira.Lib.Managers.SelectionManager : Object {
         if (to_shift.length > 0 && amount != 0) {
             view_canvas.window.event_bus.create_model_snapshot ("shift items' z-order");
             view_canvas.items_manager.shift_items (to_shift, amount, to_end);
+            // Regenerate the layers list.
+            view_canvas.window.main_window.regenerate_list (true);
         }
     }
 

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -62,7 +62,6 @@ public class Akira.Services.EventBus : Object {
     // Item signals.
     public signal void change_z_selected (bool raise, bool total);
     public signal void flip_item (bool vertical = false);
-    public signal void z_selected_changed ();
     public signal void detect_artboard_change ();
     public signal void detect_image_size_change ();
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Regenerate the Layers list when a restacking (z order change) happens.
- It also takes care of restoring the correct selection if needed.
- Added regeneration also for bulk operations and copy actions.
- Re-enabled headerbar buttons based on item selection.