### PR TITLE
Implement filename for exports

### DIFF
--- a/data/css/layout.css
+++ b/data/css/layout.css
@@ -102,19 +102,6 @@
     border: none;
 }
 
-.input-button {
-    padding: 0 2pt;
-    margin: 0;
-}
-
-.input-button.up {
-    margin-bottom: -2pt;
-}
-
-.input-button.down {
-    margin-top: -2pt;
-}
-
 paned > separator {
     min-width: 1px;
     margin-right: 0;
@@ -129,10 +116,14 @@ paned > separator {
     background-color: transparent;
 }
 
-.export-filename {
-    background: none;
-    border: none;
-    box-shadow: none;
+.export-widget {
+    background-color: shade (@bg_color, 0.98);
+    padding: 9px;
+    border-radius: 4px;
+}
+
+.export-image {
+    border: 1px solid shade (@bg_color, 0.85);
 }
 
 .export-info {

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -38,6 +38,8 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     public Gtk.Label alpha_title;
     public Gtk.Switch alpha_switch;
 
+    private Gtk.Button export_button;
+
     private Gtk.Overlay main_overlay;
     private Granite.Widgets.Toast notification;
     private Granite.Widgets.OverlayBar overlaybar;
@@ -149,6 +151,8 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         manager.show_preview.connect (on_show_preview);
         manager.free.connect (on_free);
         manager.export_finished.connect (on_export_finished);
+
+        canvas.window.event_bus.toggle_export_button.connect (on_toggle_export_button);
     }
 
     private void build_export_sidebar () {
@@ -289,7 +293,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
             close ();
         });
 
-        var export_button = new Gtk.Button.with_label (_("Export")) {
+        export_button = new Gtk.Button.with_label (_("Export")) {
             halign = Gtk.Align.END
         };
         export_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
@@ -347,5 +351,9 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     public void on_export_finished (string message) {
         notification.title = message;
         notification.send_notification ();
+    }
+
+    private void on_toggle_export_button (bool sensitive) {
+        export_button.sensitive = sensitive;
     }
 }

--- a/src/Dialogs/ExportDialog.vala
+++ b/src/Dialogs/ExportDialog.vala
@@ -295,7 +295,7 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
         export_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
         action_area.add (export_button);
         export_button.clicked.connect (() => {
-            manager.export_images.begin ();
+            manager.export_images.begin (list_store);
         });
 
         sidebar.add (grid);
@@ -314,7 +314,9 @@ public class Akira.Dialogs.ExportDialog : Gtk.Dialog {
     public async void on_show_preview (Gee.HashMap<int, Gdk.Pixbuf> pixbufs) {
         list_store.remove_all ();
         foreach (var entry in pixbufs.entries) {
-            var model = new Models.ExportModel (entry.key, entry.value);
+            var node = entry.key == Lib.Items.Model.ORIGIN_ID ?
+                null : canvas.items_manager.node_from_id (entry.key);
+            var model = new Models.ExportModel (canvas, node, entry.value);
             list_store.append (model);
         }
     }

--- a/src/Lib/Components/Name.vala
+++ b/src/Lib/Components/Name.vala
@@ -22,6 +22,7 @@
 public class Akira.Lib.Components.Name : Component, Copyable<Name> {
     private string _id;
     private string _name;
+    private string _filename;
 
     public string id {
         get { return _id; }
@@ -31,22 +32,29 @@ public class Akira.Lib.Components.Name : Component, Copyable<Name> {
         get { return _name; }
     }
 
-    public Name (string name, string id) {
+    public string filename {
+        get { return _filename; }
+    }
+
+    public Name (string name, string id, string? filename = null) {
         _id = id;
         _name = name;
+        _filename = filename != null ? filename : name;
     }
 
     public Name.deserialized (Json.Object obj) {
-        _id = obj.get_string_member ("name");
-        _name = obj.get_string_member ("id");
+        _id = obj.get_string_member ("id");
+        _name = obj.get_string_member ("name");
+        _filename = obj.get_string_member ("filename");
     }
 
     protected override void serialize_details (ref Json.Object obj) {
-        obj.set_string_member ("name", _name);
         obj.set_string_member ("id", _id);
+        obj.set_string_member ("name", _name);
+        obj.set_string_member ("filename", _filename);
     }
 
     public Name copy () {
-        return new Name (_name, _id);
+        return new Name (_name, _id, _filename);
     }
 }

--- a/src/Lib/Managers/ExportManager.vala
+++ b/src/Lib/Managers/ExportManager.vala
@@ -103,7 +103,7 @@ public class Akira.Lib.Managers.ExportManager : Object {
         yield generate_image_surface (area);
         var pixbuf = yield generate_pixbuf (surface);
 
-        pixbufs.set (9999, pixbuf);
+        pixbufs.set (Lib.Items.Model.ORIGIN_ID, pixbuf);
     }
 
     private async void generate_selection_pixbufs (GLib.Cancellable cancellable) {
@@ -296,26 +296,27 @@ public class Akira.Lib.Managers.ExportManager : Object {
             canvas.window.event_bus.set_focus_on_canvas ();
 
             // Clean up.
+            pixbufs.clear ();
             context = null;
             surface = null;
         });
     }
 
-    public async void export_images () {
-        /*
-        TODO:
-         - Implement filenames and don't allow exporting without one.
-        */
+    public async void export_images (GLib.ListStore list_store) {
         busy (_("Exporting images…"));
 
         bool overwrite_all = false;
         bool skip_all = false;
 
-        // Loop through all generated pixbufs and handle the save to a file.
-        foreach (var entry in pixbufs.entries) {
-            var pixbuf = entry.value;
-            var node_id = entry.key;
-            var file_name = ("%s/%i.%s").printf (settings.export_folder, node_id, settings.export_format);
+        // Loop through all generated models and handle the save to a file.
+        for (int i = 0; i < list_store.get_n_items () ; i++) {
+            var model = (Akira.Models.ExportModel) list_store.get_object (i);
+            var pixbuf = model.pixbuf;
+            var file_name = ("%s/%s.%s").printf (
+                settings.export_folder,
+                model.filename,
+                settings.export_format
+            );
 
             // Check for existing files to avoid overwriting them.
             var image_file = File.new_for_path (file_name);

--- a/src/Models/ExportModel.vala
+++ b/src/Models/ExportModel.vala
@@ -78,4 +78,8 @@ public class Akira.Models.ExportModel : GLib.Object {
             _cached_instance = node.instance;
         }
     }
+
+    public void toggle_export_button (bool sensitive) {
+        _view_canvas.window.event_bus.toggle_export_button (sensitive);
+    }
 }

--- a/src/Services/EventBus.vala
+++ b/src/Services/EventBus.vala
@@ -89,11 +89,7 @@ public class Akira.Services.EventBus : Object {
     public signal void connect_typing_accel ();
 
     // Export signals.
-    public signal void export_preview (string message);
-    public signal void preview_completed ();
-    public signal void exporting (string message);
-    public signal void export_completed ();
-
+    public signal void toggle_export_button (bool sensitive);
     // History signals
     public signal void create_model_snapshot (string description);
     public signal void undo ();

--- a/src/Widgets/ExportWidget.vala
+++ b/src/Widgets/ExportWidget.vala
@@ -93,11 +93,11 @@ public class Akira.Widgets.ExportWidget : Gtk.Grid {
         });
 
         // Trigger the detection of and empty file name filed on creation.
-        //  on_input_changed ();
+        on_input_changed ();
     }
 
     private void on_input_changed () {
-        bool empty = input.text._strip () == "";
+        bool empty = input.text.strip () == "";
         model.toggle_export_button (!empty);
         if (empty) {
             input.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-error");

--- a/src/Widgets/ExportWidget.vala
+++ b/src/Widgets/ExportWidget.vala
@@ -20,9 +20,6 @@
  */
 
 public class Akira.Widgets.ExportWidget : Gtk.Grid {
-    private const int MB = 1024 * 1024;
-    private const int KB = 1024;
-
     public Models.ExportModel model { get; set construct; }
 
     private Gtk.Label info;
@@ -68,6 +65,8 @@ public class Akira.Widgets.ExportWidget : Gtk.Grid {
             hexpand = true
         };
         input.get_style_context ().add_class ("export-filename");
+        model.bind_property ("filename", input, "text",
+            BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
 
         attach (input, 0, 0);
         attach (info, 1, 0);

--- a/src/Widgets/ExportWidget.vala
+++ b/src/Widgets/ExportWidget.vala
@@ -22,6 +22,7 @@
 public class Akira.Widgets.ExportWidget : Gtk.Grid {
     public Models.ExportModel model { get; set construct; }
 
+    private Gtk.Entry input;
     private Gtk.Label info;
     private Gtk.Grid image_container;
     private Gtk.Image image;
@@ -29,7 +30,7 @@ public class Akira.Widgets.ExportWidget : Gtk.Grid {
 
     public ExportWidget (Models.ExportModel model) {
         Object (
-            orientation: Gtk.Orientation.HORIZONTAL,
+            orientation: Gtk.Orientation.VERTICAL,
             model: model
         );
     }
@@ -37,15 +38,25 @@ public class Akira.Widgets.ExportWidget : Gtk.Grid {
     construct {
         halign = Gtk.Align.CENTER;
         valign = Gtk.Align.CENTER;
-        column_spacing = 6;
+        row_spacing = 9;
+        margin_top = margin_bottom = 6;
         expand = true;
+        var ctx = get_style_context ();
+        ctx.add_class ("export-widget");
+        ctx.add_class (Granite.STYLE_CLASS_CARD);
 
-        // Label for image size info. We need to create this before calling get_image ().
-        info = new Gtk.Label (null) {
-            hexpand = false,
-            halign = Gtk.Align.END
+        // Filename with editable entry.
+        input = new Gtk.Entry () {
+            placeholder_text = _("File name"),
+            width_chars = 10,
+            hexpand = true
         };
-        info.get_style_context ().add_class ("export-info");
+        input.secondary_icon_activatable = false;
+        input.secondary_icon_tooltip_text = _("A file name is required to export this image");
+        input.get_style_context ().add_class ("export-filename");
+        input.changed.connect (on_input_changed);
+        input.text = model.filename;
+        input.bind_property ("text", model, "filename", BindingFlags.DEFAULT);
 
         // Image preview container with checker.
         image_container = new Gtk.Grid () {
@@ -53,24 +64,24 @@ public class Akira.Widgets.ExportWidget : Gtk.Grid {
         };
         var image_container_ctx = image_container.get_style_context ();
         image_container_ctx.add_class (Granite.STYLE_CLASS_CHECKERBOARD);
-        image_container_ctx.add_class (Granite.STYLE_CLASS_CARD);
+        image_container_ctx.add_class ("export-image");
 
         image = new Gtk.Image ();
         image_container.add (image);
+
+        // Label for image size info.
+        info = new Gtk.Label (null) {
+            hexpand = true,
+            halign = Gtk.Align.END
+        };
+        info.get_style_context ().add_class ("export-info");
+
+        // Fetch the image and its info after all the widgets have been created.
         get_image.begin ();
 
-        // Filename with editable entry.
-        var input = new Gtk.Entry () {
-            width_chars = 10,
-            hexpand = true
-        };
-        input.get_style_context ().add_class ("export-filename");
-        model.bind_property ("filename", input, "text",
-            BindingFlags.BIDIRECTIONAL | BindingFlags.SYNC_CREATE);
-
         attach (input, 0, 0);
-        attach (info, 1, 0);
-        attach (image_container, 0, 1, 2);
+        attach (image_container, 0, 1);
+        attach (info, 0, 2);
 
         show_all ();
 
@@ -80,6 +91,22 @@ public class Akira.Widgets.ExportWidget : Gtk.Grid {
         settings.changed["export-compression"].connect (() => {
             update_file_size.begin ();
         });
+
+        // Trigger the detection of and empty file name filed on creation.
+        //  on_input_changed ();
+    }
+
+    private void on_input_changed () {
+        bool empty = input.text._strip () == "";
+        model.toggle_export_button (!empty);
+        if (empty) {
+            input.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-error");
+            return;
+        }
+
+        if (input.get_icon_name (Gtk.EntryIconPosition.SECONDARY) != null) {
+            input.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, null);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary / How this PR fixes the problem?
Allow users to specify a filename for the exported area or selected nodes.
Saves the `filename` in the `Name` component so it can be updated and maintained.
Disable the export button and show a warning if the filename is empty.

- Fixes #733 
