### PR TITLE
Re-implement the Export Tool

### DIFF
--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -103,7 +103,9 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         export_grid = new Gtk.FlowBox () {
             activate_on_single_click = false,
             max_children_per_line = 1,
-            selection_mode = Gtk.SelectionMode.NONE
+            selection_mode = Gtk.SelectionMode.NONE,
+            column_spacing = 12,
+            row_spacing = 12
         };
         export_grid.get_style_context ().add_class ("export-panel");
 
@@ -141,9 +143,9 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         settings.bind ("export-format", file_format, "active_id",
             SettingsBindFlags.DEFAULT | GLib.SettingsBindFlags.GET_NO_CHANGES);
 
-        manager.generating_preview.connect (on_generating_preview);
+        manager.busy.connect (on_busy);
         manager.show_preview.connect (on_show_preview);
-        manager.preview_finished.connect (on_preview_finished);
+        manager.free.connect (on_free);
         manager.export_finished.connect (on_export_finished);
     }
 
@@ -308,7 +310,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         return title_label;
     }
 
-    private async void on_generating_preview (string message) {
+    private async void on_busy (string message) {
         overlaybar.label = message;
         overlaybar.visible = true;
         sidebar.@foreach ((child) => {
@@ -316,7 +318,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         });
     }
 
-    private async void on_preview_finished () {
+    private async void on_free () {
         sidebar.@foreach ((child) => {
             child.sensitive = true;
         });

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -42,6 +42,8 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     private Granite.Widgets.Toast notification;
     private Granite.Widgets.OverlayBar overlaybar;
 
+    private GLib.Cancellable? preview_cancellable;
+
     public ExportDialog (Lib.ViewCanvas view_canvas, Lib.Managers.ExportManager export_manager) {
         Object (
             canvas: view_canvas,
@@ -90,7 +92,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         build_export_sidebar ();
 
         main_overlay = new Gtk.Overlay ();
-        notification = new Granite.Widgets.Toast (_(""));
+        notification = new Granite.Widgets.Toast ("");
         overlaybar = new Granite.Widgets.OverlayBar (main_overlay);
         overlaybar.active = true;
 
@@ -184,7 +186,12 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         file_format.changed.connect (update_format_ui);
         grid.attach (file_format, 1, 2, 1, 1);
         settings.changed["export-format"].connect (() => {
-            manager.generate_preview.begin ();
+            if (preview_cancellable != null) {
+                preview_cancellable.cancel ();
+            }
+
+            preview_cancellable = new GLib.Cancellable ();
+            manager.generate_preview.begin (preview_cancellable);
         });
 
         // Quality spinbutton.
@@ -233,7 +240,12 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         settings.bind ("export-alpha", alpha_switch, "active",
             SettingsBindFlags.DEFAULT | SettingsBindFlags.GET_NO_CHANGES);
         settings.changed["export-alpha"].connect (() => {
-            manager.generate_preview.begin ();
+            if (preview_cancellable != null) {
+                preview_cancellable.cancel ();
+            }
+
+            preview_cancellable = new GLib.Cancellable ();
+            manager.generate_preview.begin (preview_cancellable);
         });
 
         // Resolution.
@@ -252,7 +264,12 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
             SettingsBindFlags.DEFAULT | SettingsBindFlags.GET_NO_CHANGES);
         grid.attach (scale_button, 1, 6, 1, 1);
         settings.changed["export-scale"].connect (() => {
-            manager.generate_preview.begin ();
+            if (preview_cancellable != null) {
+                preview_cancellable.cancel ();
+            }
+
+            preview_cancellable = new GLib.Cancellable ();
+            manager.generate_preview.begin (preview_cancellable);
         });
 
         // Buttons.

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -39,6 +39,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     public Gtk.Switch alpha_switch;
 
     private Gtk.Overlay main_overlay;
+    private Granite.Widgets.Toast notification;
     private Granite.Widgets.OverlayBar overlaybar;
 
     public ExportDialog (Lib.ViewCanvas view_canvas, Lib.Managers.ExportManager export_manager) {
@@ -89,6 +90,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         build_export_sidebar ();
 
         main_overlay = new Gtk.Overlay ();
+        notification = new Granite.Widgets.Toast (_(""));
         overlaybar = new Granite.Widgets.OverlayBar (main_overlay);
         overlaybar.active = true;
 
@@ -117,6 +119,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         main.add (scrolled);
 
         main_overlay.add (main);
+        main_overlay.add_overlay (notification);
 
         var pane = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         pane.pack1 (sidebar, false, false);
@@ -141,6 +144,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         manager.generating_preview.connect (on_generating_preview);
         manager.show_preview.connect (on_show_preview);
         manager.preview_finished.connect (on_preview_finished);
+        manager.export_finished.connect (on_export_finished);
     }
 
     private void build_export_sidebar () {
@@ -317,5 +321,10 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
             child.sensitive = true;
         });
         overlaybar.visible = false;
+    }
+
+    public void on_export_finished (string message) {
+        notification.title = message;
+        notification.send_notification ();
     }
 }

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2020 Alecaddd (https://alecaddd.com)
+* Copyright (c) 2020-2022 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -20,9 +20,8 @@
 */
 
 public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
-    public weak Akira.Window window { get; construct; }
-    public weak Akira.Lib.Managers.ExportManager manager { get; construct; }
-    public weak Akira.Lib.Managers.ExportManager.Type export_type { get; construct; }
+    public unowned Lib.ViewCanvas canvas { get; construct; }
+    public unowned Lib.Managers.ExportManager manager { get; construct; }
 
     public GLib.ListStore list_store;
 
@@ -42,15 +41,10 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     private Gtk.Overlay main_overlay;
     private Granite.Widgets.OverlayBar overlaybar;
 
-    public ExportDialog (
-        Akira.Window window,
-        Akira.Lib.Managers.ExportManager manager,
-        Akira.Lib.Managers.ExportManager.Type export_type
-    ) {
+    public ExportDialog (Lib.ViewCanvas view_canvas, Lib.Managers.ExportManager export_manager) {
         Object (
-            window: window,
-            manager: manager,
-            export_type: export_type,
+            canvas: view_canvas,
+            manager: export_manager,
             border_width: 0,
             deletable: true,
             resizable: true,
@@ -59,21 +53,20 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     }
 
     construct {
-        window.event_bus.export_preview.connect (on_export_preview);
-        window.event_bus.preview_completed.connect (on_preview_completed);
-
-        transient_for = window;
+        transient_for = canvas.window;
         use_header_bar = 1;
         default_width = settings.export_width;
         default_height = settings.export_height;
 
-        var sidebar_header = new Gtk.Grid ();
-        sidebar_header.vexpand = true;
+        var sidebar_header = new Gtk.Grid () {
+            vexpand = true,
+            height_request = 30
+        };
         sidebar_header.get_style_context ().add_class ("sidebar-export-header");
-        sidebar_header.height_request = 30;
 
-        var main_header = new Gtk.Grid ();
-        main_header.vexpand = true;
+        var main_header = new Gtk.Grid () {
+            vexpand = true
+        };
 
         var pane_header = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         pane_header.pack1 (sidebar_header, false, false);
@@ -99,23 +92,26 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         overlaybar = new Granite.Widgets.OverlayBar (main_overlay);
         overlaybar.active = true;
 
-        var main = new Gtk.Grid ();
-        main.expand = true;
+        var main = new Gtk.Grid () {
+            expand = true
+        };
 
         list_store = new GLib.ListStore (typeof (Akira.Models.ExportModel));
 
-        export_grid = new Gtk.FlowBox ();
-        export_grid.activate_on_single_click = false;
-        export_grid.max_children_per_line = 1;
-        export_grid.selection_mode = Gtk.SelectionMode.NONE;
+        export_grid = new Gtk.FlowBox () {
+            activate_on_single_click = false,
+            max_children_per_line = 1,
+            selection_mode = Gtk.SelectionMode.NONE
+        };
         export_grid.get_style_context ().add_class ("export-panel");
 
         export_grid.bind_model (list_store, model => {
             return new Widgets.ExportWidget (model as Akira.Models.ExportModel);
         });
 
-        var scrolled = new Gtk.ScrolledWindow (null, null);
-        scrolled.expand = true;
+        var scrolled = new Gtk.ScrolledWindow (null, null) {
+            expand = true
+        };
         scrolled.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
         scrolled.add (export_grid);
         main.add (scrolled);
@@ -138,14 +134,20 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
 
         settings.bind ("export-paned", pane, "position", SettingsBindFlags.DEFAULT);
         settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
+
+        manager.generating_preview.connect (on_generating_preview);
+        manager.preview_finished.connect (on_preview_finished);
     }
 
     private void build_export_sidebar () {
-        var grid = new Gtk.Grid ();
-        grid.expand = true;
-        grid.column_spacing = 12;
-        grid.margin_start = grid.margin_end = grid.margin_bottom = 12;
-        grid.row_spacing = 6;
+        var grid = new Gtk.Grid () {
+            expand = true,
+            column_spacing = 12,
+            margin_start = 12,
+            margin_end = 12,
+            margin_bottom = 12,
+            row_spacing = 6
+        };
 
         // Folder location.
         grid.attach (section_title (_("Export to:")), 0, 0, 1, 1);
@@ -171,19 +173,20 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         file_format.append ("jpg", "JPG");
         file_format.changed.connect (update_format_ui);
         grid.attach (file_format, 1, 2, 1, 1);
-        settings.changed["export-format"].connect (() => {
-            manager.regenerate_pixbuf (export_type);
-        });
+        //  settings.changed["export-format"].connect (() => {
+        //      manager.regenerate_pixbuf (export_type);
+        //  });
 
         // Quality spinbutton.
         jpg_title = section_title (_("Quality:"));
         grid.attach (jpg_title, 0, 3, 1, 1);
 
         quality_adj = new Gtk.Adjustment (100.0, 0, 100.0, 0, 0, 0);
-        quality_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, quality_adj);
-        quality_scale.hexpand = true;
-        quality_scale.draw_value = true;
-        quality_scale.digits = 0;
+        quality_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, quality_adj) {
+            hexpand = true,
+            draw_value = true,
+            digits = 0
+        };
         grid.attach (quality_scale, 1, 3, 1, 1);
         settings.bind ("export-quality", quality_adj, "value", SettingsBindFlags.DEFAULT);
 
@@ -192,10 +195,11 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         grid.attach (png_title, 0, 4, 1, 1);
 
         compression_adj = new Gtk.Adjustment (0.0, 0, 9.0, 1, 0, 0);
-        compression_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, compression_adj);
-        compression_scale.hexpand = true;
-        compression_scale.draw_value = true;
-        compression_scale.digits = 0;
+        compression_scale = new Gtk.Scale (Gtk.Orientation.HORIZONTAL, compression_adj) {
+            hexpand = true,
+            draw_value = true,
+            digits = 0
+        };
         for (int i = 1; i <= 9; i++) {
             compression_scale.add_mark (i, Gtk.PositionType.BOTTOM, null);
         }
@@ -205,21 +209,23 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         alpha_title = section_title (_("Transparency:"));
         grid.attach (alpha_title, 0, 5, 1, 1);
 
-        alpha_switch = new Gtk.Switch ();
-        alpha_switch.valign = Gtk.Align.CENTER;
-        alpha_switch.halign = Gtk.Align.START;
+        alpha_switch = new Gtk.Switch () {
+            valign = Gtk.Align.CENTER,
+            halign = Gtk.Align.START
+        };
         grid.attach (alpha_switch, 1, 5, 1, 1);
         settings.bind ("export-alpha", alpha_switch, "active", SettingsBindFlags.DEFAULT);
-        settings.changed["export-alpha"].connect (() => {
-            manager.regenerate_pixbuf (export_type);
-        });
+        //  settings.changed["export-alpha"].connect (() => {
+        //      manager.regenerate_pixbuf (export_type);
+        //  });
 
         // Resolution.
         var size_title = section_title (_("Scale:"));
         grid.attach (size_title, 0, 6, 1, 1);
 
-        var scale_button = new Granite.Widgets.ModeButton ();
-        scale_button.halign = Gtk.Align.FILL;
+        var scale_button = new Granite.Widgets.ModeButton () {
+            halign = Gtk.Align.FILL
+        };
         scale_button.append_text ("0.5×");
         scale_button.append_text ("1×");
         scale_button.append_text ("2×");
@@ -227,31 +233,34 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         scale_button.set_active (settings.export_scale);
         settings.bind ("export-scale", scale_button, "selected", SettingsBindFlags.DEFAULT);
         grid.attach (scale_button, 1, 6, 1, 1);
-        settings.changed["export-scale"].connect (() => {
-            manager.regenerate_pixbuf (export_type);
-        });
+        //  settings.changed["export-scale"].connect (() => {
+        //      manager.regenerate_pixbuf (export_type);
+        //  });
 
         // Buttons.
-        var action_area = new Gtk.Grid ();
-        action_area.column_spacing = 6;
-        action_area.halign = Gtk.Align.END;
-        action_area.valign = Gtk.Align.END;
-        action_area.vexpand = true;
+        var action_area = new Gtk.Grid () {
+            column_spacing = 6,
+            halign = Gtk.Align.END,
+            valign = Gtk.Align.END,
+            vexpand = true
+        };
         grid.attach (action_area, 0, 7, 2, 1);
 
-        var cancel_button = new Gtk.Button.with_label (_("Cancel"));
-        cancel_button.halign = Gtk.Align.START;
+        var cancel_button = new Gtk.Button.with_label (_("Cancel")) {
+            halign = Gtk.Align.START
+        };
         action_area.add (cancel_button);
         cancel_button.clicked.connect (() => {
             close ();
         });
 
-        var export_button = new Gtk.Button.with_label (_("Export"));
+        var export_button = new Gtk.Button.with_label (_("Export")) {
+            halign = Gtk.Align.END
+        };
         export_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-        export_button.halign = Gtk.Align.END;
         action_area.add (export_button);
         export_button.clicked.connect (() => {
-            manager.export_images.begin ();
+            //  manager.export_images.begin ();
             close ();
         });
 
@@ -268,30 +277,31 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         alpha_switch.visible = (file_format.active_id == "png");
     }
 
-    public async void generate_export_preview () {
-        if (list_store.get_n_items () > 0) {
-            var array = manager.pixbufs.values.to_array ();
-            for (int i = 0; i < list_store.get_n_items () ; i++) {
-                var model = (Akira.Models.ExportModel) list_store.get_object (i);
-                model.pixbuf = array[i];
-            }
-            return;
-        }
+    //  public async void generate_export_preview () {
+    //      if (list_store.get_n_items () > 0) {
+    //          var array = manager.pixbufs.values.to_array ();
+    //          for (int i = 0; i < list_store.get_n_items () ; i++) {
+    //              var model = (Akira.Models.ExportModel) list_store.get_object (i);
+    //              model.pixbuf = array[i];
+    //          }
+    //          return;
+    //      }
 
-        foreach (var entry in manager.pixbufs.entries) {
-            var model = new Akira.Models.ExportModel (entry.value, entry.key);
-            list_store.append (model);
-        }
-    }
+    //      foreach (var entry in manager.pixbufs.entries) {
+    //          var model = new Akira.Models.ExportModel (entry.value, entry.key);
+    //          list_store.append (model);
+    //      }
+    //  }
 
     private Gtk.Label section_title (string title) {
-        var title_label = new Gtk.Label (title);
-        title_label.halign = Gtk.Align.END;
+        var title_label = new Gtk.Label (title) {
+            halign = Gtk.Align.END
+        };
 
         return title_label;
     }
 
-    private async void on_export_preview (string message) {
+    private async void on_generating_preview (string message) {
         overlaybar.label = message;
         overlaybar.visible = true;
         sidebar.@foreach ((child) => {
@@ -299,7 +309,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         });
     }
 
-    private async void on_preview_completed () {
+    private async void on_preview_finished () {
         sidebar.@foreach ((child) => {
             child.sensitive = true;
         });

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -184,7 +184,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         file_format.changed.connect (update_format_ui);
         grid.attach (file_format, 1, 2, 1, 1);
         settings.changed["export-format"].connect (() => {
-            manager.generate_preview ();
+            manager.generate_preview.begin ();
         });
 
         // Quality spinbutton.
@@ -233,7 +233,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         settings.bind ("export-alpha", alpha_switch, "active",
             SettingsBindFlags.DEFAULT | SettingsBindFlags.GET_NO_CHANGES);
         settings.changed["export-alpha"].connect (() => {
-            manager.generate_preview ();
+            manager.generate_preview.begin ();
         });
 
         // Resolution.
@@ -252,7 +252,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
             SettingsBindFlags.DEFAULT | SettingsBindFlags.GET_NO_CHANGES);
         grid.attach (scale_button, 1, 6, 1, 1);
         settings.changed["export-scale"].connect (() => {
-            manager.generate_preview ();
+            manager.generate_preview.begin ();
         });
 
         // Buttons.

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -174,9 +174,9 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         file_format.append ("jpg", "JPG");
         file_format.changed.connect (update_format_ui);
         grid.attach (file_format, 1, 2, 1, 1);
-        //  settings.changed["export-format"].connect (() => {
-        //      manager.regenerate_pixbuf (export_type);
-        //  });
+        settings.changed["export-format"].connect (() => {
+            manager.generate_preview ();
+        });
 
         // Quality spinbutton.
         jpg_title = section_title (_("Quality:"));
@@ -189,7 +189,10 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
             digits = 0
         };
         grid.attach (quality_scale, 1, 3, 1, 1);
-        settings.bind ("export-quality", quality_adj, "value", SettingsBindFlags.DEFAULT);
+        quality_scale.button_release_event.connect (() => {
+            settings.export_quality = (int) quality_adj.value;
+            return false;
+        });
 
         // Compression spinbutton.
         png_title = section_title (_("Compression:"));
@@ -205,7 +208,10 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
             compression_scale.add_mark (i, Gtk.PositionType.BOTTOM, null);
         }
         grid.attach (compression_scale, 1, 4, 1, 1);
-        settings.bind ("export-compression", compression_adj, "value", SettingsBindFlags.DEFAULT);
+        compression_scale.button_release_event.connect (() => {
+            settings.export_compression = (int) compression_adj.value;
+            return false;
+        });
 
         alpha_title = section_title (_("Transparency:"));
         grid.attach (alpha_title, 0, 5, 1, 1);
@@ -216,9 +222,9 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         };
         grid.attach (alpha_switch, 1, 5, 1, 1);
         settings.bind ("export-alpha", alpha_switch, "active", SettingsBindFlags.DEFAULT);
