### PR TITLE
Implement export area selection

### DIFF
--- a/src/Lib/Modes/ExportMode.vala
+++ b/src/Lib/Modes/ExportMode.vala
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2023 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+ */
+
+public class Akira.Lib.Modes.ExportMode : AbstractInteractionMode {
+    public unowned Lib.ViewCanvas view_canvas { get; construct; }
+
+    public class DragItemData : Object {
+        public Lib.Components.CompiledGeometry item_geometry;
+    }
+
+    public class InitialDragState : Object {
+        public double press_x;
+        public double press_y;
+
+        // initial_selection_data
+        public Geometry.Quad area;
+
+        public Gee.HashMap<int, DragItemData> item_data_map;
+
+        construct {
+            item_data_map = new Gee.HashMap<int, DragItemData> ();
+        }
+    }
+
+    private InitialDragState initial_drag_state;
+    private ViewLayers.ViewLayerExportArea export_area_layer;
+
+    public ExportMode (Akira.Lib.ViewCanvas canvas) {
+        Object (view_canvas: canvas);
+
+        initial_drag_state = new InitialDragState ();
+    }
+
+    construct {
+        export_area_layer = new ViewLayers.ViewLayerExportArea ();
+    }
+
+    public override void mode_begin () {
+        export_area_layer.add_to_canvas (ViewLayers.ViewLayer.EXPORT_AREA_LAYER_ID, view_canvas);
+    }
+
+    public override void mode_end () {}
+
+    public override AbstractInteractionMode.ModeType mode_type () {
+        return AbstractInteractionMode.ModeType.EXPORT;
+    }
+
+    public override Gdk.CursorType? cursor_type () {
+        return Gdk.CursorType.CROSSHAIR;
+    }
+
+    public override bool key_press_event (Gdk.EventKey event) {
+        return true;
+    }
+
+    public override bool key_release_event (Gdk.EventKey event) {
+        return false;
+    }
+
+    public override bool button_press_event (Gdk.EventButton event) {
+        initial_drag_state.press_x = event.x;
+        initial_drag_state.press_y = event.y;
+
+        export_area_layer.create_region (event);
+
+        return true;
+    }
+
+    public override bool button_release_event (Gdk.EventButton event) {
+        var area = export_area_layer.get_region_bounds ();
+        view_canvas.export_area.begin (area);
+
+        export_area_layer.remove_region ();
+
+        request_deregistration (mode_type ());
+        return true;
+    }
+
+    public override bool motion_notify_event (Gdk.EventMotion event) {
+        var width = event.x - initial_drag_state.press_x;
+        var height = event.y - initial_drag_state.press_y;
+
+        export_area_layer.update_region (width, height);
+
+        return true;
+    }
+
+    public override Object? extra_context () {
+        return null;
+    }
+}

--- a/src/Lib/Modes/ExportMode.vala
+++ b/src/Lib/Modes/ExportMode.vala
@@ -57,7 +57,9 @@ public class Akira.Lib.Modes.ExportMode : AbstractInteractionMode {
         export_area_layer.add_to_canvas (ViewLayers.ViewLayer.EXPORT_AREA_LAYER_ID, view_canvas);
     }
 
-    public override void mode_end () {}
+    public override void mode_end () {
+        export_area_layer.remove_region ();
+    }
 
     public override AbstractInteractionMode.ModeType mode_type () {
         return AbstractInteractionMode.ModeType.EXPORT;

--- a/src/Lib/ViewCanvas.vala
+++ b/src/Lib/ViewCanvas.vala
@@ -799,4 +799,14 @@ public class Akira.Lib.ViewCanvas : ViewLayers.BaseCanvas {
         init_export_manager ();
         yield export_manager.export_selection ();
     }
+
+    public async void export_area (Geometry.Rectangle area) {
+        if (area.width == 0 || area.height == 0) {
+            window.main_window.main_view_canvas.trigger_notification (_("Unable to export the selected area!"));
+            return;
+        }
+
+        init_export_manager ();
+        yield export_manager.export_area (area);
+    }
 }

