### PR TITLE
Implement group hover and selection

### DIFF
--- a/data/css/artboard.css
+++ b/data/css/artboard.css
@@ -1,25 +1,13 @@
-.artboard {
+row.artboard {
     transition: box-shadow 160ms ease, background-color 160ms ease;
     background-color: shade (@bg_color, 1);
 }
 
-.artboard entry {
-    background-color: @base_color;
-}
-
-.artboard label {
+row.artboard label {
     font-weight: bold;
     padding: 8px 0;
 }
 
-.artboard:hover:not(:selected) {
-    box-shadow: inset 0 0 0 2px @accent_color;
-}
-
-.artboard:hover .actions {
+row.artboard:hover .actions {
   opacity: 1;
-}
-
-.artboard:selected {
-    background-color: alpha (@accent_color, 0.4);
 }

--- a/data/css/layer.css
+++ b/data/css/layer.css
@@ -1,21 +1,21 @@
-.layer {
+row {
     transition: box-shadow 160ms ease, background-color 160ms ease;
 }
 
-.layer,
-.layer entry {
+row,
+row entry {
     background-color: @base_color;
 }
 
-.layer label {
+row label {
     padding: 8px 0;
 }
 
-.layer:selected {
+row:selected {
     background-color: alpha (@accent_color, 0.4);
 }
 
-.layer:hover:not(:selected) {
+row:hover:not(:selected) {
     box-shadow: inset 0 0 0 2px @accent_color;
 }
 

--- a/src/Drawables/DrawableGroup.vala
+++ b/src/Drawables/DrawableGroup.vala
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+ * Copyright (c) 2022 Alecaddd (https://alecaddd.com)
  *
  * This file is part of Akira.
  *
@@ -43,7 +43,7 @@ public class Akira.Drawables.DrawableGroup : Drawable {
         context.save ();
         Cairo.Matrix global_transform = context.get_matrix ();
 
-        // We apply the item transform before creating the path
+        // We apply the item transform before creating the path.
         Cairo.Matrix tr = transform;
         context.transform (tr);
 
@@ -56,8 +56,7 @@ public class Akira.Drawables.DrawableGroup : Drawable {
 
         context.restore ();
 
-        // Very important to initialize new path
+        // Very important to initialize new path.
         context.new_path ();
     }
-
 }

--- a/src/Drawables/DrawableGroup.vala
+++ b/src/Drawables/DrawableGroup.vala
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2019-2021 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Martin "mbfraga" Fraga <mbfraga@gmail.com>
+ */
+
+/*
+ * Drawable for groups.
+ */
+public class Akira.Drawables.DrawableGroup : Drawable {
+
+    public DrawableGroup () {}
+
+    public override void simple_create_path (Cairo.Context context) {}
+
+    public override void paint (Cairo.Context context, Geometry.Rectangle target_bounds, double scale, Drawable.DrawType draw_type) {}
+
+    /*
+     * Hover paint method for the drawable.
+     */
+    public override void paint_hover (
+        Cairo.Context context,
+        Gdk.RGBA color,
+        double line_width,
+        Geometry.Rectangle target_bounds,
+        double scale
+    ) {
+        context.save ();
+        Cairo.Matrix global_transform = context.get_matrix ();
+
+        // We apply the item transform before creating the path
+        Cairo.Matrix tr = transform;
+        context.transform (tr);
+
+        context.rectangle (bounds.left, bounds.top, bounds.width, bounds.height);
+
+        context.set_line_width (line_width / scale);
+        context.set_source_rgba (color.red, color.green, color.blue, color.alpha);
+        context.set_matrix (global_transform);
+        context.stroke ();
+
+        context.restore ();
+
+        // Very important to initialize new path
+        context.new_path ();
+    }
+
+}

--- a/src/Drawables/DrawableGroup.vala
+++ b/src/Drawables/DrawableGroup.vala
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Akira. If not, see <https://www.gnu.org/licenses/>.
  *
- * Authored by: Martin "mbfraga" Fraga <mbfraga@gmail.com>
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
  */
 
 /*

--- a/src/Layouts/BordersList/BordersPanel.vala
+++ b/src/Layouts/BordersList/BordersPanel.vala
@@ -74,7 +74,7 @@ public class Akira.Layouts.BordersList.BordersPanel : Gtk.Grid {
         bool is_visible = false;
         foreach (var selected in sm.selection.nodes.values) {
             // Show the borders panel only if at least one item is not an artboard.
-            if (!(selected.node.instance.type is Lib.Items.ModelTypeArtboard)) {
+            if (!selected.node.instance.is_artboard) {
                 is_visible = true;
                 break;
             }
@@ -101,7 +101,7 @@ public class Akira.Layouts.BordersList.BordersPanel : Gtk.Grid {
         unowned var im = _view_canvas.items_manager;
         foreach (var selected in sm.selection.nodes.values) {
             // Don't add borders for Artboards.
-            if (selected.node.instance.type is Lib.Items.ModelTypeArtboard) {
+            if (selected.node.instance.is_artboard) {
                 continue;
             }
 

--- a/src/Layouts/LayersList/LayerItemModel.vala
+++ b/src/Layouts/LayersList/LayerItemModel.vala
@@ -118,7 +118,7 @@ public class Akira.Layouts.LayersList.LayerItemModel : GLib.Object {
      */
     public bool is_artboard {
         get {
-            return _cached_instance.type is Lib.Items.ModelTypeArtboard;
+            return _cached_instance.is_artboard;
         }
     }
 
@@ -127,7 +127,7 @@ public class Akira.Layouts.LayersList.LayerItemModel : GLib.Object {
      */
     public bool is_group {
         get {
-            return _cached_instance.type is Lib.Items.ModelTypeGroup;
+            return _cached_instance.is_group;
         }
     }
 

--- a/src/Lib/Components/CompiledGeometry.vala
+++ b/src/Lib/Components/CompiledGeometry.vala
@@ -209,9 +209,8 @@ public class Akira.Lib.Components.CompiledGeometry : Copyable<CompiledGeometry> 
         _data.area.br_x = right;
         _data.area.br_y = bottom;
 
+        _data.drawable_area = _data.area;
         _data.local_bb = _data.area.bounding_box;
-        _data.area_bb = _data.area_bb;
-        _data._transformation_matrix.x0 = _data.area_bb.center_x;
-        _data._transformation_matrix.y0 = _data.area_bb.center_y;
+        _data.area_bb = _data.area.bounding_box;
     }
 }

--- a/src/Lib/Items/Model.vala
+++ b/src/Lib/Items/Model.vala
@@ -226,7 +226,7 @@ public class Akira.Lib.Items.Model : Object {
         int target_id,
         int target_pos,
         bool restack = false,
-        bool listen = true
+        Utils.TrivialDelegate? prep_for_op = null
     ) {
         if (num_items == 0) {
             return 0;
@@ -261,8 +261,65 @@ public class Akira.Lib.Items.Model : Object {
             target_pos = target_children_size;
         }
 
-        if (listener != null && listen) {
-            //  listener.on_item_transferred (node.id);
+        if (source_id != ORIGIN_ID && target_id != ORIGIN_ID) {
+            // check for cycle
+            for (var i = source_pos; i < source_pos + num_items; ++i) {
+                unowned var node = source_children.index (i);
+                if (node.id == target_id || target_node.has_ancestor (node.id, true)) {
+                    assert (false);
+                    return -1;
+                }
+            }
+        }
+
+        if (prep_for_op != null) {
+            prep_for_op ();
+        }
+
+        var target_start_num_of_children = target_children.length;
+
+        target_children.insert_vals (target_pos, source_children.data[source_pos : source_pos + num_items] , num_items);
+
+        Utils.Array.insert_array_at_iarray (
+            ref target_node.instance.children,
+            target_pos,
+            source_node.instance.children [source_pos : source_pos + num_items]
+        );
+
+        source_children.remove_range (source_pos, num_items);
+        Utils.Array.remove_from_iarray (
+            ref source_node.instance.children,
+            source_pos,
+            num_items
+        );
+
+        if (restack) {
+            for (var i = source_pos; i < source_children.length; ++i) {
+                source_children.index (i).pos_in_parent = i;
+            }
+        }
+
+        var target_count = target_pos >= target_start_num_of_children ? target_start_num_of_children : target_pos;
+
+        var added_count = 0;
+
+        for (var i = target_count; i < target_children.length; ++i) {
+            unowned var tgt = target_children.index (i);
+
+            // Updating the parent is mandatory for nodes within the transfered range.
+            tgt.pos_in_parent = (int)(target_count + added_count++);
+            tgt.parent = target_node;
+
+            if (!restack && added_count > num_items) {
+                // we need to set the new parent regardless. But further restacking is unnecessary
+                break;
+            }
+
+            internal_alert_item_change (tgt, false, Components.Component.Type.COMPILED_GEOMETRY);
+        }
+
+        if (source_node.id != ORIGIN_ID) {
+            internal_alert_item_change (source_node, false, Components.Component.Type.COMPILED_GEOMETRY);
         }
 
         return 0;
@@ -368,8 +425,11 @@ public class Akira.Lib.Items.Model : Object {
             for (var i = start; i < parent_node.children.length; ++i) {
                 unowned var ch = parent_node.children.index (i);
                 ch.pos_in_parent = i;
-                alert_node_changed (ch, Components.Component.Type.COMPILED_GEOMETRY);
             }
+        }
+
+        if (parent_node.id != ORIGIN_ID) {
+            alert_node_changed (parent_node, Components.Component.Type.COMPILED_GEOMETRY);
         }
 
         return 1;
@@ -501,6 +561,10 @@ public class Akira.Lib.Items.Model : Object {
             for (var i = ipos; i < parent_node.children.length; ++i) {
                 parent_node.children.index (ipos).pos_in_parent = ipos++;
             }
+        }
+
+        if (candidate.is_group) {
+            new_node.children = new GLib.Array<unowned ModelNode> ();
         }
 
         new_node.parent = parent_node;

--- a/src/Lib/Items/ModelInstance.vala
+++ b/src/Lib/Items/ModelInstance.vala
@@ -114,7 +114,7 @@ public class Akira.Lib.Items.ModelInstance {
         something_changed = compiled_components.maybe_compile_fill (type, components, node) || something_changed;
         something_changed = compiled_components.maybe_compile_border (type, components, node) || something_changed;
         something_changed = compiled_components.maybe_compile_geometry (type, components, node) || something_changed;
-        something_changed = node.instance.type is ModelTypeArtboard
+        something_changed = node.instance.is_artboard
             && compiled_components.maybe_compile_name (type, components, node)
             || something_changed;
 

--- a/src/Lib/Items/ModelInstance.vala
+++ b/src/Lib/Items/ModelInstance.vala
@@ -70,6 +70,7 @@ public class Akira.Lib.Items.ModelInstance {
     public Components.CompiledName compiled_name { get { return compiled_components.compiled_name; } }
 
     public bool is_group { get { return type.is_group (); } }
+    public bool is_artboard { get { return type.is_artboard (); } }
     public bool is_stackable { get { return drawable != null; } }
 
     public ModelInstance (int uid, ModelType type) {

--- a/src/Lib/Items/ModelNode.vala
+++ b/src/Lib/Items/ModelNode.vala
@@ -156,6 +156,10 @@ public class Akira.Lib.Items.ModelNode {
         Drawables.Drawable.HitTestType hit_test_type,
         ref Gee.ArrayList<unowned ModelNode> nodes
     ) {
+        if (instance.components.layer.locked) {
+            return;
+        }
+
         unowned var dr = instance.drawable;
         if (dr == null) {
             if (instance.bounding_box.contains (x, y)) {

--- a/src/Lib/Items/ModelNode.vala
+++ b/src/Lib/Items/ModelNode.vala
@@ -162,8 +162,7 @@ public class Akira.Lib.Items.ModelNode {
 
         unowned var dr = instance.drawable;
         if (dr == null) {
-            if (instance.bounding_box.contains (x, y)) {
-                nodes.add (this);
+            if (!instance.bounding_box.contains (x, y)) {
                 return;
             }
         } else {

--- a/src/Lib/Items/ModelNode.vala
+++ b/src/Lib/Items/ModelNode.vala
@@ -161,7 +161,7 @@ public class Akira.Lib.Items.ModelNode {
         }
 
         unowned var dr = instance.drawable;
-        if (dr == null) {
+        if (dr == null || (instance.is_group && !instance.is_artboard)) {
             if (!instance.bounding_box.contains (x, y)) {
                 return;
             }

--- a/src/Lib/Items/ModelNode.vala
+++ b/src/Lib/Items/ModelNode.vala
@@ -158,11 +158,11 @@ public class Akira.Lib.Items.ModelNode {
     ) {
         unowned var dr = instance.drawable;
         if (dr == null) {
-            if (!instance.bounding_box.contains (x, y)) {
+            if (instance.bounding_box.contains (x, y)) {
+                nodes.add (this);
                 return;
             }
-        }
-        else {
+        } else {
             if (dr.hit_test (x, y, cr, scale, hit_test_type)) {
                 nodes.add (this);
             }

--- a/src/Lib/Items/ModelType.vala
+++ b/src/Lib/Items/ModelType.vala
@@ -77,6 +77,7 @@ public class Akira.Lib.Items.ModelType : Object {
     }
 
     public virtual bool is_group () { return false; }
+    public virtual bool is_artboard () { return false; }
 }
 
 public class Akira.Lib.Items.DummyItemType : ModelType {

--- a/src/Lib/Items/ModelTypeArtboard.vala
+++ b/src/Lib/Items/ModelTypeArtboard.vala
@@ -82,4 +82,5 @@ public class Akira.Lib.Items.ModelTypeArtboard : ModelType {
     }
 
     public override bool is_group () { return true; }
+    public override bool is_artboard () { return true; }
 }

--- a/src/Lib/Items/ModelTypeGroup.vala
+++ b/src/Lib/Items/ModelTypeGroup.vala
@@ -42,5 +42,9 @@ public class Akira.Lib.Items.ModelTypeGroup : ModelType {
         return new Components.CompiledGeometry.from_descendants (components, node);
     }
 
+    public override void construct_canvas_item (ModelInstance instance) {
+        instance.drawable = new Drawables.DrawableGroup ();
+    }
+
     public override bool is_group () { return true; }
 }

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -89,12 +89,8 @@ public class Akira.Lib.Managers.HoverManager : Object {
     }
 
     private void maybe_create_hover_effect (Lib.Items.ModelNode node) {
-        // Prevent the creation of the hover effect if the item is selected or
-        // the layer is currently locked.
-        if (
-            view_canvas.selection_manager.item_selected (node.id)
-            || node.instance.components.layer.locked
-        ) {
+        // Prevent the creation of the hover effect if the item is selected.
+        if (view_canvas.selection_manager.item_selected (node.id)) {
             return;
         }
 
@@ -104,7 +100,6 @@ public class Akira.Lib.Managers.HoverManager : Object {
             remove_hover_effect ();
         }
 
-        // TODO: The group drawable is empty (all values are 0).
         hover_layer.add_drawable (node.instance.drawable);
         current_hovered_id = node.id;
         hover_changed (node.instance.id);

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -61,20 +61,9 @@ public class Akira.Lib.Managers.HoverManager : Object {
             return;
         }
 
+        unowned var sm = view_canvas.selection_manager;
         // Account for groups.
-        if (!view_canvas.ctrl_is_pressed) {
-            var old_target = target;
-            target = Utils.ModelUtil.recursive_get_parent_target (target);
-
-            unowned var sm = view_canvas.selection_manager;
-            if (
-                !sm.is_empty () &&
-                (target.has_child (old_target.id, true) || sm.item_is_sibling (old_target.id))
-            ) {
-                target = old_target;
-            }
-            old_target = null;
-        }
+        sm.ensure_correct_target (ref target);
 
         maybe_create_hover_effect (target);
         return;

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -58,13 +58,8 @@ public class Akira.Lib.Managers.HoverManager : Object {
         }
 
         // Account for groups.
-        if (
-            !view_canvas.ctrl_is_pressed &&
-            target.parent != null &&
-            target.parent.id != Lib.Items.Model.ORIGIN_ID &&
-            target.parent.instance.is_group
-        ) {
-            target = Utils.ModelUtil.recursive_get_parent_target (target.parent);
+        if (!view_canvas.ctrl_is_pressed) {
+            target = Utils.ModelUtil.recursive_get_parent_target (target);
         }
 
         maybe_create_hover_effect (target);

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -57,6 +57,16 @@ public class Akira.Lib.Managers.HoverManager : Object {
             return;
         }
 
+        // Account for groups.
+        if (
+            !view_canvas.ctrl_is_pressed &&
+            target.parent != null &&
+            target.parent.id != Lib.Items.Model.ORIGIN_ID &&
+            target.parent.instance.is_group
+        ) {
+            target = Utils.ModelUtil.recursive_get_parent_target (target.parent);
+        }
+
         maybe_create_hover_effect (target);
         return;
     }
@@ -94,6 +104,7 @@ public class Akira.Lib.Managers.HoverManager : Object {
             remove_hover_effect ();
         }
 
+        // TODO: The group drawable is empty (all values are 0).
         hover_layer.add_drawable (node.instance.drawable);
         current_hovered_id = node.id;
         hover_changed (node.instance.id);

--- a/src/Lib/Managers/HoverManager.vala
+++ b/src/Lib/Managers/HoverManager.vala
@@ -57,9 +57,23 @@ public class Akira.Lib.Managers.HoverManager : Object {
             return;
         }
 
+        if (view_canvas.selection_manager.item_selected (target.id)) {
+            return;
+        }
+
         // Account for groups.
         if (!view_canvas.ctrl_is_pressed) {
+            var old_target = target;
             target = Utils.ModelUtil.recursive_get_parent_target (target);
+
+            unowned var sm = view_canvas.selection_manager;
+            if (
+                !sm.is_empty () &&
+                (target.has_child (old_target.id, true) || sm.item_is_sibling (old_target.id))
+            ) {
+                target = old_target;
+            }
+            old_target = null;
         }
 
         maybe_create_hover_effect (target);
@@ -80,21 +94,19 @@ public class Akira.Lib.Managers.HoverManager : Object {
             return;
         }
 
+        if (view_canvas.selection_manager.item_selected (id)) {
+            return;
+        }
+
         maybe_create_hover_effect (node);
     }
 
     private void maybe_create_hover_effect (Lib.Items.ModelNode node) {
-        // Prevent the creation of the hover effect if the item is selected.
-        if (view_canvas.selection_manager.item_selected (node.id)) {
-            return;
-        }
-
         if (current_hovered_id == node.id) {
             return;
-        } else {
-            remove_hover_effect ();
         }
 
+        remove_hover_effect ();
         hover_layer.add_drawable (node.instance.drawable);
         current_hovered_id = node.id;
         hover_changed (node.instance.id);

--- a/src/Lib/Managers/SelectionManager.vala
+++ b/src/Lib/Managers/SelectionManager.vala
@@ -129,6 +129,22 @@ public class Akira.Lib.Managers.SelectionManager : Object {
         return false;
     }
 
+    public void ensure_correct_target (ref Items.ModelNode target) {
+        if (
+            (!item_selected (target.id) && !view_canvas.ctrl_is_pressed)
+        ) {
+            var old_target = target;
+            target = Utils.ModelUtil.recursive_get_parent_target (target);
+
+            if (
+                !is_empty () && item_is_sibling (old_target.id)
+            ) {
+                target = old_target;
+            }
+            old_target = null;
+        }
+    }
+
     /*
      * Called whenever the selection is changed, including adding and removing
      * items, and modifying the selection's geometry.

--- a/src/Lib/Managers/SelectionManager.vala
+++ b/src/Lib/Managers/SelectionManager.vala
@@ -111,6 +111,25 @@ public class Akira.Lib.Managers.SelectionManager : Object {
     }
 
     /*
+     * Check if a selection or hover actions are triggered on a sibling of
+     * a currently selected item of the same group.
+     */
+    public bool item_is_sibling (int id) {
+        foreach (var node_id in selection.nodes.keys) {
+            var node = view_canvas.items_manager.node_from_id (node_id);
+            if (node == null || node.parent == null || node.parent.id == Lib.Items.Model.ORIGIN_ID) {
+                continue;
+            }
+            node = Utils.ModelUtil.recursive_get_parent_target (node);
+            if (node.has_child (id, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /*
      * Called whenever the selection is changed, including adding and removing
      * items, and modifying the selection's geometry.
      */
@@ -173,5 +192,4 @@ public class Akira.Lib.Managers.SelectionManager : Object {
         }
         change_blocked |= change_type;
     }
-
 }

--- a/src/Lib/Modes/PathEditMode.vala
+++ b/src/Lib/Modes/PathEditMode.vala
@@ -311,9 +311,6 @@ public class Akira.Lib.Modes.PathEditMode : AbstractInteractionMode {
         underlying_pt.sel_index = -1;
 
         bool is_selected = edit_model.hit_test (event.x, event.y, ref sel_point, ref underlying_pt);
-
-        bool is_alt = (event.state == Gdk.ModifierType.MOD1_MASK);
-
         if (!is_selected) {
             return false;
         }
@@ -331,7 +328,7 @@ public class Akira.Lib.Modes.PathEditMode : AbstractInteractionMode {
                 edit_model.set_selected_points (sel_point, true);
                 return true;
             }
-        } else if (is_alt) {
+        } else if (view_canvas.alt_is_pressed && !view_canvas.ctrl_is_pressed) {
             if (sel_point.sel_type == PointType.TANGENT_FIRST || sel_point.sel_type == PointType.TANGENT_SECOND) {
                 sel_point.tangents_staggered = true;
                 edit_model.set_selected_points (sel_point, false);

--- a/src/Lib/Modes/TransformMode.vala
+++ b/src/Lib/Modes/TransformMode.vala
@@ -317,7 +317,7 @@ public class Akira.Lib.Modes.TransformMode : AbstractInteractionMode {
             if (child.instance.is_group) {
                 translate_group (
                     view_canvas,
-                    group,
+                    child,
                     initial_drag_state,
                     delta_x,
                     delta_y,

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -365,6 +365,13 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
                     // Remove the item fom the current selection if SHIFT is pressed.
                     selection_manager.remove_from_selection (target.id);
                     selection_manager.selection_modified_external (true);
+                } else if (ctrl_is_pressed) {
+                    // If we already have a selection but CTRL is pressed, we should
+                    // reset the selection and allow selecting the targeted element.
+                    // AKA, we ignore a group selection.
+                    selection_manager.reset_selection ();
+                    selection_manager.add_to_selection (target.id);
+                    selection_manager.selection_modified_external (true);
                 }
             } else if (
                 !selection_manager.selection.area ().contains (event.x, event.y) &&

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -333,13 +333,8 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
             );
 
             if (target != null) {
-                if (
-                    !ctrl_is_pressed &&
-                    target.parent != null &&
-                    target.parent.id != Lib.Items.Model.ORIGIN_ID &&
-                    target.parent.instance.is_group
-                ) {
-                    target = Utils.ModelUtil.recursive_get_parent_target (target.parent);
+                if (!ctrl_is_pressed) {
+                    target = Utils.ModelUtil.recursive_get_parent_target (target);
                 }
 
                 // Check if the clicked item is not already selected.

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -342,11 +342,6 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
                     target = Utils.ModelUtil.recursive_get_parent_target (target.parent);
                 }
 
-                // If the item is locked, no selection is allowed.
-                if (target.instance.components.layer.locked) {
-                    return false;
-                }
-
                 // Check if the clicked item is not already selected.
                 if (!selection_manager.item_selected (target.id)) {
                     // Reset the selection if SHIFT isn't pressed.

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -333,6 +333,15 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
             );
 
             if (target != null) {
+                if (
+                    !ctrl_is_pressed &&
+                    target.parent != null &&
+                    target.parent.id != Lib.Items.Model.ORIGIN_ID &&
+                    target.parent.instance.is_group
+                ) {
+                    target = Utils.ModelUtil.recursive_get_parent_target (target.parent);
+                }
+
                 // If the item is locked, no selection is allowed.
                 if (target.instance.components.layer.locked) {
                     return false;

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -342,19 +342,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
             );
 
             if (target != null) {
-                if (
-                    (!selection_manager.item_selected (target.id) && !ctrl_is_pressed)
-                ) {
-                    var old_target = target;
-                    target = Utils.ModelUtil.recursive_get_parent_target (target);
-
-                    if (
-                        !selection_manager.is_empty () && selection_manager.item_is_sibling (old_target.id)
-                    ) {
-                        target = old_target;
-                    }
-                    old_target = null;
-                }
+                selection_manager.ensure_correct_target (ref target);
 
                 // Check if the clicked item is not already selected.
                 if (!selection_manager.item_selected (target.id)) {

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -86,6 +86,10 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
     private double initial_event_x;
     private double initial_event_y;
 
+    // Keep track of a double clicked child item inside a group if we need to
+    // enfoce the selection of a specific target.
+    private int? enforced_target = null;
+
     public ViewCanvas (Akira.Window window) {
         Object (
             window: window,
@@ -398,6 +402,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
     }
 
     private void handle_double_click_event (Gdk.EventButton event) {
+        enforced_target = null;
         Lib.Items.ModelNode? target = null;
         var nob_clicked = nob_manager.hit_test (event.x, event.y);
 
@@ -427,10 +432,35 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
                 path_edit_mode.toggle_functionality (false);
                 mode_manager.register_mode (path_edit_mode);
             }
+            return;
+        }
+
+        // If the double click happened on an item that is already selected and
+        // all otehr previous conditions are false, check if this item is part
+        // of a group and enforce its selection, meaning the user wants to access
+        // the group's child nodes.
+        if (selection_manager.item_selected (target.id)) {
+            var old_target = target;
+            target = Utils.ModelUtil.recursive_get_parent_target (target);
+
+            if (target.instance.is_group) {
+                enforced_target = old_target.id;
+            }
         }
     }
 
     public override bool button_release_event (Gdk.EventButton event) {
+        // Enforce the selection of a specific target if it was registered
+        // during the double click event on a group.
+        if (enforced_target != null) {
+            selection_manager.reset_selection ();
+            selection_manager.add_to_selection (enforced_target);
+            enforced_target = null;
+            if (mode_manager.button_release_event (event)) {
+                return true;
+            }
+        }
+
         event.x = event.x / current_scale;
         event.y = event.y / current_scale;
 

--- a/src/Utils/Array.vala
+++ b/src/Utils/Array.vala
@@ -49,7 +49,7 @@ public class Akira.Utils.Array : Object {
 
         int start_length = a.length;
 
-        a.resize (other.length);
+        a.resize (start_length + other.length);
         a.move (pos, pos + other.length, start_length - pos);
 
         for (var i = 0; i < other.length; ++i) {

--- a/src/Utils/Array.vala
+++ b/src/Utils/Array.vala
@@ -27,7 +27,7 @@ public class Akira.Utils.Array : Object {
      * Insert value in an int array. Return true on success.
      */
     public static bool insert_at_iarray (ref int[] a, int pos, int value) {
-        if (pos >= a.length || pos < 0) {
+        if (pos > a.length || pos < 0) {
             assert (false);
             return false;
         }
@@ -35,6 +35,27 @@ public class Akira.Utils.Array : Object {
         a.resize (a.length + 1);
         a.move (pos, pos + 1, a.length - pos - 1);
         a[pos] = value;
+        return true;
+    }
+
+    /*
+     * Insert an array of integers within another array at `pos`.
+     */
+    public static bool insert_array_at_iarray (ref int[] a, int pos, int [] other) {
+        if (pos > a.length || pos < 0) {
+            assert (false);
+            return false;
+        }
+
+        int start_length = a.length;
+
+        a.resize (other.length);
+        a.move (pos, pos + other.length, start_length - pos);
+
+        for (var i = 0; i < other.length; ++i) {
+            a[pos + i] = other[i];
+        }
+
         return true;
     }
 

--- a/src/Utils/ModelUtil.vala
+++ b/src/Utils/ModelUtil.vala
@@ -107,7 +107,8 @@
         if (
             target.parent != null &&
             target.parent.id != Lib.Items.Model.ORIGIN_ID &&
-            target.parent.instance.is_group
+            target.parent.instance.is_group &&
+            !(target.parent.instance.type is Lib.Items.ModelTypeArtboard)
         ) {
             return recursive_get_parent_target (target.parent);
         }

--- a/src/Utils/ModelUtil.vala
+++ b/src/Utils/ModelUtil.vala
@@ -108,7 +108,7 @@
             target.parent != null &&
             target.parent.id != Lib.Items.Model.ORIGIN_ID &&
             target.parent.instance.is_group &&
-            !(target.parent.instance.type is Lib.Items.ModelTypeArtboard)
+            !target.parent.instance.is_artboard
         ) {
             return recursive_get_parent_target (target.parent);
         }

--- a/src/Utils/ModelUtil.vala
+++ b/src/Utils/ModelUtil.vala
@@ -102,4 +102,16 @@
 
         return new_id;
     }
+
+    public static Lib.Items.ModelNode recursive_get_parent_target (Lib.Items.ModelNode target) {
+        if (
+            target.parent != null &&
+            target.parent.id != Lib.Items.Model.ORIGIN_ID &&
+            target.parent.instance.is_group
+        ) {
+            return recursive_get_parent_target (target.parent);
+        }
+
+        return target;
+    }
  }

--- a/src/meson.build
+++ b/src/meson.build
@@ -116,6 +116,7 @@ sources = files(
     'Drawables/Drawable.vala',
     'Drawables/DrawableArtboard.vala',
     'Drawables/DrawableEllipse.vala',
+    'Drawables/DrawableGroup.vala',
     'Drawables/DrawablePath.vala',
     'Drawables/DrawableRect.vala',
     'Drawables/DrawableText.vala',


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Implement hover effect for groups, and the ability to select groups or child nodes by holding <kbd>CTRL</kbd>

### ToDo
- [x] Ignore artboards and allow selecting/hover child items
- [x] <kbd>CTRL</kbd> + Click on an item inside a selected group should select the item
- [x] If an item is already selected, don't go through the whole recursive parent detection again
- [x] Groups inside an artboard are selectable via click on an empty area. They should not
- [x] Double clicking an item inside a group should "open" the group, and select the double clicked item