-        //  settings.changed["export-alpha"].connect (() => {
-        //      manager.regenerate_pixbuf (export_type);
-        //  });
+        settings.changed["export-alpha"].connect (() => {
+            manager.generate_preview ();
+        });
 
         // Resolution.
         var size_title = section_title (_("Scale:"));
@@ -234,9 +240,9 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         scale_button.set_active (settings.export_scale);
         settings.bind ("export-scale", scale_button, "selected", SettingsBindFlags.DEFAULT);
         grid.attach (scale_button, 1, 6, 1, 1);
-        //  settings.changed["export-scale"].connect (() => {
-        //      manager.regenerate_pixbuf (export_type);
-        //  });
+        settings.changed["export-scale"].connect (() => {
+            manager.generate_preview ();
+        });
 
         // Buttons.
         var action_area = new Gtk.Grid () {
@@ -261,8 +267,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         export_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         action_area.add (export_button);
         export_button.clicked.connect (() => {
-            //  manager.export_images.begin ();
-            close ();
+            manager.export_images.begin ();
         });
 
         sidebar.add (grid);
@@ -279,17 +284,9 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     }
 
     public async void on_show_preview (Gee.HashMap<int, Gdk.Pixbuf> pixbufs) {
-        //  if (list_store.get_n_items () > 0) {
-        //      var array = manager.pixbufs.values.to_array ();
-        //      for (int i = 0; i < list_store.get_n_items () ; i++) {
-        //          var model = (Akira.Models.ExportModel) list_store.get_object (i);
-        //          model.pixbuf = array[i];
-        //      }
-        //      return;
-        //  }
-
+        list_store.remove_all ();
         foreach (var entry in pixbufs.entries) {
-            var model = new Models.ExportModel (entry.value, entry.key);
+            var model = new Models.ExportModel (entry.key, entry.value);
             list_store.append (model);
         }
     }

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -289,11 +289,9 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         //  }
 
         foreach (var entry in pixbufs.entries) {
-            var model = new Akira.Models.ExportModel (entry.value, entry.key);
+            var model = new Models.ExportModel (entry.value, entry.key);
             list_store.append (model);
         }