--- a/src/Services/ActionManager.vala
+++ b/src/Services/ActionManager.vala
@@ -327,8 +327,9 @@ public class Akira.Services.ActionManager : Object {
     }
 
     private void action_export_grab () {
-        // weak Akira.Lib.Canvas canvas = window.main_window.main_canvas.canvas;
-        // canvas.start_export_area_selection ();
+        unowned Akira.Lib.ViewCanvas canvas = window.main_window.main_view_canvas.canvas;
+        var new_mode = new Lib.Modes.ExportMode (canvas);
+        canvas.mode_manager.register_mode (new_mode);
     }
 
     private void action_zoom_in () {

--- a/src/ViewLayers/ViewLayer.vala
+++ b/src/ViewLayers/ViewLayer.vala
@@ -44,6 +44,7 @@ public class Akira.ViewLayers.ViewLayer : Object {
     public const string GRID_LAYER_ID = "88_grid_layer";
     public const string ANCHOR_LAYER_ID = "78_anchor_layer";
     public const string HOVER_LAYER_ID = "77_hover_layer";
+    public const string EXPORT_AREA_LAYER_ID = "76_export_layer";
     public const string MULTI_SELECT_LAYER_ID = "76_multiselect_layer";
     // at a time, only one of nobs and path layer will be shown.
     // so they have equal priority

--- a/src/ViewLayers/ViewLayerExportArea.vala
+++ b/src/ViewLayers/ViewLayerExportArea.vala
@@ -88,7 +88,7 @@ public class Akira.ViewLayers.ViewLayerExportArea : ViewLayer {
         drawable.fill_rgba = fill;
         drawable.line_width = UI_LINE_WIDTH / scale;
         drawable.stroke_rgba = stroke;
-        context.set_dash ({10, 5}, 10 / scale);
+        context.set_dash ({10 / scale, 5 / scale}, 10 / scale);
         drawable.paint (context, target_bounds, scale, Drawables.Drawable.DrawType.NORMAL);
 
         last_drawn_bb = drawable.bounds;

--- a/src/ViewLayers/ViewLayerExportArea.vala
+++ b/src/ViewLayers/ViewLayerExportArea.vala
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2023 Alecaddd (https://alecaddd.com)
+ *
+ * This file is part of Akira.
+ *
+ * Akira is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Akira is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with Akira. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Authored by: Alessandro "Alecaddd" Castellani <castellani.ale@gmail.com>
+ */
+
+public class Akira.ViewLayers.ViewLayerExportArea : ViewLayer {
+    private const double UI_LINE_WIDTH = 2.0;
+    private Gdk.RGBA fill { get; default = Gdk.RGBA () { red = 0.25, green = 0.79, blue = 0.98, alpha = 0.2 }; }
+    private Gdk.RGBA stroke {
+        get {
+            var color = fill;
+            color.alpha = 1;
+            return color;
+        }
+    }
+
+    private Drawables.Drawable? drawable = null;
+    private Drawables.Drawable? old_drawable = null;
+    private Geometry.Rectangle last_drawn_bb = Geometry.Rectangle.empty ();
+
+    private double initial_press_x;
+    private double initial_press_y;
+
+    public void create_region (Gdk.EventButton event) {
+        initial_press_x = event.x;
+        initial_press_y = event.y;
+
+        drawable = new Drawables.DrawableRect (event.x, event.y, 0, 0);
+    }
+
+    public void update_region (double width, double height) {
+        // Bail out if we just entered the export mode but no click was registered
+        // on the canvas, meaning the drawable area hasn't been created yet.
+        if (drawable == null) {
+            return;
+        }
+
+        var center_x = initial_press_x + width / 2;
+        var center_y = initial_press_y + height / 2;
+
+        drawable.center_x = center_x;
+        drawable.center_y = center_y;
+        drawable.width = width;
+        drawable.height = height;
+
+        old_drawable = drawable;
+
+        drawable.bounds = Geometry.Rectangle.with_coordinates (
+            initial_press_x,
+            initial_press_y,
+            initial_press_x + width,
+            initial_press_y + height
+        );
+
+        update ();
+    }
+
+    public void remove_region () {
+        update ();
+        drawable = null;
+    }
+
+    public Geometry.Rectangle? get_region_bounds () {
+        return drawable.bounds;
+    }
+
+    public override void draw_layer (Cairo.Context context, Geometry.Rectangle target_bounds, double scale) {
+        if (canvas == null || drawable == null) {
+            return;
+        }
+
+        drawable.fill_rgba = fill;
+        drawable.line_width = UI_LINE_WIDTH / scale;
+        drawable.stroke_rgba = stroke;
+        context.set_dash ({10, 5}, 10 / scale);
+        drawable.paint (context, target_bounds, scale, Drawables.Drawable.DrawType.NORMAL);
+
+        last_drawn_bb = drawable.bounds;
+    }
+
+    public override void update () {
+        if (canvas == null) {
+            return;
+        }
+
+        if (old_drawable != null) {
+            canvas.request_redraw (last_drawn_bb);
+        }
+
+        if (drawable != null) {
+            canvas.request_redraw (drawable.bounds);
+        }
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -99,6 +99,7 @@ sources = files(
     'ViewLayers/ViewLayerSnaps.vala',
     'ViewLayers/ViewLayerNobs.vala',
     'ViewLayers/ViewLayerHover.vala',
+    'ViewLayers/ViewLayerExportArea.vala',
     'ViewLayers/ViewLayerGrid.vala',
     'ViewLayers/ViewLayerPath.vala',
     'ViewLayers/ViewLayerMultiSelect.vala',


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Re-implement the ability to select an arbitrary area on the canvas to generate a quick export snapshot.

## Steps to Test
- Use the `Export` header bar button or use the shortcut.
- Highlight an area on the canvas.
- Ensure the export dialog shows the correct area and changing settings maintains the defined bounds.

## Screenshots 
[export-area.webm](https://user-images.githubusercontent.com/2527103/210911572-842c3dc5-8f02-41af-b57e-30d2d68ba998.webm)

## Known Issues / Things To Do
- Filenames are still not implemented, will do in the next PR.

## This PR fixes/implements the following **bugs/features**:
Partially addresses #740
