### PR TITLE
Implement a Duplicate feature

### DIFF
--- a/src/Lib/Items/Model.vala
+++ b/src/Lib/Items/Model.vala
@@ -249,9 +249,11 @@ public class Akira.Lib.Items.Model : Object {
             return -1;
         }
 
+        // If a candidate_pos was passed, we need to respect that to maintain the
+        // pos_in_parent from a duplicated node, otherwise check if we have any
+        // siblings to determine the correct position.
         var pos = candidate_pos != -1 ? candidate_pos :
             parent_node.children == null ? 0 : parent_node.children.length;
-        print ("add to node %u\n", pos);
         return inner_splice_new_item (parent_node, pos, candidate);
     }
 

--- a/src/Lib/Items/Model.vala
+++ b/src/Lib/Items/Model.vala
@@ -239,21 +239,13 @@ public class Akira.Lib.Items.Model : Object {
         return 0;
     }
 
-    public int append_new_item (
-        int parent_id,
-        Lib.Items.ModelInstance candidate,
-        int candidate_pos = -1
-    ) {
+    public int append_new_item (int parent_id, Lib.Items.ModelInstance candidate) {
         var parent_node = group_nodes.get (parent_id);
         if (parent_node == null) {
             return -1;
         }
 
-        // If a candidate_pos was passed, we need to respect that to maintain the
-        // pos_in_parent from a duplicated node, otherwise check if we have any
-        // siblings to determine the correct position.
-        var pos = candidate_pos != -1 ? candidate_pos :
-            parent_node.children == null ? 0 : parent_node.children.length;
+        var pos = parent_node.children == null ? 0 : parent_node.children.length;
         return inner_splice_new_item (parent_node, pos, candidate);
     }
 

--- a/src/Lib/Items/Model.vala
+++ b/src/Lib/Items/Model.vala
@@ -239,13 +239,37 @@ public class Akira.Lib.Items.Model : Object {
         return 0;
     }
 
-    public int append_new_item (int parent_id, Lib.Items.ModelInstance candidate) {
+    public int append_new_item (
+        int parent_id,
+        Lib.Items.ModelInstance candidate,
+        int candidate_id = 0,
+        bool in_place = false
+    ) {
         var parent_node = group_nodes.get (parent_id);
         if (parent_node == null) {
             return -1;
         }
 
-        var pos = parent_node.children == null ? 0 : parent_node.children.length;
+        var pos = 0;
+        if (parent_node.children != null) {
+            // If this was a paste in place action, append the new node in the same
+            // position of the cloned item.
+            if (in_place) {
+                print ("Children %u\n", parent_node.children.length);
+                print ("Candidate ID %i\n", candidate_id);
+                for (var i = 0; i < parent_node.children.length; ++i) {
+                    unowned var ch = parent_node.children.index (i);
+                    print ("Instance ID %i\n", ch.instance.id);
+                    if (ch.instance.id == candidate_id) {
+                        pos = i;
+                        break;
+                    }
+                }
+                print ("Paste in place %i\n", pos);
+            } else {
+                pos = (int) parent_node.children.length;
+            }
+        }
         return inner_splice_new_item (parent_node, pos, candidate);
     }
 
@@ -259,11 +283,11 @@ public class Akira.Lib.Items.Model : Object {
 
     /*
      * Move items within a parent to change their z-order.
-     * 
+     *
      * Set restack to false if several move operations will be executed, which could make
      * later restacking more efficient. Make sure to call recalculate_children_stacking
      * after all operations.
-     * 
+     *
      * prep_for_op is an optional lambda that will get called only if the move ends up
      * in an actual change to the model. it serves as a way to have side-effects that
      * don't trigger on no-ops. For example, only add to the undo stack if a change happens.

--- a/src/Lib/Items/Model.vala
+++ b/src/Lib/Items/Model.vala
@@ -242,34 +242,16 @@ public class Akira.Lib.Items.Model : Object {
     public int append_new_item (
         int parent_id,
         Lib.Items.ModelInstance candidate,
-        int candidate_id = 0,
-        bool in_place = false
+        int candidate_pos = -1
     ) {
         var parent_node = group_nodes.get (parent_id);
         if (parent_node == null) {
             return -1;
         }
 
-        var pos = 0;
-        if (parent_node.children != null) {
-            // If this was a paste in place action, append the new node in the same
-            // position of the cloned item.
-            if (in_place) {
-                print ("Children %u\n", parent_node.children.length);
-                print ("Candidate ID %i\n", candidate_id);
-                for (var i = 0; i < parent_node.children.length; ++i) {
-                    unowned var ch = parent_node.children.index (i);
-                    print ("Instance ID %i\n", ch.instance.id);
-                    if (ch.instance.id == candidate_id) {
-                        pos = i;
-                        break;
-                    }
-                }
-                print ("Paste in place %i\n", pos);
-            } else {
-                pos = (int) parent_node.children.length;
-            }
-        }
+        var pos = candidate_pos != -1 ? candidate_pos :
+            parent_node.children == null ? 0 : parent_node.children.length;
+        print ("add to node %u\n", pos);
         return inner_splice_new_item (parent_node, pos, candidate);
     }
 

--- a/src/Lib/Managers/CopyManager.vala
+++ b/src/Lib/Managers/CopyManager.vala
@@ -31,29 +31,43 @@ public class Akira.Lib.Managers.CopyManager : Object {
     construct {
         view_canvas.window.event_bus.request_copy.connect (do_copy);
         view_canvas.window.event_bus.request_paste.connect (do_paste);
+        view_canvas.window.event_bus.request_duplicate.connect (do_duplicate);
+    }
+
+    /*
+     * Return a tree map of the currently selected items, with their sorted position.
+     */
+    private Gee.TreeMap<Lib.Items.PositionKey, int> collect_sorted_candidates () {
+        var candidates = new Gee.TreeMap<Lib.Items.PositionKey, int> (Lib.Items.PositionKey.compare);
+        foreach (var to_copy in view_canvas.selection_manager.selection.nodes.values) {
+            var key = new Lib.Items.PositionKey ();
+            key.parent_path = view_canvas.items_manager.item_model.path_from_node (to_copy.node.parent);
+            key.pos_in_parent = to_copy.node.pos_in_parent;
+            candidates[key] = to_copy.node.id;
+        }
+
+        return candidates;
     }
 
     /*
      * Copy the currently selected nodes.
      */
     public void do_copy () {
+        var sorted_candidates = collect_sorted_candidates ();
+        // Don't do anything if we don't have selected nodes.
+        if (sorted_candidates.size == 0) {
+            return;
+        }
+
         // Create a new Model to hold all the cloned nodes in memory.
         copy_model = new Lib.Items.Model ();
 
-        var sorted_candidates = new Gee.TreeMap<Lib.Items.PositionKey, int> (Lib.Items.PositionKey.compare);
-        foreach (var to_copy in view_canvas.selection_manager.selection.nodes.values) {
-            var key = new Lib.Items.PositionKey ();
-            key.parent_path = view_canvas.items_manager.item_model.path_from_node (to_copy.node.parent);
-            key.pos_in_parent = to_copy.node.pos_in_parent;
-            sorted_candidates[key] = to_copy.node.id;
-        }
-
-        int res = 0;
         // Populate the model with all the currently selected nodes.
-        foreach (var entry in sorted_candidates.entries) {
+        int res = 0;
+        foreach (var sorted_id in sorted_candidates.values) {
             res += Utils.ModelUtil.clone_from_model (
                 view_canvas.items_manager.item_model,
-                entry,
+                sorted_id,
                 copy_model,
                 Lib.Items.Model.ORIGIN_ID
             );
@@ -64,6 +78,13 @@ public class Akira.Lib.Managers.CopyManager : Object {
 
     /*
      * Paste a copied node into the item_model.
+     * TODO:
+     * - If the `in_place` is true, the cloned node should be spliced at the same position of the
+     * currently selected node, ignoring the source node position (eg. paste into group, paste into
+     * another artboard, etc.), and the X & Y coordinates of the cloned node should match the
+     * coordiante sof the currently selected node.
+     * - If the `in_place` is false, we should paste the node at the center of the viewport, at the
+     * top most position.
      */
     public void do_paste (bool in_place = false) {
         if (copy_model == null) {
@@ -71,7 +92,6 @@ public class Akira.Lib.Managers.CopyManager : Object {
         }
 
         var children = copy_model.node_from_id (Lib.Items.Model.ORIGIN_ID).children;
-
         if (children == null || children.length == 0) {
             return;
         }
@@ -80,25 +100,78 @@ public class Akira.Lib.Managers.CopyManager : Object {
         (blocker);
 
         view_canvas.selection_manager.reset_selection ();
-
         view_canvas.window.event_bus.create_model_snapshot (
             in_place ? "paste selection in place" : "paste selection");
 
         int res = 0;
         foreach (var child in children.data) {
-            res += Utils.ModelUtil.paste_from_model (
+            res += Utils.ModelUtil.clone_from_model (
                 copy_model,
                 child.id,
                 view_canvas.items_manager.item_model,
                 Lib.Items.Model.ORIGIN_ID,
                 on_subtree_cloned,
-                in_place
+                in_place ? Utils.ModelUtil.State.PASTE_IN_PLACE : Utils.ModelUtil.State.PASTE
             );
         }
+        assert (res == 0);
+        on_after_paste ();
+    }
 
-        view_canvas.items_manager.compile_model ();
+    private void do_duplicate () {
+        var sorted_candidates = collect_sorted_candidates ();
+        // Don't do anything if we don't have selected nodes.
+        if (sorted_candidates.size == 0) {
+            return;
+        }
+
+        // Populate the model with all the currently selected nodes. Use a locally
+        // scoped variable to not override the copy_model in order to maintain any
+        // existing copied model.
+        var duplicate_model = new Lib.Items.Model ();
+        int res = 0;
+        foreach (var sorted_id in sorted_candidates.values) {
+            res += Utils.ModelUtil.clone_from_model (
+                view_canvas.items_manager.item_model,
+                sorted_id,
+                duplicate_model,
+                Lib.Items.Model.ORIGIN_ID
+            );
+        }
         assert (res == 0);
 
+        if (duplicate_model == null) {
+            return;
+        }
+
+        var children = duplicate_model.node_from_id (Lib.Items.Model.ORIGIN_ID).children;
+        if (children == null || children.length == 0) {
+            return;
+        }
+
+        var blocker = new SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
+        (blocker);
+
+        view_canvas.selection_manager.reset_selection ();
+        view_canvas.window.event_bus.create_model_snapshot ("duplicate selection");
+
+        res = 0;
+        foreach (var child in children.data) {
+            res += Utils.ModelUtil.clone_from_model (
+                duplicate_model,
+                child.id,
+                view_canvas.items_manager.item_model,
+                Lib.Items.Model.ORIGIN_ID,
+                on_subtree_cloned,
+                Utils.ModelUtil.State.DUPLICATE
+            );
+        }
+        assert (res == 0);
+        on_after_paste ();
+    }
+
+    private void on_after_paste () {
+        view_canvas.items_manager.compile_model ();
         // Regenerate the layers list.
         view_canvas.window.main_window.regenerate_list (true);
     }

--- a/src/Lib/Managers/CopyManager.vala
+++ b/src/Lib/Managers/CopyManager.vala
@@ -31,10 +31,13 @@ public class Akira.Lib.Managers.CopyManager : Object {
     construct {
         view_canvas.window.event_bus.request_copy.connect (do_copy);
         view_canvas.window.event_bus.request_paste.connect (do_paste);
-        view_canvas.window.event_bus.request_paste_in_place.connect (do_paste_in_place);
     }
 
+    /*
+     * Copy the currently selected nodes.
+     */
     public void do_copy () {
+        // Create a new Model to hold all the cloned nodes in memory.
         copy_model = new Lib.Items.Model ();
 
         var sorted_candidates = new Gee.TreeMap<Lib.Items.PositionKey, int> (Lib.Items.PositionKey.compare);
@@ -46,10 +49,11 @@ public class Akira.Lib.Managers.CopyManager : Object {
         }
 
         int res = 0;
-        foreach (var sorted_id in sorted_candidates.values) {
+        // Populate the model with all the currently selected nodes.
+        foreach (var entry in sorted_candidates.entries) {
             res += Utils.ModelUtil.clone_from_model (
                 view_canvas.items_manager.item_model,
-                sorted_id,
+                entry,
                 copy_model,
                 Lib.Items.Model.ORIGIN_ID
             );
@@ -59,9 +63,9 @@ public class Akira.Lib.Managers.CopyManager : Object {
     }
 
     /*
-     * Paste a copied model at the center of the viewport.
+     * Paste a copied node into the item_model.
      */
-    public void do_paste () {
+    public void do_paste (bool in_place = false) {
         if (copy_model == null) {
             return;
         }
@@ -77,56 +81,18 @@ public class Akira.Lib.Managers.CopyManager : Object {
 
         view_canvas.selection_manager.reset_selection ();
 
-        view_canvas.window.event_bus.create_model_snapshot ("paste selection");
+        view_canvas.window.event_bus.create_model_snapshot (
+            in_place ? "paste selection in place" : "paste selection");
 
         int res = 0;
         foreach (var child in children.data) {
-            res += Utils.ModelUtil.clone_from_model (
-                copy_model,
-                child.id,
-                view_canvas.items_manager.item_model,
-                Lib.Items.Model.ORIGIN_ID,
-                on_subtree_cloned
-            );
-        }
-
-        view_canvas.items_manager.compile_model ();
-        assert (res == 0);
-
-        // Regenerate the layers list.
-        view_canvas.window.main_window.regenerate_list (true);
-    }
-
-    /*
-     * Paste a copied model at its original place.
-     */
-    public void do_paste_in_place () {
-        if (copy_model == null) {
-            return;
-        }
-
-        var children = copy_model.node_from_id (Lib.Items.Model.ORIGIN_ID).children;
-
-        if (children == null || children.length == 0) {
-            return;
-        }
-
-        var blocker = new SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
-        (blocker);
-
-        view_canvas.selection_manager.reset_selection ();
-
-        view_canvas.window.event_bus.create_model_snapshot ("paste selection in place");
-
-        int res = 0;
-        foreach (var child in children.data) {
-            res += Utils.ModelUtil.clone_from_model (
+            res += Utils.ModelUtil.paste_from_model (
                 copy_model,
                 child.id,
                 view_canvas.items_manager.item_model,
                 Lib.Items.Model.ORIGIN_ID,
                 on_subtree_cloned,
-                true
+                in_place
             );
         }
 

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -549,7 +549,7 @@ public class Akira.Services.ActionManager : Object {
 
     private void action_duplicate () {
         window.event_bus.request_copy ();
-        window.event_bus.request_paste_in_place ();
+        window.event_bus.request_paste (true);
     }
 
     private void action_copy () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -548,8 +548,7 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_duplicate () {
-        window.event_bus.request_copy ();
-        window.event_bus.request_paste (true);
+        window.event_bus.request_duplicate ();
     }
 
     private void action_copy () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -67,6 +67,7 @@ public class Akira.Services.ActionManager : Object {
     public const string ACTION_ESCAPE = "action_escape";
     public const string ACTION_SHORTCUTS = "action_shortcuts";
     public const string ACTION_PICK_COLOR = "action_pick_color";
+    public const string ACTION_DUPLICATE = "action_duplicate";
     public const string ACTION_COPY = "action_copy";
     public const string ACTION_PASTE = "action_paste";
     public const string ACTION_ALIGN_LEFT = "action_align_left";
@@ -116,6 +117,7 @@ public class Akira.Services.ActionManager : Object {
         { ACTION_ESCAPE, action_escape },
         { ACTION_SHORTCUTS, action_shortcuts },
         { ACTION_PICK_COLOR, action_pick_color },
+        { ACTION_DUPLICATE, action_duplicate },
         { ACTION_COPY, action_copy },
         { ACTION_PASTE, action_paste },
         { ACTION_ALIGN_LEFT, action_align_left },
@@ -161,6 +163,7 @@ public class Akira.Services.ActionManager : Object {
         action_accelerators.set (ACTION_FLIP_V, "<Control>bracketright");
         action_accelerators.set (ACTION_SHORTCUTS, "F1");
         action_accelerators.set (ACTION_PICK_COLOR, "<Alt>c");
+        action_accelerators.set (ACTION_DUPLICATE, "<Control>d");
         action_accelerators.set (ACTION_COPY, "<Control>c");
         action_accelerators.set (ACTION_PASTE, "<Control>v");
         action_accelerators.set (ACTION_ESCAPE, "Escape");
@@ -542,6 +545,11 @@ public class Akira.Services.ActionManager : Object {
         //     // had their properties changed.
         //     canvas.window.event_bus.selected_items_list_changed (canvas.selected_bound_manager.selected_items);
         // });
+    }
+
+    private void action_duplicate () {
+        window.event_bus.request_copy ();
+        window.event_bus.request_paste_in_place ();
     }
 
     private void action_copy () {

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -77,8 +77,7 @@ public class Akira.Services.EventBus : Object {
     // triggered at every geometry change. Use the simple selection_modified ();
     public signal void selection_geometry_modified ();
     public signal void request_copy ();
-    public signal void request_paste ();
-    public signal void request_paste_in_place ();
+    public signal void request_paste (bool in_place = false);
     public signal void delete_selected_items ();
 
     // Selection align signals

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -78,6 +78,7 @@ public class Akira.Services.EventBus : Object {
     public signal void selection_geometry_modified ();
     public signal void request_copy ();
     public signal void request_paste ();
+    public signal void request_paste_in_place ();
     public signal void delete_selected_items ();
 
     // Selection align signals

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -78,6 +78,7 @@ public class Akira.Services.EventBus : Object {
     public signal void selection_geometry_modified ();
     public signal void request_copy ();
     public signal void request_paste (bool in_place = false);
+    public signal void request_duplicate ();
     public signal void delete_selected_items ();
 
     // Selection align signals

--- a/src/Utils/ModelUtil.vala
+++ b/src/Utils/ModelUtil.vala
@@ -25,6 +25,12 @@
  public class Akira.Utils.ModelUtil : Object {
 
     public delegate void OnSubtreeCloned (int id);
+    public enum State {
+        COPY,
+        PASTE,
+        PASTE_IN_PLACE,
+        DUPLICATE
+    }
 
     /*
      * Clones an instance with `source_id` from a source model, into a target model into a specific
@@ -34,41 +40,11 @@
      */
     public static int clone_from_model (
         Lib.Items.Model source_model,
-        Gee.Map.Entry<Lib.Items.PositionKey, int> source,
-        Lib.Items.Model target_model,
-        int target_group_id
-    ) {
-        var target_node = target_model.node_from_id (target_group_id);
-        if (target_node == null || !target_node.instance.is_group) {
-            return -1;
-        }
-
-        var source_node = source_model.node_from_id (source.value);
-        if (source_node == null) {
-            return -1;
-        }
-
-        source_node.pos_in_parent = source.key.pos_in_parent;
-        recursive_clone (source_node, target_node, target_model);
-
-        return 0;
-    }
-
-    /*
-     * Pastes an instance with `source_id` from the copy model, into a target model into a specific
-     * group with id `tagret_group_id`.
-     * If the `in_place` is true, the cloned node is appended above the source node.
-     * TODO: If the `in_place` is false, we should paste the node at the center of the viewport.
-     * Cloning is recursive, so all dependencies are copied over.
-     * Return 0 on success.
-     */
-    public static int paste_from_model (
-        Lib.Items.Model source_model,
         int source_id,
         Lib.Items.Model target_model,
         int target_group_id,
-        OnSubtreeCloned on_subtree_cloned,
-        bool in_place = false
+        OnSubtreeCloned? on_subtree_cloned = null,
+        State state = State.COPY
     ) {
         var target_node = target_model.node_from_id (target_group_id);
         if (target_node == null || !target_node.instance.is_group) {
@@ -80,18 +56,17 @@
             return -1;
         }
 
-        if (!in_place) {
-            // Reset the position to -1 to let the cloned node be appended above
-            // all available child nodes.
+        if (state == State.PASTE) {
+            // Regular paste action. Reset the position to -1 to let the cloned
+            // node be appended above all available child nodes.
             source_node.pos_in_parent = -1;
-        } else {
-            // Increase the position by one to let the cloned node be appended
-            // above the source node.
+        } else if (state == State.PASTE_IN_PLACE || state == State.DUPLICATE) {
+            // Paste in place action. Increase the position by one to let the
+            // cloned node be appended above the source node.
             source_node.pos_in_parent += 1;
         }
-
         var new_id = recursive_clone (source_node, target_node, target_model);
-        if (new_id >= Lib.Items.Model.GROUP_START_ID) {
+        if (new_id >= Lib.Items.Model.GROUP_START_ID && on_subtree_cloned != null) {
             on_subtree_cloned (new_id);
         }
 
@@ -103,11 +78,20 @@
         Lib.Items.ModelNode target_node,
         Lib.Items.Model target_model
     ) {
-        var new_id = target_model.append_new_item (
-            target_node.id,
-            source_node.instance.clone (false),
-            source_node.pos_in_parent
-        );
+        int new_id;
+        if (source_node.pos_in_parent != -1) {
+            // Splice the node into position if we have one set.
+            new_id = target_model.splice_new_item (
+                target_node.id,
+                source_node.pos_in_parent,
+                source_node.instance.clone (false)
+            );
+        } else {
+            new_id = target_model.append_new_item (
+                target_node.id,
+                source_node.instance.clone (false)
+            );
+        }
 
         if (source_node.instance.is_group) {
             foreach (var child in source_node.children.data) {

--- a/src/Utils/ModelUtil.vala
+++ b/src/Utils/ModelUtil.vala
@@ -28,7 +28,8 @@
 
     /*
      * Clones an instance with `source_id` from a source model, into a target model into a specific
-     * group with id `tagret_group_id`.
+     * group with id `tagret_group_id`. If the `in_place` is false, the cloned model is appended
+     * at the center of the canvas viewport, otherwise the current model coordinates are kept.
      * Cloning is recursive, so all dependencies are copied over.
      * Return 0 on success.
      */
@@ -37,7 +38,8 @@
         int source_id,
         Lib.Items.Model target_model,
         int target_group_id,
-        OnSubtreeCloned? on_subtree_cloned = null
+        OnSubtreeCloned? on_subtree_cloned = null,
+        bool in_place = false
     ) {
         var target_node = target_model.node_from_id (target_group_id);
         if (target_node == null || !target_node.instance.is_group) {
@@ -49,7 +51,7 @@
             return -1;
         }
 
-        var new_id = recursive_clone (source_node, target_node, target_model);
+        var new_id = recursive_clone (source_node, target_node, target_model, in_place);
 
         if (new_id >= Lib.Items.Model.GROUP_START_ID && on_subtree_cloned != null) {
             on_subtree_cloned (new_id);
@@ -61,13 +63,19 @@
     private static int recursive_clone (
         Lib.Items.ModelNode source_node,
         Lib.Items.ModelNode target_node,
-        Lib.Items.Model target_model
+        Lib.Items.Model target_model,
+        bool in_place
     ) {
-        var new_id = target_model.append_new_item (target_node.id, source_node.instance.clone (false));
+        var new_id = target_model.append_new_item (
+            target_node.id,
+            source_node.instance.clone (false),
+            source_node.id,
+            in_place
+        );
 
         if (source_node.instance.is_group) {
             foreach (var child in source_node.children.data) {
-                recursive_clone (child, target_model.node_from_id (new_id), target_model);
+                recursive_clone (child, target_model.node_from_id (new_id), target_model, in_place);
             }
         }
 

--- a/src/Utils/ModelUtil.vala
+++ b/src/Utils/ModelUtil.vala
@@ -28,17 +28,46 @@
 
     /*
      * Clones an instance with `source_id` from a source model, into a target model into a specific
-     * group with id `tagret_group_id`. If the `in_place` is false, the cloned model is appended
-     * at the center of the canvas viewport, otherwise the current model coordinates are kept.
+     * group with id `tagret_group_id`.
      * Cloning is recursive, so all dependencies are copied over.
      * Return 0 on success.
      */
     public static int clone_from_model (
         Lib.Items.Model source_model,
+        Gee.Map.Entry<Lib.Items.PositionKey, int> source,
+        Lib.Items.Model target_model,
+        int target_group_id
+    ) {
+        var target_node = target_model.node_from_id (target_group_id);
+        if (target_node == null || !target_node.instance.is_group) {
+            return -1;
+        }
+
+        var source_node = source_model.node_from_id (source.value);
+        if (source_node == null) {
+            return -1;
+        }
+
+        source_node.pos_in_parent = source.key.pos_in_parent;
+        recursive_clone (source_node, target_node, target_model);
+
+        return 0;
+    }
+
+    /*
+     * Pastes an instance with `source_id` from the copy model, into a target model into a specific
+     * group with id `tagret_group_id`.
+     * If the `in_place` is true, the cloned node is appended above the source node.
+     * TODO: If the `in_place` is false, we should paste the node at the center of the viewport.
+     * Cloning is recursive, so all dependencies are copied over.
+     * Return 0 on success.
+     */
+    public static int paste_from_model (
+        Lib.Items.Model source_model,
         int source_id,
         Lib.Items.Model target_model,
         int target_group_id,
-        OnSubtreeCloned? on_subtree_cloned = null,
+        OnSubtreeCloned on_subtree_cloned,
         bool in_place = false
     ) {
         var target_node = target_model.node_from_id (target_group_id);
@@ -51,9 +80,18 @@
             return -1;
         }
 
-        var new_id = recursive_clone (source_node, target_node, target_model, in_place);
+        if (!in_place) {
+            // Reset the position to -1 to let the cloned node be appended above
+            // all available child nodes.
+            source_node.pos_in_parent = -1;
+        } else {
+            // Increase the position by one to let the cloned node be appended
+            // above the source node.
+            source_node.pos_in_parent += 1;
+        }
 
-        if (new_id >= Lib.Items.Model.GROUP_START_ID && on_subtree_cloned != null) {
+        var new_id = recursive_clone (source_node, target_node, target_model);
+        if (new_id >= Lib.Items.Model.GROUP_START_ID) {
             on_subtree_cloned (new_id);
         }
 
@@ -63,19 +101,17 @@
     private static int recursive_clone (
         Lib.Items.ModelNode source_node,
         Lib.Items.ModelNode target_node,
-        Lib.Items.Model target_model,
-        bool in_place
+        Lib.Items.Model target_model
     ) {
         var new_id = target_model.append_new_item (
             target_node.id,
             source_node.instance.clone (false),
-            source_node.id,
-            in_place
+            source_node.pos_in_parent
         );
 
         if (source_node.instance.is_group) {
             foreach (var child in source_node.children.data) {
-                recursive_clone (child, target_model.node_from_id (new_id), target_model, in_place);
+                recursive_clone (child, target_model.node_from_id (new_id), target_model);
             }
         }
 


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implement a <kbd>CTRL</kbd>+<kbd>d</kbd> feature to duplicate a node into place.
The node target node should be created above the source node in the layers list.
A regular `paste` action should create the target node at the top of every other available layer.

## Screenshot
![2022-07-02 13-14-18](https://user-images.githubusercontent.com/2527103/177015096-2927e547-e83e-4ab6-a6c0-832dcf45c54e.gif)

## Known Issues / Things To Do
The code comes with a few repetitions, probably not the cleanest solution but it's serviceable.
We should find a way to instruct a node to reset its coordinates to the center of the current viewport, so we can easily handle the past and past in place scenarios.
