### PR TITLE
Drop standalone usage of Gdk.ModifierType

### DIFF
--- a/src/Layouts/MainViewCanvas.vala
+++ b/src/Layouts/MainViewCanvas.vala
@@ -95,20 +95,17 @@ public class Akira.Layouts.MainViewCanvas : Gtk.Grid {
     }
 
     public bool on_scroll (Gdk.EventScroll event) {
-        bool is_shift = (event.state & Gdk.ModifierType.SHIFT_MASK) > 0;
-        bool is_ctrl = (event.state & Gdk.ModifierType.CONTROL_MASK) > 0;
-
         double delta_x, delta_y;
         event.get_scroll_deltas (out delta_x, out delta_y);
 
-        if (is_ctrl) {
+        if (canvas.ctrl_is_pressed) {
             var norm_scale = canvas.scale / Lib.ViewCanvas.MAX_SCALE;
             delta_y *= 1 - (1 - norm_scale) * (1 - norm_scale);
             window.event_bus.adjust_zoom (-delta_y, false, Geometry.Point (event.x, event.y));
             return true;
         }
 
-        if (is_shift) {
+        if (canvas.shift_is_pressed) {
             main_scroll.hadjustment.value += delta_y * 10;
             return true;
         }

--- a/src/Lib/Modes/PathEditMode.vala
+++ b/src/Lib/Modes/PathEditMode.vala
@@ -312,7 +312,6 @@ public class Akira.Lib.Modes.PathEditMode : AbstractInteractionMode {
 
         bool is_selected = edit_model.hit_test (event.x, event.y, ref sel_point, ref underlying_pt);
 
-        bool is_shift = (event.state == Gdk.ModifierType.SHIFT_MASK);
         bool is_alt = (event.state == Gdk.ModifierType.MOD1_MASK);
 
         if (!is_selected) {
@@ -327,7 +326,7 @@ public class Akira.Lib.Modes.PathEditMode : AbstractInteractionMode {
             }
         }
 
-        if (is_shift) {
+        if (view_canvas.shift_is_pressed) {
             if (sel_point.sel_type != PointType.TANGENT_FIRST && sel_point.sel_type != PointType.TANGENT_SECOND) {
                 edit_model.set_selected_points (sel_point, true);
                 return true;

--- a/src/Widgets/InputField.vala
+++ b/src/Widgets/InputField.vala
@@ -110,13 +110,13 @@ public class Akira.Widgets.InputField : Gtk.Grid {
 
     private bool handle_key_press (Gdk.EventKey event) {
         // Arrow UP.
-        if (event.keyval == Gdk.Key.Up && (event.state & Gdk.ModifierType.SHIFT_MASK) > 0) {
+        if (event.keyval == Gdk.Key.Up && view_canvas.shift_is_pressed) {
             entry.spin (Gtk.SpinType.STEP_FORWARD, 10);
             return true;
         }
 
         // Arrow DOWN.
-        if (event.keyval == Gdk.Key.Down && (event.state & Gdk.ModifierType.SHIFT_MASK) > 0) {
+        if (event.keyval == Gdk.Key.Down && view_canvas.shift_is_pressed) {
             entry.spin (Gtk.SpinType.STEP_BACKWARD, 10);
             return true;
         }

--- a/src/Widgets/ZoomButton.vala
+++ b/src/Widgets/ZoomButton.vala
@@ -131,7 +131,7 @@ public class Akira.Widgets.ZoomButton : Gtk.Grid {
      */
     public bool zoom_reset (Gdk.EventButton event) {
         // If the CTRL key was pressed, show the popover with the input field.
-        if ((event.state & Gdk.ModifierType.CONTROL_MASK) > 0) {
+        if (window.main_window.main_view_canvas.canvas.ctrl_is_pressed) {
             zoom_popover.popup ();
             return true;
         }
@@ -199,7 +199,7 @@ public class Akira.Widgets.ZoomButton : Gtk.Grid {
         // is not a number, or the CTRL modifier is not pressed.
         if (
             !(event.keyval >= Gdk.Key.@0 && event.keyval <= Gdk.Key.@9) &&
-            (event.state & Gdk.ModifierType.CONTROL_MASK) == 0
+            !window.main_window.main_view_canvas.canvas.ctrl_is_pressed
         ) {
             return true;
         }


### PR DESCRIPTION
Drop standalone usage of Gdk.ModifierType in favor of boolean getters from the main canvas based on modifier intent.

- Fixes #730