-
-        print ("Generated!");
     }
 
     private Gtk.Label section_title (string title) {

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -133,7 +133,10 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         });
 
         settings.bind ("export-paned", pane, "position", SettingsBindFlags.DEFAULT);
-        settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
+        // GTK issue: combobox need to be added to a parent and be visible before
+        // we can use bind () to prevent a critical error.
+        settings.bind ("export-format", file_format, "active_id",
+            SettingsBindFlags.DEFAULT | GLib.SettingsBindFlags.GET_NO_CHANGES);
 
         manager.generating_preview.connect (on_generating_preview);
         manager.show_preview.connect (on_show_preview);
@@ -221,7 +224,8 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
             halign = Gtk.Align.START
         };
         grid.attach (alpha_switch, 1, 5, 1, 1);
-        settings.bind ("export-alpha", alpha_switch, "active", SettingsBindFlags.DEFAULT);
+        settings.bind ("export-alpha", alpha_switch, "active",
+            SettingsBindFlags.DEFAULT | SettingsBindFlags.GET_NO_CHANGES);
         settings.changed["export-alpha"].connect (() => {
             manager.generate_preview ();
         });
@@ -238,7 +242,8 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         scale_button.append_text ("2×");
         scale_button.append_text ("4×");
         scale_button.set_active (settings.export_scale);
