### PR TITLE
Implement layers groups

### DIFF
--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -323,7 +323,7 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
         var node1 = im.node_from_id (layer1.id);
         var node2 = im.node_from_id (layer2.id);
 
-        bool node1_is_group = node1.instance.is_group;
+        var node1_is_group = node1.instance.is_group;
         var node2_is_group = node2.instance.is_group;
 
         if (node1_is_group != node2_is_group) {

--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -323,6 +323,7 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
         var node1 = im.node_from_id (layer1.id);
         var node2 = im.node_from_id (layer2.id);
 
+        // Why does this crash?
         var node1_is_group = node1.instance.is_group;
         var node2_is_group = node2.instance.is_group;
 

--- a/src/Layouts/LayersList/LayerListBox.vala
+++ b/src/Layouts/LayersList/LayerListBox.vala
@@ -323,8 +323,7 @@ public class Akira.Layouts.LayersList.LayerListBox : VirtualizingListBox {
         var node1 = im.node_from_id (layer1.id);
         var node2 = im.node_from_id (layer2.id);
 
-        // Why does this crash?
-        var node1_is_group = node1.instance.is_group;
+        bool node1_is_group = node1.instance.is_group;
         var node2_is_group = node2.instance.is_group;
 
         if (node1_is_group != node2_is_group) {

--- a/src/Layouts/LayersList/LayerListItem.vala
+++ b/src/Layouts/LayersList/LayerListItem.vala
@@ -147,6 +147,7 @@ public class Akira.Layouts.LayersList.LayerListItem : VirtualizingListBoxRow {
     private void build_artboard_ui () {
         // Update the general UI.
         style_ctx.remove_class ("layer");
+        style_ctx.remove_class ("group");
         style_ctx.add_class ("artboard");
 
         // Update icon.
@@ -159,16 +160,27 @@ public class Akira.Layouts.LayersList.LayerListItem : VirtualizingListBoxRow {
         update_btn_toggle ();
     }
 
-    /*
-     * TODO.
-     */
     private void build_group_ui () {
+        // Update the general UI.
+        style_ctx.remove_class ("layer");
+        style_ctx.remove_class ("artboard");
+        style_ctx.add_class ("group");
+
+        // Update icon.
+        icon.clear ();
+        icon.margin_start = 0;
+
+        // Show the toggle button.
+        btn_toggle.no_show_all = false;
+        btn_toggle.visible = true;
+
         update_btn_toggle ();
     }
 
     private void build_layer_ui () {
         // Update general UI.
         style_ctx.remove_class ("artboard");
+        style_ctx.remove_class ("group");
         style_ctx.add_class ("layer");
 
         // Update icon.

--- a/src/Layouts/MainViewCanvas.vala
+++ b/src/Layouts/MainViewCanvas.vala
@@ -35,7 +35,6 @@ public class Akira.Layouts.MainViewCanvas : Gtk.Grid {
     private double scroll_origin_x = 0;
     private double scroll_origin_y = 0;
 
-
     public MainViewCanvas (Akira.Window window) {
         Object (window: window, orientation: Gtk.Orientation.VERTICAL);
     }

--- a/src/Lib/Items/Model.vala
+++ b/src/Lib/Items/Model.vala
@@ -17,13 +17,18 @@
  * along with Akira. If not, see <https://www.gnu.org/licenses/>.
  *
  * Authored by: Martin "mbfraga" Fraga <mbfraga@gmail.com>
+ * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
+ *
+ * Many of the methods inside this code base come from the Fireloom code base.
+ * https://gitlab.com/mbfraga/fireloom_core
  */
 
- public interface Akira.Lib.Items.ModelListener : Object {
-     public abstract void on_item_added (int id);
-     public abstract void on_item_geometry_changed (int id);
-     public abstract void on_items_deleted (GLib.Array<int> ids);
- }
+public interface Akira.Lib.Items.ModelListener : Object {
+    public abstract void on_item_added (int id);
+    public abstract void on_item_geometry_changed (int id);
+    public abstract void on_items_deleted (GLib.Array<int> ids);
+    public abstract void on_item_transferred (int id);
+}
 
 /*
  * Holds maps to instances that define connectivity between items and groups.
@@ -208,6 +213,59 @@ public class Akira.Lib.Items.Model : Object {
         }
 
         internal_recalculate_children_stacking (group);
+    }
+
+    /*
+    TODO: Finish the transfer method based on
+    https://gitlab.com/mbfraga/fireloom_core/-/blob/main/packages/flmd/flmd_ItemModel.cpp#L148
+    */
+    public int transfer (
+        int source_id,
+        int source_pos,
+        int num_items,
+        int target_id,
+        int target_pos,
+        bool restack = false,
+        bool listen = true
+    ) {
+        if (num_items == 0) {
+            return 0;
+        }
+
+        var source_node = node_from_id (source_id);
+        var target_node = node_from_id (target_id);
+
+        if (!(source_node is Lib.Items.ModelNode) || !(target_node is Lib.Items.ModelNode)) {
+            assert (false);
+            return -1;
+        }
+
+        unowned var source_children = source_node.children;
+        int source_children_size = (int) source_children.length;
+
+        if (source_pos >= source_children_size || source_pos + num_items > source_children_size) {
+            assert (false);
+            return -1;
+        }
+
+        if (source_id == target_id) {
+            // TODO: shift instead
+            assert (false);
+            return -1;
+        }
+
+        unowned var target_children = target_node.children;
+        int target_children_size = (int) target_children.length;
+
+        if (target_pos >= target_children_size) {
+            target_pos = target_children_size;
+        }
+
+        if (listener != null && listen) {
+            //  listener.on_item_transferred (node.id);
+        }
+
+        return 0;
     }
 
     public int remove (int id, bool restack) {

--- a/src/Lib/Items/ModelInstance.vala
+++ b/src/Lib/Items/ModelInstance.vala
@@ -151,7 +151,8 @@ public class Akira.Lib.Items.ModelInstance {
     }
 
     public void remove_from_canvas (ViewLayers.BaseCanvas? canvas) {
-        if (canvas != null) {
+        // A ModelTypeGroup doesn't have a drawable instance.
+        if (canvas != null && drawable != null) {
             drawable.request_redraw (canvas, false);
         }
         drawable = null;

--- a/src/Lib/Managers/CopyManager.vala
+++ b/src/Lib/Managers/CopyManager.vala
@@ -37,7 +37,7 @@ public class Akira.Lib.Managers.CopyManager : Object {
     /*
      * Return a tree map of the currently selected items, with their sorted position.
      */
-    private Gee.TreeMap<Lib.Items.PositionKey, int> collect_sorted_candidates () {
+    public Gee.TreeMap<Lib.Items.PositionKey, int> collect_sorted_candidates () {
         var candidates = new Gee.TreeMap<Lib.Items.PositionKey, int> (Lib.Items.PositionKey.compare);
         foreach (var to_copy in view_canvas.selection_manager.selection.nodes.values) {
             var key = new Lib.Items.PositionKey ();

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -575,33 +575,17 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
         (blocker);
         view_canvas.pause_redraw = true;
 
-        var sorted_tree = new Gee.TreeMap<Lib.Items.PositionKey, Lib.Items.ModelNode> (
-            Lib.Items.PositionKey.compare,
-            null
-        );
-        foreach (var c_node in selection.nodes.values) {
-            var node = item_model.node_from_id (c_node.node.id);
-            if (node == null) {
-                continue;
-            }
-
-            var key = new Lib.Items.PositionKey ();
-            key.parent_path = node.parent == null ? "" : item_model.path_from_node (node.parent);
-            key.pos_in_parent = node.pos_in_parent;
-
-            sorted_tree[key] = node;
-        }
+        var sorted_candidates = view_canvas.copy_manager.collect_sorted_candidates ();
 
         view_canvas.selection_manager.reset_selection ();
 
         var group = Lib.Items.ModelTypeGroup.default_group ();
         add_item_to_origin (group);
 
-        foreach (var mapit in sorted_tree) {
-            var node = mapit.value;
-            var instance = node.instance.clone (true);
+        foreach (var node_id in sorted_candidates.values) {
+            var node = item_model.node_from_id (node_id);
+            add_item_to_group (group.id, node.instance.clone (false), true);
             item_model.remove (node.id, true);
-            add_item_to_group (group.id, instance, true);
         }
         view_canvas.selection_manager.add_to_selection (group.id);
 

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -564,6 +564,33 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
         }
     }
 
+    public void create_group_from_selection () {
+        // Don't create a group if we don't have any node selected.
+        unowned var selection = view_canvas.selection_manager.selection;
+        if (selection.count () == 0) {
+            return;
+        }
+        view_canvas.window.event_bus.create_model_snapshot ("create group from selection");
+
+        var blocker = new SelectionManager.ChangeSignalBlocker (view_canvas.selection_manager);
+        (blocker);
+        view_canvas.pause_redraw = true;
+
+        var group = Lib.Items.ModelTypeGroup.default_group ();
+        add_item_to_origin (group);
+
+        foreach (var node in selection.nodes.values) {
+            add_item_to_group (group.id, node.node.instance, true);
+        }
+        view_canvas.selection_manager.add_to_selection (group.id);
+
+        view_canvas.pause_redraw = false;
+        view_canvas.request_redraw (view_canvas.get_bounds ());
+
+        // Regenerate the layers list.
+        view_canvas.window.main_window.regenerate_list ();
+    }
+
     public void selection_align (Utils.ItemAlignment.AlignmentDirection direction) {
         unowned var selection = view_canvas.selection_manager.selection;
         if (selection.count () <= 1) {

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -47,6 +47,7 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
 
     public signal void item_added (int id);
     public signal void items_removed (GLib.Array<int> ids);
+    public signal void item_transferred (int id);
 
     public void on_item_added (int id) {
         item_added (id);
@@ -58,6 +59,10 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
 
     public void on_items_deleted (GLib.Array<int> ids) {
         items_removed (ids);
+    }
+
+    public void on_item_transferred (int id) {
+        item_transferred (id);
     }
 
     public Lib.Items.ModelInstance? instance_from_id (int id) {

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -240,21 +240,28 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
                 //window.event_bus.move_item_from_canvas (event);
                 //window.event_bus.detect_artboard_change ();
                 return true;
+
+            case Gdk.Key.g:
+                if (ctrl_is_pressed) {
+                    items_manager.create_group_from_selection ();
+                }
+                break;
             default:
                 break;
         }
 
-        uint uppercase_keyval = Gdk.keyval_to_upper (event.keyval);
-        if (uppercase_keyval == Gdk.Key.J) {
-            window.event_bus.create_model_snapshot ("add debug items");
-            items_manager.debug_add_rectangles (10000, true);
-            return true;
-        }
-        if (uppercase_keyval == Gdk.Key.G) {
-            window.event_bus.create_model_snapshot ("add debug group");
-            items_manager.add_debug_group (300, 300, true);
-            return true;
-        }
+        // TODO: Debuggging features, move this behind a pref.
+        //  uint uppercase_keyval = Gdk.keyval_to_upper (event.keyval);
+        //  if (uppercase_keyval == Gdk.Key.J) {
+        //      window.event_bus.create_model_snapshot ("add debug items");
+        //      items_manager.debug_add_rectangles (10000, true);
+        //      return true;
+        //  }
+        //  if (uppercase_keyval == Gdk.Key.G) {
+        //      window.event_bus.create_model_snapshot ("add debug group");
+        //      items_manager.add_debug_group (300, 300, true);
+        //      return true;
+        //  }
 
         return false;
     }

--- a/src/Utils/ModelUtil.vala
+++ b/src/Utils/ModelUtil.vala
@@ -17,14 +17,15 @@
  * along with Akira. If not, see <https://www.gnu.org/licenses/>.
  *
  * Authored by: Martin "mbfraga" Fraga <mbfraga@gmail.com>
+ * Authored by: Alessandro "alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
 /*
  * Utility to handle some model operations
  */
  public class Akira.Utils.ModelUtil : Object {
-
     public delegate void OnSubtreeCloned (int id);
+
     public enum State {
         COPY,
         PASTE,
@@ -33,8 +34,8 @@
     }
 
     /*
-     * Clones an instance with `source_id` from a source model, into a target model into a specific
-     * group with id `tagret_group_id`.
+     * Clones an instance with `source_id` from a source model, into a target
+     * model into a specific group with id `tagret_group_id`.
      * Cloning is recursive, so all dependencies are copied over.
      * Return 0 on success.
      */


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Initial implementation to create a group from a selection of nodes.
Hit <kbd>CTRL</kbd>+<kbd>G</kbd> to create a group from a selection.

### ToDo
This is a first rough implementation of the feature, a lot more works is needed.
The most obvious issues are:
- An initial draft of a `transfer()` method is part of this PR, it's unfinished and unused, but the scope is to later use that to handle the group creation.
- The nodes names should be maintained when a transfer happens, instead of manually updating the name to match the old ones after the fact.
- Empty Groups shouldn't exist. When a node is delete from a group, we should check if that group is currently empty and delete it automatically.
- The UI of the layers group needs to be done.
- Hover effect for both canvas and layers panel needs to be implemented.
- Nested groups are not a thing at all.
- Many more little things I'm probably missing.

### Screenshot
![group](https://user-images.githubusercontent.com/2527103/179371435-b75c2715-aa84-438b-98c7-027e00a6408c.png)