### PR TITLE
Add simple XRay implementation

### DIFF
--- a/src/Drawables/DrawableArtboard.vala
+++ b/src/Drawables/DrawableArtboard.vala
@@ -64,7 +64,7 @@ public class Akira.Drawables.DrawableArtboard : Drawable {
         Drawables.DrawableRect.rect_path (context, this);
     }
 
-    public override void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale, DrawType draw_type) {
+    public override void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale, Drawable.DrawType draw_type) {
         base.paint (context, target_bounds, scale, draw_type);
 
         draw_text (context, scale);

--- a/src/Drawables/DrawableArtboard.vala
+++ b/src/Drawables/DrawableArtboard.vala
@@ -64,8 +64,8 @@ public class Akira.Drawables.DrawableArtboard : Drawable {
         Drawables.DrawableRect.rect_path (context, this);
     }
 
-    public override void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale) {
-        base.paint (context, target_bounds, scale);
+    public override void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale, DrawType draw_type) {
+        base.paint (context, target_bounds, scale, draw_type);
 
         draw_text (context, scale);
     }

--- a/src/Drawables/DrawableText.vala
+++ b/src/Drawables/DrawableText.vala
@@ -44,7 +44,7 @@ public class Akira.Drawables.DrawableText : Drawable {
         context.rectangle (x, y, w, h);
     }
 
-    public override void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale, DrawType draw_type) {
+    public override void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale, Drawable.DrawType draw_type) {
         // Simple bounds check
         if (bounds.left > target_bounds.right || bounds.right < target_bounds.left
             || bounds.top > target_bounds.bottom || bounds.bottom < target_bounds.top) {

--- a/src/Drawables/DrawableText.vala
+++ b/src/Drawables/DrawableText.vala
@@ -44,7 +44,7 @@ public class Akira.Drawables.DrawableText : Drawable {
         context.rectangle (x, y, w, h);
     }
 
-    public override void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale) {
+    public override void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale, DrawType draw_type) {
         // Simple bounds check
         if (bounds.left > target_bounds.right || bounds.right < target_bounds.left
             || bounds.top > target_bounds.bottom || bounds.bottom < target_bounds.top) {

--- a/src/ViewLayers/BaseCanvas.vala
+++ b/src/ViewLayers/BaseCanvas.vala
@@ -60,6 +60,8 @@ public class Akira.ViewLayers.BaseCanvas : Gtk.Widget , Gtk.Scrollable {
 
     private Gee.TreeMap<string, ViewLayers.ViewLayer> overlays;
 
+    public Drawables.Drawable.DrawType p_draw_type { get; set; default = Drawables.Drawable.DrawType.NORMAL; }
+
     public double scale {
         get { return p_scale; }
         set { this.internal_set_scale (value); }
@@ -640,7 +642,7 @@ public class Akira.ViewLayers.BaseCanvas : Gtk.Widget , Gtk.Scrollable {
 
     public void draw_model_node (Lib.Items.ModelNode node, Cairo.Context context, Geometry.Rectangle bounds) {
         if (node.instance.drawable != null) {
-            node.instance.drawable.paint (context, bounds, scale);
+            node.instance.drawable.paint (context, bounds, scale, p_draw_type);
         }
 
         if (node.children != null) {

--- a/src/ViewLayers/ViewLayerMultiSelect.vala
+++ b/src/ViewLayers/ViewLayerMultiSelect.vala
@@ -94,7 +94,7 @@ public class Akira.ViewLayers.ViewLayerMultiSelect : ViewLayer {
         drawable.fill_rgba = fill;
         drawable.line_width = UI_LINE_WIDTH / scale;
         drawable.stroke_rgba = stroke;
-        drawable.paint (context, target_bounds, scale);
+        drawable.paint (context, target_bounds, scale, Drawables.Drawable.DrawType.NORMAL);
 
         last_drawn_bb = drawable.bounds;
 


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?
Implements XRay mode:

Ignores artboard/group clipping and draws a 1px stroke on items. Not exposed in the UI as a setting/toggle.

## Steps to Test
Must be enabled via BaseCanvas property.

## Screenshots 
![Screenshot from 2022-02-19 17-51-55](https://user-images.githubusercontent.com/5934417/154821789-dfe7d86f-8b79-426d-988f-f3685999b202.png)

## Known Issues / Things To Do
In the future the implementation of drawing things should be cleaned up. But imo that should be done once the canvas is rewritten.
Right now it draws black lines. Perhaps this should be theme-dependent?

## This PR fixes/implements the following **bugs/features**:
<!--- If there was an issue that this PR targets, adding it here will auto close it --> 

- Fixes #<!--- Replace me with Issue number -->
- Fixes #<!--- Replace me with Issue number -->
