### PR TITLE
Various selection fixes

### DIFF
--- a/data/css/layer.css
+++ b/data/css/layer.css
@@ -2,7 +2,7 @@ row {
     transition: box-shadow 160ms ease, background-color 160ms ease;
 }
 
-row,
+row:not(.item-property),
 row entry {
     background-color: @base_color;
 }

--- a/src/Layouts/BordersList/BorderListItem.vala
+++ b/src/Layouts/BordersList/BorderListItem.vala
@@ -41,6 +41,8 @@ public class Akira.Layouts.BordersList.BorderListItem : VirtualizingListBoxRow {
             view_canvas: canvas
         );
 
+        get_style_context ().add_class ("item-property");
+
         var grid = new Gtk.Grid () {
             margin = 3
         };

--- a/src/Layouts/FillsList/FillListItem.vala
+++ b/src/Layouts/FillsList/FillListItem.vala
@@ -41,6 +41,8 @@ public class Akira.Layouts.FillsList.FillListItem : VirtualizingListBoxRow {
             view_canvas: canvas
         );
 
+        get_style_context ().add_class ("item-property");
+
         var grid = new Gtk.Grid () {
             margin = 3
         };

--- a/src/Lib/Managers/ItemsManager.vala
+++ b/src/Lib/Managers/ItemsManager.vala
@@ -360,6 +360,7 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
                 foreach (unowned var child_node in node.children.data) {
                     // Only add items that are not currently selected.
                     if (
+                        !child_node.instance.components.layer.locked &&
                         !view_canvas.selection_manager.item_selected (child_node.id) &&
                         bound.contains_bound (child_node.instance.bounding_box)
                     ) {
@@ -371,6 +372,7 @@ public class Akira.Lib.Managers.ItemsManager : Object, Items.ModelListener {
 
             // Only add items that are not currently selected.
             if (
+                !node.instance.components.layer.locked &&
                 !view_canvas.selection_manager.item_selected (node.id) &&
                 bound.contains_bound (node.instance.bounding_box)
             ) {

--- a/src/Utils/ModelUtil.vala
+++ b/src/Utils/ModelUtil.vala
@@ -115,4 +115,20 @@
 
         return target;
     }
+
+    public static Lib.Items.ModelNode? recursive_get_target_parent_artboard (Lib.Items.ModelNode target) {
+        if (
+            target.parent != null &&
+            target.parent.id != Lib.Items.Model.ORIGIN_ID &&
+            !target.parent.instance.is_artboard
+        ) {
+            return recursive_get_target_parent_artboard (target.parent);
+        }
+
+        if (target.parent.instance.is_artboard) {
+            return target.parent;
+        }
+
+        return null;
+    }
  }


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
- Prevent area selection of locked items.
- Deselect the artboard is a click and release without delta happens on an empty artboard body
- Select the child item inside an artboard is the click and release without delta happens on an item inside a currently selected artboard.
