### PR TITLE
Implement 705: Undo should not get stacks in no-ops

### DIFF
--- a/src/Lib/Items/Model.vala
+++ b/src/Lib/Items/Model.vala
@@ -257,7 +257,25 @@ public class Akira.Lib.Items.Model : Object {
         return inner_splice_new_item (parent_node, pos, candidate);
     }
 
-    public int move_items (int parent_id, uint pos, uint newpos, int length, bool restack) {
+    /*
+     * Move items within a parent to change their z-order.
+     * 
+     * Set restack to false if several move operations will be executed, which could make
+     * later restacking more efficient. Make sure to call recalculate_children_stacking
+     * after all operations.
+     * 
+     * prep_for_op is an optional lambda that will get called only if the move ends up
+     * in an actual change to the model. it serves as a way to have side-effects that
+     * don't trigger on no-ops. For example, only add to the undo stack if a change happens.
+     */
+    public int move_items (
+        int parent_id,
+        uint pos,
+        uint newpos,
+        int length,
+        bool restack,
+        Utils.TrivialDelegate? prep_for_op = null
+    ) {
         if (pos == newpos || length <= 0) {
             return 0;
         }
@@ -273,6 +291,10 @@ public class Akira.Lib.Items.Model : Object {
 
         if (newpos + length > parent_node.children.length) {
             return 0;
+        }
+
+        if (prep_for_op != null) {
+            prep_for_op ();
         }
 
         // convert to rotation parameters

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -224,6 +224,13 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
             current_set.length++;
         }
 
+        bool no_operation_yet = true;
+        Utils.TrivialDelegate prep = () => {
+            view_canvas.window.event_bus.create_model_snapshot ("shift items' z-order");
+            // run only once
+            no_operation_yet = false;
+        };
+
         foreach (var cs in shift_groups) {
             var pos = cs.first_child;
 
@@ -247,23 +254,12 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
                 continue;
             }
 
-            if (0 >= item_model.move_items (cs.parent_node.id, pos, newpos, cs.length, true)) {
+            if (0 >= item_model.move_items (cs.parent_node.id, pos, newpos, cs.length, true, prep)) {
                 // no items were shifted
                 cs = null;
                 continue;
             }
         }
-
-
-        //print ("ref: %d\n", reference.id);
-        //foreach (var cs in shift_groups) {
-        //    if (cs != null) {
-        //        view_restack (cs, amount > 0, reference);
-        //    }
-        //}
-
-        print ("shift item zorder-----\n");
-        item_model.print_dag ();
 
         compile_model ();
 
@@ -589,7 +585,11 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
             type = Utils.ItemAlignment.AlignmentType.ANCHOR;
         }
 
-        Utils.ItemAlignment.align_selection (selection, direction, type, anchor, view_canvas);
+        Utils.TrivialDelegate prep = () => {
+            view_canvas.window.event_bus.create_model_snapshot ("autoalign items");
+        };
+
+        Utils.ItemAlignment.align_selection (selection, direction, type, anchor, view_canvas, prep);
     }
 
 }

--- a/src/Lib/Managers/SelectionManager.vala
+++ b/src/Lib/Managers/SelectionManager.vala
@@ -146,7 +146,6 @@ public class Akira.Lib.Managers.SelectionManager : Object {
 
         int amount = up ? 1 : -1;
         if (to_shift.length > 0 && amount != 0) {
-            view_canvas.window.event_bus.create_model_snapshot ("shift items' z-order");
             view_canvas.items_manager.shift_items (to_shift, amount, to_end);
         }
     }

--- a/src/Utils/Delegates.vala
+++ b/src/Utils/Delegates.vala
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Alecaddd (http://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Martin "mbfraga" Fraga <mbfraga@gmail.com>
+ */
+
+/*
+ * A colleciton of useful delegate definitions
+ */
+
+public delegate void Akira.Utils.TrivialDelegate ();

--- a/src/meson.build
+++ b/src/meson.build
@@ -43,6 +43,7 @@ sources = files(
     'Utils/SVGUtil.vala',
     'Utils/GeometryMath.vala',
     'Utils/Bezier.vala',
+    'Utils/Delegates.vala',
 
     'Layouts/HeaderBar.vala',
     'Layouts/MainViewCanvas.vala',


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
Don't trigger unnecessary undos on some ops.

Shifting items (z-order) don't trigger undo stack adds in no-ops

Added undo to aligning items, and added code to make sure they
also don't add undo stacks in no-ops.

## Steps to Test
Shift top-most item multiple times and make sure undos work correctly.
Run align-items multiple times and check that undo works correctly

## This PR fixes/implements the following **bugs/features**:

- Fixes #705
