### PR TITLE
Fixes deserializing rectangle on file load

### DIFF
--- a/src/FileFormat/JsonDeserializer.vala
+++ b/src/FileFormat/JsonDeserializer.vala
@@ -95,7 +95,7 @@ public class Akira.FileFormat.JsonDeserializer {
         var components = Lib.Components.Components.deserialize (components_json);
 
         Lib.Items.ModelInstance? new_inst = null;
-        if (type == "rect") {
+        if (type == "rectangle") {
             new_inst = new Lib.Items.ModelInstance (-1, new Lib.Items.ModelTypeRect ());
         } else if (type == "ellipse") {
             new_inst = new Lib.Items.ModelInstance (-1, new Lib.Items.ModelTypeEllipse ());


### PR DESCRIPTION
<!--- Thanks for submitting a pull request! Please provide enough information -->
<!--- so that others can review your pull request. We will review it as soon as possible -->

<!--- Make sure that the Travis tests pass in your PR -->
<!--- and that you are also using the elementary code style guidelines. -->
<!--- The code guideline is available here: https://elementary.io/docs/code/reference --> 

## Summary / How this PR fixes the problem?

- Resolves loading a saved akira file with "rectangle" type.

I found akira and started playing around with it, then ran into this bug. I figured out the file format was a zipped json file pretty quickly, opened it up, saw the inconsistency, and the found the issue. I don't really feel comfortable writing in vala, but I felt I would be comfortable enough to create a pull request for this small fix.

## Steps to Test

1. Open Akira
2. Press the Insert button
3. Choose Shapes
4. Choose Rectangle
5. Place the Rectangle
6. Save the file
7. Close Akira
8. Open Akira
9. Open the file

Result: the application does not bail with 

    Akira:ERROR:../src/FileFormat/JsonDeserializer.vala:113:akira_file_format_json_deserializer_deserialize_node: assertion failed: (false)

## Known Issues / Things To Do

- The rest of #732 is out-of-scope of what I can contribute.