-        settings.bind ("export-scale", scale_button, "selected", SettingsBindFlags.DEFAULT);
+        settings.bind ("export-scale", scale_button, "selected",
+            SettingsBindFlags.DEFAULT | SettingsBindFlags.GET_NO_CHANGES);
         grid.attach (scale_button, 1, 6, 1, 1);
         settings.changed["export-scale"].connect (() => {
             manager.generate_preview ();

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -136,6 +136,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         settings.bind ("export-format", file_format, "active_id", SettingsBindFlags.DEFAULT);
 
         manager.generating_preview.connect (on_generating_preview);
+        manager.show_preview.connect (on_show_preview);
         manager.preview_finished.connect (on_preview_finished);
     }
 
@@ -277,21 +278,23 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         alpha_switch.visible = (file_format.active_id == "png");
     }
 
-    //  public async void generate_export_preview () {
-    //      if (list_store.get_n_items () > 0) {
-    //          var array = manager.pixbufs.values.to_array ();
-    //          for (int i = 0; i < list_store.get_n_items () ; i++) {
-    //              var model = (Akira.Models.ExportModel) list_store.get_object (i);
-    //              model.pixbuf = array[i];
-    //          }
-    //          return;
-    //      }
+    public async void on_show_preview (Gee.HashMap<int, Gdk.Pixbuf> pixbufs) {
+        //  if (list_store.get_n_items () > 0) {
+        //      var array = manager.pixbufs.values.to_array ();
+        //      for (int i = 0; i < list_store.get_n_items () ; i++) {
+        //          var model = (Akira.Models.ExportModel) list_store.get_object (i);
+        //          model.pixbuf = array[i];
+        //      }
+        //      return;
+        //  }
 
-    //      foreach (var entry in manager.pixbufs.entries) {
-    //          var model = new Akira.Models.ExportModel (entry.value, entry.key);
-    //          list_store.append (model);
-    //      }
-    //  }
+        foreach (var entry in pixbufs.entries) {
+            var model = new Akira.Models.ExportModel (entry.value, entry.key);
+            list_store.append (model);
+        }
+
+        print ("Generated!");
+    }
 
     private Gtk.Label section_title (string title) {
         var title_label = new Gtk.Label (title) {

--- a/src/Layouts/LayersList/LayerListItem.vala
+++ b/src/Layouts/LayersList/LayerListItem.vala
@@ -77,7 +77,7 @@ public class Akira.Layouts.LayersList.LayerListItem : VirtualizingListBoxRow {
         };
         icon.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
-        label = new Gtk.Label ("") {
+        label = new Gtk.Label (null) {
             halign = Gtk.Align.FILL,
             xalign = 0,
             expand = true,

--- a/src/Layouts/MainViewCanvas.vala
+++ b/src/Layouts/MainViewCanvas.vala
@@ -44,7 +44,7 @@ public class Akira.Layouts.MainViewCanvas : Gtk.Grid {
         get_style_context ().add_class ("main-canvas");
 
         main_overlay = new Gtk.Overlay ();
-        notification = new Granite.Widgets.Toast (_(""));
+        notification = new Granite.Widgets.Toast ("");
 
         main_scroll = new Gtk.ScrolledWindow (null, null);
         main_scroll.expand = true;

--- a/src/Layouts/MainViewCanvas.vala
+++ b/src/Layouts/MainViewCanvas.vala
@@ -31,6 +31,7 @@ public class Akira.Layouts.MainViewCanvas : Gtk.Grid {
     public weak Akira.Window window { get; construct; }
 
     private Gtk.Overlay main_overlay;
+    private Granite.Widgets.Toast notification;
 
     private double scroll_origin_x = 0;
     private double scroll_origin_y = 0;
@@ -43,6 +44,7 @@ public class Akira.Layouts.MainViewCanvas : Gtk.Grid {
         get_style_context ().add_class ("main-canvas");
 
         main_overlay = new Gtk.Overlay ();
+        notification = new Granite.Widgets.Toast (_(""));
 
         main_scroll = new Gtk.ScrolledWindow (null, null);
         main_scroll.expand = true;
@@ -90,6 +92,7 @@ public class Akira.Layouts.MainViewCanvas : Gtk.Grid {
         main_scroll.add (canvas);
 
         main_overlay.add (main_scroll);
+        main_overlay.add_overlay (notification);
 
         add (main_overlay);
     }
@@ -113,5 +116,14 @@ public class Akira.Layouts.MainViewCanvas : Gtk.Grid {
         main_scroll.hadjustment.value += delta_x * 10;
         main_scroll.vadjustment.value += delta_y * 10;
         return true;
+    }
+
+    /**
+     * Pass a simple string message and trigger the Granite.Toast notification
+     * At the top of the Canvas.
+     */
+    public void trigger_notification (string message) {
+        notification.title = message;
+        notification.send_notification ();
     }
 }

--- a/src/Lib/Components/Borders.vala
+++ b/src/Lib/Components/Borders.vala
@@ -176,4 +176,18 @@ public class Akira.Lib.Components.Borders : Component, Copyable<Borders> {
         data.resize (data.length - 1);
         return true;
     }
+
+    /*
+     * Helper method used to retrieve the size of the thickest visible border.
+     */
+    public double get_border_width () {
+        double size = 0;
+        foreach (unowned var border in data) {
+            if (border.hidden) {
+                continue;
+            }
+            size = double.max (size, border.size);
+        }
+        return size;
+    }
 }

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -33,7 +33,6 @@ public class Akira.Lib.Managers.ExportManager : Object {
     private Type export_type;
 
     public unowned Akira.Lib.ViewCanvas canvas { get; construct; }
-    public Akira.Dialogs.ExportDialog export_dialog;
 
     private Cairo.Format format;
     private Cairo.ImageSurface? surface = null;
@@ -105,30 +104,36 @@ public class Akira.Lib.Managers.ExportManager : Object {
             bounds.left = left;
             bounds.right = right;
 
+            double width = bounds.width;
+            double height = bounds.height;
+            scale_surface (ref width, ref height);
+
             // Create the rendered image with Cairo.
             surface = new Cairo.ImageSurface (
                 format,
-                (int) Math.round (bounds.width),
-                (int) Math.round (bounds.height)
+                (int) Math.round (width),
+                (int) Math.round (height)
             );
             context = new Cairo.Context (surface);
-
-            // Move the context to the right coordinates.
-            context.translate (-left, -top);
-
-            // Render what's currently on the canvas inside those coordinates.
-            canvas.draw_model (context, bounds);
 
             // Draw a white background if JPG export.
             if (settings.export_format == "jpg" || !settings.export_alpha) {
                 context.set_source_rgba (1, 1, 1, 1);
                 context.rectangle (
                     0, 0,
-                    (int) Math.round (bounds.width),
-                    (int) Math.round (bounds.height)
+                    (int) Math.round (width),
+                    (int) Math.round (height)
                 );
                 context.fill ();
             }
+
+            scale_context (ref context);
+
+            // Move the context to the right coordinates.
+            context.translate (-left, -top);
+
+            // Render what's currently on the canvas inside those coordinates.
+            canvas.draw_model (context, bounds);
 
             // Create pixbuf from stream.
             try {
@@ -145,10 +150,8 @@ public class Akira.Lib.Managers.ExportManager : Object {
                 }
                 return Cairo.Status.SUCCESS;
             });
-            // TODO: Image scaling should happen in the canvas before generating
-            // the pixbufs in order to avoid pixelated previews if we're only
-            // dealing with vector nodes.
-            var scaled = rescale_image (loader.get_pixbuf (), bounds);
+            //  var scaled = rescale_image (loader.get_pixbuf (), bounds);
+            var scaled = loader.get_pixbuf ();
 
             try {
                 loader.close ();
@@ -160,51 +163,55 @@ public class Akira.Lib.Managers.ExportManager : Object {
         }
     }
 
-    public Gdk.Pixbuf rescale_image (Gdk.Pixbuf pixbuf, Geometry.Rectangle bounds) {
-        Gdk.Pixbuf scaled_image;
-
+    private void scale_surface (ref double width, ref double height) {
         switch (settings.export_scale) {
             case 0:
-                scaled_image = pixbuf.scale_simple (
-                    (int) bounds.width / 2,
-                    (int) bounds.height / 2,
-                    Gdk.InterpType.BILINEAR
-                );
+                width = width / 2;
+                height = height / 2;
                 break;
 
             case 2:
-                scaled_image = pixbuf.scale_simple (
-                    (int) bounds.width * 2,
-                    (int) bounds.height * 2,
-                    Gdk.InterpType.BILINEAR
-                );
+                width = width * 2;
+                height = height * 2;
                 break;
 
             case 3:
-                scaled_image = pixbuf.scale_simple (
-                    (int) bounds.width * 4,
-                    (int) bounds.height * 4,
-                    Gdk.InterpType.BILINEAR
-                );
+                width = width * 4;
+                height = height * 4;
                 break;
 
             default:
-                scaled_image = pixbuf.scale_simple (
-                    (int) bounds.width * 1,
-                    (int) bounds.height * 1,
-                    Gdk.InterpType.BILINEAR
-                );
+                width = width * 1;
+                height = height * 1;
                 break;
         }
+    }
 
-        return scaled_image;
+    private void scale_context (ref Cairo.Context context) {
+        switch (settings.export_scale) {
+            case 0:
+                context.scale (0.5, 0.5);
+                break;
+
+            case 2:
+                context.scale (2, 2);
+                break;
+
+            case 3:
+                context.scale (4, 4);
+                break;
+
+            default:
+                context.scale (1, 1);
+                break;
+        }
     }
 
     private void trigger_export_dialog () {
         // Disable all those accels interfering with regular typing.
         canvas.window.event_bus.disconnect_typing_accel ();
 
-        export_dialog = new Akira.Dialogs.ExportDialog (canvas, this);
+        var export_dialog = new Akira.Dialogs.ExportDialog (canvas, this);
         export_dialog.show_all ();
         export_dialog.present ();
 

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -90,7 +90,7 @@ public class Akira.Lib.Managers.ExportManager : Object {
                 // Currently we only support centered border as per SVG specs, but
                 // in the future we will support internal and external border types
                 // so we will need to account for those.
-                border_size = size > 0 ? Math.round (size / 2) : 0;
+                border_size = size > 0 ? size / 2 : 0;
             }
 
             var top = inst.bounding_box.top - border_size;
@@ -241,7 +241,6 @@ public class Akira.Lib.Managers.ExportManager : Object {
         TODO:
          - Implement filenames and don't allow exporting without one.
          - Detect overwriting of existing files.
-         - Handle confirmation message in the dialog.
          - Handle error messages in the dialog.
         */
         generating_preview (_("Exporting images…"));

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2022 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+ */
+
+public class Akira.Lib.Managers.ExportManager : Object {
+    public signal void generating_preview (string message);
+    public signal void preview_finished ();
+
+    public enum Type {
+        AREA,
+        SELECTION,
+        ARTBOARD
+    }
+
+    public unowned Akira.Lib.ViewCanvas canvas { get; construct; }
+    public Akira.Dialogs.ExportDialog export_dialog;
+
+    private Cairo.Format format;
+    private Cairo.ImageSurface? surface = null;
+    private Cairo.Context? context = null;
+    private Gdk.PixbufLoader loader;
+    private Gee.HashMap<int, Gdk.Pixbuf> pixbufs;
+
+    public ExportManager (Lib.ViewCanvas view_canvas) {
+        Object (canvas: view_canvas);
+        pixbufs = new Gee.HashMap<int, Gdk.Pixbuf> ();
+    }
+
+    public void export_selection () {
+        trigger_export_dialog ();
+        // TODO: Generate the image from the current selection
+        generating_preview (_("Generating preview, please wait…"));
+        init_generate_preview ();
+        preview_finished ();
+    }
+
+    private void init_generate_preview () {
+        pixbufs.clear ();
+
+        if (settings.export_format == "png") {
+            format = Cairo.Format.ARGB32;
+        } else if (settings.export_format == "jpg") {
+            format = Cairo.Format.RGB24;
+        }
+    }
+
+    private void trigger_export_dialog () {
+        // Disable all those accels interfering with regular typing.
+        canvas.window.event_bus.disconnect_typing_accel ();
+
+        export_dialog = new Akira.Dialogs.ExportDialog (canvas, this);
+        export_dialog.show_all ();
+        export_dialog.present ();
+
+        // Update the dialog UI based on the stored gsettings options.
+        export_dialog.update_format_ui ();
+
+        export_dialog.close.connect (() => {
+            // Store the dialog size into gsettings so users don't get upset.
+            int width, height;
+            export_dialog.get_size (out width, out height);
+            settings.export_width = width;
+            settings.export_height = height;
+
+            // Enable accels again.
+            canvas.window.event_bus.connect_typing_accel ();
+            canvas.window.event_bus.set_focus_on_canvas ();
+
+            // Clean up.
+            context = null;
+            surface.finish ();
+            surface = null;
+        });
+    }
+}

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -790,13 +790,13 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
         }
     }
 
-    public void export_selection () {
+    public async void export_selection () {
         if (selection_manager.selection.is_empty ()) {
             window.main_window.main_view_canvas.trigger_notification (_("Nothing selected to export!"));
             return;
         }
 
         init_export_manager ();
-        export_manager.export_selection ();
+        yield export_manager.export_selection ();
     }
 }

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -43,6 +43,7 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
     public Lib.Managers.SnapManager snap_manager;
     public Lib.Managers.CopyManager copy_manager;
     public Lib.Managers.HistoryManager history_manager;
+    private Lib.Managers.ExportManager? export_manager = null;
 
     private bool is_modifier_pressed (Gdk.ModifierIntent type) {
         Gdk.ModifierType state;
@@ -779,5 +780,23 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
      */
     private void on_items_removed (GLib.Array<int> ids) {
         window.main_window.remove_layers (ids);
+    }
+
+    /* EXPORT METHODS */
+
+    private void init_export_manager () {
+        if (export_manager == null) {
+            export_manager = new Lib.Managers.ExportManager (this);
+        }
+    }
+
+    public void export_selection () {
+        if (selection_manager.selection.is_empty ()) {
+            window.main_window.main_view_canvas.trigger_notification (_("Nothing selected to export!"));
+            return;
+        }
+
+        init_export_manager ();
+        export_manager.export_selection ();
     }
 }

--- a/src/Models/ExportModel.vala
+++ b/src/Models/ExportModel.vala
@@ -21,16 +21,16 @@
 
 public class Akira.Models.ExportModel : GLib.Object {
     public Gdk.Pixbuf pixbuf { get; set construct; }
-    public string filename { get; set construct; }
+    public int node_id { get; set construct; }
 
-    public ExportModel (Gdk.Pixbuf pixbuf, string filename) {
+    public ExportModel (Gdk.Pixbuf pixbuf, int node_id) {
         Object (
             pixbuf: pixbuf,
-            filename: filename
+            node_id: node_id
         );
     }
 
     public string to_string () {
-        return "Filename: %s".printf (filename);
+        return "Node ID: %i".printf (node_id);
     }
 }

--- a/src/Models/ExportModel.vala
+++ b/src/Models/ExportModel.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2020 Alecaddd (https://alecaddd.com)
+* Copyright (c) 2020-2022 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -20,15 +20,18 @@
 */
 
 public class Akira.Models.ExportModel : GLib.Object {
-    public Gdk.Pixbuf pixbuf { get; set construct; }
     public int node_id { get; set construct; }
+    public Gdk.Pixbuf pixbuf { get; set construct; }
 
-    public ExportModel (Gdk.Pixbuf pixbuf, int node_id) {
+    public ExportModel (int node_id, Gdk.Pixbuf pixbuf) {
         Object (
             pixbuf: pixbuf,
             node_id: node_id
         );
     }
+
+    /* TODO: Allow udpating the export name of nodes, and also handle the
+    temporary export name for area selection exports. */
 
     public string to_string () {
         return "Node ID: %i".printf (node_id);

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -317,13 +317,7 @@ public class Akira.Services.ActionManager : Object {
 
     private void action_export_selection () {
         unowned Akira.Lib.ViewCanvas canvas = window.main_window.main_view_canvas.canvas;
-        unowned var sm = canvas.selection_manager;
-        if (sm.selection.is_empty ()) {
-            window.main_window.main_view_canvas.trigger_notification (_("Nothing selected to export!"));
-            return;
-        }
-
-        // canvas.export_manager.create_selection_snapshot ();
+        canvas.export_selection ();
     }
 
     private void action_export_artboards () {

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -316,19 +316,19 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_export_selection () {
-        // weak Akira.Lib.Canvas canvas = window.main_window.main_canvas.canvas;
-        // if (canvas.selected_bound_manager.selected_items.length () == 0) {
-        //     // Check if an element is currently selected.
-        //     window.event_bus.canvas_notification (_("Nothing selected to export!"));
-        //     return;
-        // }
+        unowned Akira.Lib.ViewCanvas canvas = window.main_window.main_view_canvas.canvas;
+        unowned var sm = canvas.selection_manager;
+        if (sm.selection.is_empty ()) {
+            window.main_window.main_view_canvas.trigger_notification (_("Nothing selected to export!"));
+            return;
+        }
 
         // canvas.export_manager.create_selection_snapshot ();
     }
 
     private void action_export_artboards () {
         // Check if at least an artboard is present.
-        window.event_bus.canvas_notification (_("Export of Artboards currently unavailable…sorry 😑️"));
+        window.main_window.main_view_canvas.trigger_notification (_("Export of Artboards currently unavailable…sorry 😑️"));
         // TODO: Trigger artboards pixbuf generation.
     }
 

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -317,7 +317,7 @@ public class Akira.Services.ActionManager : Object {
 
     private void action_export_selection () {
         unowned Akira.Lib.ViewCanvas canvas = window.main_window.main_view_canvas.canvas;
-        canvas.export_selection ();
+        canvas.export_selection.begin ();
     }
 
     private void action_export_artboards () {

--- a/src/Utils/Dialogs.vala
+++ b/src/Utils/Dialogs.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2019-2023 Alecaddd (https://alecaddd.com)
 *
 * This file is part of Akira.
 *
@@ -10,11 +10,11 @@
 
 * Akira is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU General Public License for more details.
 
 * You should have received a copy of the GNU General Public License
-* along with Akira.  If not, see <https://www.gnu.org/licenses/>.
+* along with Akira. If not, see <https://www.gnu.org/licenses/>.
 *
 * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
 */
@@ -32,7 +32,7 @@ public class Akira.Utils.Dialogs : Object {
         string title,
         string description,
         string icon,
-        string primary_button,
+        string? primary_button = null,
         string? secondary_button = null
     ) {
         var dialog = new Granite.MessageDialog.with_image_from_icon_name (
@@ -45,9 +45,11 @@ public class Akira.Utils.Dialogs : Object {
             dialog.add_action_widget (button2, 2);
         }
 
-        var button = new Gtk.Button.with_label (primary_button);
-        button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
-        dialog.add_action_widget (button, Gtk.ResponseType.ACCEPT);
+        if (primary_button != null) {
+            var button = new Gtk.Button.with_label (primary_button);
+            button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+            dialog.add_action_widget (button, Gtk.ResponseType.ACCEPT);
+        }
 
         return dialog;
     }

--- a/src/ViewLayers/BaseCanvas.vala
+++ b/src/ViewLayers/BaseCanvas.vala
@@ -660,6 +660,6 @@ public class Akira.ViewLayers.BaseCanvas : Gtk.Widget , Gtk.Scrollable {
      * Render target bounds to a cairo context.
      */
     public void render (Cairo.Context context, Geometry.Rectangle bounds, double scale) {
-        // TODO
+        // TODO: This is needed for export purpose.
     }
 }

--- a/src/ViewLayers/BaseCanvas.vala
+++ b/src/ViewLayers/BaseCanvas.vala
@@ -655,11 +655,4 @@ public class Akira.ViewLayers.BaseCanvas : Gtk.Widget , Gtk.Scrollable {
     public void toggle_layer_visibility (string layer_id, bool visibility) {
         overlays[layer_id].set_visible (visibility);
     }
-
-    /*
-     * Render target bounds to a cairo context.
-     */
-    public void render (Cairo.Context context, Geometry.Rectangle bounds, double scale) {
-        // TODO: This is needed for export purpose.
-    }
 }

--- a/src/Widgets/ExportWidget.vala
+++ b/src/Widgets/ExportWidget.vala
@@ -44,7 +44,7 @@ public class Akira.Widgets.ExportWidget : Gtk.Grid {
         expand = true;
 
         // Label for image size info. We need to create this before calling get_image ().
-        info = new Gtk.Label ("") {
+        info = new Gtk.Label (null) {
             hexpand = false,
             halign = Gtk.Align.END
         };

--- a/src/Widgets/ExportWidget.vala
+++ b/src/Widgets/ExportWidget.vala
@@ -69,8 +69,8 @@ public class Akira.Widgets.ExportWidget : Gtk.Grid {
         input.get_style_context ().add_class ("export-filename");
         input.width_chars = 10;
         input.hexpand = true;
-        model.bind_property ("filename", input, "text",
-            BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
+        //  model.bind_property ("filename", input, "text",
+        //      BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
 
         attach (input, 0, 0);
         attach (info, 1, 0);

--- a/src/Widgets/ExportWidget.vala
+++ b/src/Widgets/ExportWidget.vala
@@ -104,13 +104,10 @@ public class Akira.Widgets.ExportWidget : Gtk.Grid {
     public async void update_file_size () {
         yield get_image_buffer_size ();
 
-        double bytes = (double) imagedata.length;
-        double full_bytes = imagedata.length > MB ? bytes / MB : bytes / KB;
-        var size = imagedata.length > MB
-            ? ("%0.1fMB").printf (full_bytes)
-            : ("%0.1fKB").printf (full_bytes);
-
-        info.label = _("%i × %i px · %s").printf (model.pixbuf.width, model.pixbuf.height, size);
+        info.label = _("%i × %i px · %s").printf (
+            model.pixbuf.width,
+            model.pixbuf.height,
+            format_size (imagedata.length));
     }
 
     private async void get_image_buffer_size () {

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -54,6 +54,7 @@ public class Akira.Window : Gtk.ApplicationWindow {
         headerbar = new Akira.Layouts.HeaderBar (this);
         file_manager = new Akira.FileFormat.FileManager (this);
         main_window = new Akira.Layouts.MainWindow (this);
+        dialogs = new Akira.Utils.Dialogs (this);
 
         build_ui ();
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -78,7 +78,7 @@ sources = files(
     'Widgets/ColorChooser.vala',
     'Widgets/ColorField.vala',
     'Widgets/ColorPicker.vala',
-    #'Widgets/ExportWidget.vala',
+    'Widgets/ExportWidget.vala',
     'Widgets/EyeDropperButton.vala',
     'Widgets/HeaderBarButton.vala',
     'Widgets/HideButton.vala',
@@ -104,13 +104,13 @@ sources = files(
     'ViewLayers/ViewLayerMultiSelect.vala',
 
     'Models/ColorModel.vala',
-    #'Models/ExportModel.vala',
+    'Models/ExportModel.vala',
     #'Models/ListModel.vala',
     'Models/PathEditModel.vala',
 
     'Dialogs/ShortcutsDialog.vala',
     'Dialogs/SettingsDialog.vala',
-    #'Dialogs/ExportDialog.vala',
+    'Dialogs/ExportDialog.vala',
     'Dialogs/ReleaseDialog.vala',
 
     'Drawables/Drawable.vala',
@@ -155,6 +155,7 @@ sources = files(
     'Lib/Items/ModelTypeText.vala',
 
     'Lib/Managers/CopyManager.vala',
+    'Lib/Managers/ExportManager.vala',
     'Lib/Managers/HistoryManager.vala',
     'Lib/Managers/ItemsManager.vala',
     'Lib/Managers/ModeManager.vala',


### PR DESCRIPTION
## Re-implement the Export feature

Add back the export feature to allow exporting the current selection or an arbitrary area in JPG and PNG formats.

### Screenshot
![Screenshot from 2022-12-23 17-21-01](https://user-images.githubusercontent.com/2527103/209416712-7dca8eca-0fc3-45fa-92cf-e13b79ee961b.png)

### Implements
- Export current selection
- Export multiple selected nodes as separate
- Export in JPG and PNG formats
- Handle overwrites and existing files

### ToDo for the next PR
- Export Artboards
- Grab area to export
- Implement a `FileName` attributes for the nodes so we can maintain it

Partially handles #733, but not entirely. 
